### PR TITLE
fix: Search Console disconnect does not remove website from API

### DIFF
--- a/1platform-content-ai.php
+++ b/1platform-content-ai.php
@@ -4,7 +4,7 @@
  * Plugin Name: 1Platform Content AI
  * Plugin URI: https://1platform.pro/
  * Description: SaaS client for AI-powered content generation, SEO optimization, and site management. All AI processing happens on 1Platform external servers. Includes free local tools: Table of Contents and Internal Links.
- * Version: 2.3.1
+ * Version: 2.3.3
  * Author: 1Platform
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Content AI are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.3.3] - 2026-03-14
+
+### Fixed
+- Search Console: Disconnect Website now deletes the website from the 1Platform API before clearing local state, preventing `initializeWebsiteStatus()` from re-syncing stale data
+- Search Console: Treat HTTP 404 on disconnect as already-disconnected and proceed with local cleanup
+- Fix corrupted string literals (`ContaiKeyword` in user-facing messages) caused by over-aggressive class rename in v2.3.2
+- Fix 288 broken unit tests caused by class name mismatches after `Contai` prefix rename; added `class_alias` mappings in test bootstrap
+
+### Changed
+- Updated Disconnect Website UI description to accurately reflect that it removes both remote and local data
+
 ## [2.3.2] - 2026-03-14
 
 ### Fixed

--- a/includes/admin/admin-content-generator.php
+++ b/includes/admin/admin-content-generator.php
@@ -189,7 +189,7 @@ function contai_content_generator_page() {
 		case 'keyword-extractor':
 			$panel = new ContaiKeywordExtractorPanel();
 			$layout->render_page_title(
-				__( 'ContaiKeyword Extractor', '1platform-content-ai' ),
+				__( 'Keyword Extractor', '1platform-content-ai' ),
 				__( 'Analyze competitor websites and extract valuable keywords for content strategy', '1platform-content-ai' ),
 				'dashicons-search'
 			);

--- a/includes/admin/apps/handlers/SearchConsoleFormHandler.php
+++ b/includes/admin/apps/handlers/SearchConsoleFormHandler.php
@@ -97,6 +97,13 @@ class ContaiSearchConsoleFormHandler
 
     private function handleDisconnectWebsite(): void
     {
+        $response = $this->websiteProvider->deleteWebsite();
+
+        if (!$response->isSuccess() && $response->getStatusCode() !== 404) {
+            $this->redirectWithMessage('error', $response->getMessage());
+            return;
+        }
+
         $this->websiteProvider->deleteWebsiteConfig();
 
         $this->redirectWithMessage('success', __('Website disconnected successfully', '1platform-content-ai'));

--- a/includes/admin/apps/panels/search-console/VerifiedSection.php
+++ b/includes/admin/apps/panels/search-console/VerifiedSection.php
@@ -146,7 +146,7 @@ class ContaiSearchConsoleVerifiedSection
                 <div class="contai-danger-content">
                     <div class="contai-danger-info">
                         <p class="contai-danger-description">
-                            <?php esc_html_e('Disconnect this website from the plugin. This will only remove the local connection data.', '1platform-content-ai'); ?>
+                            <?php esc_html_e('Disconnect this website from the plugin. This will remove the website from 1Platform and clear local connection data.', '1platform-content-ai'); ?>
                         </p>
                     </div>
                     <button type="submit" name="contai_disconnect_website" class="button button-secondary">

--- a/includes/admin/content-generator/components/sidebar.php
+++ b/includes/admin/content-generator/components/sidebar.php
@@ -19,7 +19,7 @@ class ContaiContentGeneratorSidebar {
     private function init_menu_items(): void {
         $this->menu_items = [
             'keyword-extractor' => [
-                'title' => __('ContaiKeyword Extractor', '1platform-content-ai'),
+                'title' => __('Keyword Extractor', '1platform-content-ai'),
                 'icon' => 'dashicons-search',
                 'badge' => null,
             ],

--- a/includes/admin/content-generator/handlers/KeywordExtractionHandler.php
+++ b/includes/admin/content-generator/handlers/KeywordExtractionHandler.php
@@ -123,7 +123,7 @@ class ContaiKeywordExtractionHandler {
             'success' => true,
             'message' => sprintf(
                 /* translators: %s: domain name for keyword extraction */
-                __('ContaiKeyword extraction job has been queued. Domain: %s. You can check the Keywords List page for results.', '1platform-content-ai'),
+                __('Keyword extraction job has been queued. Domain: %s. You can check the Keywords List page for results.', '1platform-content-ai'),
                 $validation['domain']
             )
         ];

--- a/includes/database/models/InternalLink.php
+++ b/includes/database/models/InternalLink.php
@@ -247,7 +247,7 @@ class ContaiInternalLink {
         }
 
         if ($this->keyword_id <= 0) {
-            throw new \InvalidArgumentException('ContaiKeyword ID must be greater than 0');
+            throw new \InvalidArgumentException('Keyword ID must be greater than 0');
         }
 
         return true;

--- a/includes/database/models/Keyword.php
+++ b/includes/database/models/Keyword.php
@@ -93,7 +93,7 @@ class ContaiKeyword {
         $errors = [];
 
         if (empty($this->keyword)) {
-            $errors[] = 'ContaiKeyword is required';
+            $errors[] = 'Keyword is required';
         }
 
         if ($this->volume < 0) {

--- a/includes/helpers/JobDetailsFormatter.php
+++ b/includes/helpers/JobDetailsFormatter.php
@@ -7,7 +7,7 @@ class ContaiJobDetailsFormatter
     private const JOB_TYPE_LABELS = [
         'post_generation' => 'Post Generation',
         'internal_link' => 'Internal Links',
-        'keyword_extraction' => 'ContaiKeyword Extraction',
+        'keyword_extraction' => 'Keyword Extraction',
         'site_generation' => 'Site Generation',
     ];
 
@@ -75,7 +75,7 @@ class ContaiJobDetailsFormatter
         $parts = [];
 
         if (isset($payload['keyword_id'])) {
-            $parts[] = sprintf('ContaiKeyword ID: %d', $payload['keyword_id']);
+            $parts[] = sprintf('Keyword ID: %d', $payload['keyword_id']);
         }
 
         if (isset($payload['post_id'])) {

--- a/includes/services/jobs/ContentGenerationPollingJob.php
+++ b/includes/services/jobs/ContentGenerationPollingJob.php
@@ -78,7 +78,7 @@ class ContaiContentGenerationPollingJob implements ContaiJobInterface
         }
 
         if ($keyword->getStatus() === ContaiKeyword::STATUS_DONE) {
-            return ['success' => true, 'message' => 'ContaiKeyword already processed'];
+            return ['success' => true, 'message' => 'Keyword already processed'];
         }
 
         $poll_start_time = $payload['poll_start_time'] ?? time();

--- a/includes/services/jobs/SiteGenerationJob.php
+++ b/includes/services/jobs/SiteGenerationJob.php
@@ -210,7 +210,7 @@ class ContaiSiteGenerationJob implements ContaiJobInterface
 
         if (!$result->isSuccess()) {
             // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
-            throw new Exception('ContaiKeyword extraction failed: ' . $result->getErrorMessage());
+            throw new Exception('Keyword extraction failed: ' . $result->getErrorMessage());
         }
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai content, seo, content generation, internal links, table of contents
 Requires at least: 5.9
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.3.1
+Stable tag: 2.3.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -158,6 +158,11 @@ The plugin sends your site URL, API key, and content generation parameters (keyw
 7. Tools — Google Search Console, Publisuites, and Ads Manager integrations.
 
 == Changelog ==
+
+= 2.3.3 =
+* Fix: Search Console Disconnect Website now properly deletes the website from the 1Platform API before clearing local state
+* Fix: Corrupted string literals showing "ContaiKeyword" instead of "Keyword" in user-facing messages
+* Fix: 288 broken unit tests from class name mismatches after Contai prefix rename
 
 = 2.3.1 =
 * Migrated all admin menu slugs and screen IDs from `wpcontentai-` to `contai-` for consistent prefixing

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,17 +8,36 @@ require_once __DIR__ . '/../vendor/autoload.php';
 
 WP_Mock::bootstrap();
 
+// ── Models ──────────────────────────────────────────────────────
 require_once __DIR__ . '/../includes/database/models/JobStatus.php';
 require_once __DIR__ . '/../includes/database/models/Job.php';
 require_once __DIR__ . '/../includes/database/models/Keyword.php';
 require_once __DIR__ . '/../includes/database/models/InternalLink.php';
+
+class_alias('ContaiJobStatus', 'JobStatus');
+class_alias('ContaiJob', 'Job');
+class_alias('ContaiKeyword', 'Keyword');
+class_alias(WPContentAI\ContaiDatabase\Models\ContaiInternalLink::class, 'WPContentAI\Database\Models\InternalLink');
+
+// ── Database ────────────────────────────────────────────────────
 require_once __DIR__ . '/../includes/database/Database.php';
 require_once __DIR__ . '/../includes/database/repositories/JobRepository.php';
 require_once __DIR__ . '/../includes/database/repositories/KeywordRepository.php';
+
+class_alias('ContaiDatabase', 'Database');
+class_alias('ContaiJobRepository', 'JobRepository');
+class_alias('ContaiKeywordRepository', 'KeywordRepository');
+
+// ── Helpers ─────────────────────────────────────────────────────
 require_once __DIR__ . '/../includes/helpers/crypto.php';
 require_once __DIR__ . '/../includes/helpers/security.php';
 require_once __DIR__ . '/../includes/helpers/TimestampHelper.php';
 require_once __DIR__ . '/../includes/helpers/JobDetailsFormatter.php';
+
+class_alias('ContaiTimestampHelper', 'TimestampHelper');
+class_alias('ContaiJobDetailsFormatter', 'JobDetailsFormatter');
+
+// ── Services ────────────────────────────────────────────────────
 require_once __DIR__ . '/../includes/services/config/EnvironmentDetector.php';
 require_once __DIR__ . '/../includes/services/toc/HeadingParser.php';
 require_once __DIR__ . '/../includes/services/toc/AnchorGenerator.php';
@@ -27,4 +46,28 @@ require_once __DIR__ . '/../includes/services/toc/TocConfiguration.php';
 require_once __DIR__ . '/../includes/services/internal-links/KeywordMatcher.php';
 require_once __DIR__ . '/../includes/services/internal-links/ContentLinkInjector.php';
 require_once __DIR__ . '/../includes/services/http/RateLimiter.php';
+
+class_alias('ContaiEnvironmentDetector', 'EnvironmentDetector');
+class_alias('ContaiHeadingParser', 'HeadingParser');
+class_alias('ContaiAnchorGenerator', 'AnchorGenerator');
+class_alias('ContaiTocBuilder', 'TocBuilder');
+class_alias('ContaiTocConfiguration', 'TocConfiguration');
+class_alias(WPContentAI\Services\InternalLinks\ContaiKeywordMatcher::class, 'WPContentAI\Services\InternalLinks\KeywordMatcher');
+class_alias(WPContentAI\Services\InternalLinks\ContaiContentLinkInjector::class, 'WPContentAI\Services\InternalLinks\ContentLinkInjector');
+class_alias('ContaiRateLimiter', 'RateLimiter');
+
+// ── Providers ───────────────────────────────────────────────────
 require_once __DIR__ . '/../includes/providers/UserProvider.php';
+
+class_alias('ContaiUserProvider', 'UserProvider');
+
+// ── API & Search Console ────────────────────────────────────────
+require_once __DIR__ . '/../includes/services/http/HTTPClientService.php';
+require_once __DIR__ . '/../includes/services/config/Config.php';
+require_once __DIR__ . '/../includes/services/api/OnePlatformAuthService.php';
+require_once __DIR__ . '/../includes/services/http/RequestLogger.php';
+require_once __DIR__ . '/../includes/services/api/OnePlatformEndpoints.php';
+require_once __DIR__ . '/../includes/services/api/OnePlatformClient.php';
+require_once __DIR__ . '/../includes/providers/WebsiteProvider.php';
+require_once __DIR__ . '/../includes/services/search-console/SearchConsoleService.php';
+require_once __DIR__ . '/../includes/admin/apps/handlers/SearchConsoleFormHandler.php';

--- a/tests/unit/admin/apps/handlers/SearchConsoleFormHandlerTest.php
+++ b/tests/unit/admin/apps/handlers/SearchConsoleFormHandlerTest.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace ContAI\Tests\Unit\Admin\Apps\Handlers;
+
+use WP_Mock;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use ContaiSearchConsoleFormHandler;
+use ContaiWebsiteProvider;
+use ContaiSearchConsoleService;
+use ContaiOnePlatformResponse;
+
+class RedirectException extends \RuntimeException {}
+
+class SearchConsoleFormHandlerTest extends TestCase
+{
+    private ContaiWebsiteProvider $websiteProvider;
+    private ContaiSearchConsoleService $service;
+    private ContaiSearchConsoleFormHandler $handler;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        WP_Mock::setUp();
+
+        $this->websiteProvider = Mockery::mock(ContaiWebsiteProvider::class);
+        $this->service = Mockery::mock(ContaiSearchConsoleService::class);
+        $this->handler = new ContaiSearchConsoleFormHandler($this->websiteProvider, $this->service);
+    }
+
+    public function tearDown(): void
+    {
+        unset(
+            $_POST['contai_search_console_nonce'],
+            $_POST['contai_disconnect_website'],
+            $_POST['contai_delete_website']
+        );
+        WP_Mock::tearDown();
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_disconnect_website_success_clears_remote_and_local_state(): void
+    {
+        $this->mockValidRequest('contai_disconnect_website');
+
+        $this->websiteProvider
+            ->shouldReceive('deleteWebsite')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(true, null, 'Deleted', 200));
+
+        $this->websiteProvider
+            ->shouldReceive('deleteWebsiteConfig')
+            ->once()
+            ->andReturn(true);
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected RedirectException');
+        } catch (RedirectException $e) {
+            $this->assertStringContainsString('contai_sc_type=success', $redirectUrl->url);
+        }
+    }
+
+    public function test_disconnect_website_api_failure_preserves_local_state_and_shows_error(): void
+    {
+        $this->mockValidRequest('contai_disconnect_website');
+
+        $this->websiteProvider
+            ->shouldReceive('deleteWebsite')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(false, null, 'Server error', 500));
+
+        $this->websiteProvider
+            ->shouldNotReceive('deleteWebsiteConfig');
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected RedirectException');
+        } catch (RedirectException $e) {
+            $this->assertStringContainsString('contai_sc_type=error', $redirectUrl->url);
+        }
+    }
+
+    public function test_disconnect_website_404_treated_as_already_disconnected(): void
+    {
+        $this->mockValidRequest('contai_disconnect_website');
+
+        $this->websiteProvider
+            ->shouldReceive('deleteWebsite')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(false, null, 'Not found', 404));
+
+        $this->websiteProvider
+            ->shouldReceive('deleteWebsiteConfig')
+            ->once()
+            ->andReturn(true);
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected RedirectException');
+        } catch (RedirectException $e) {
+            $this->assertStringContainsString('contai_sc_type=success', $redirectUrl->url);
+        }
+    }
+
+    public function test_disconnect_requires_valid_nonce(): void
+    {
+        $_POST['contai_search_console_nonce'] = 'invalid-nonce';
+        $_POST['contai_disconnect_website'] = '1';
+
+        WP_Mock::userFunction('sanitize_text_field')
+            ->andReturnUsing(function ($val) { return $val; });
+
+        WP_Mock::userFunction('wp_unslash')
+            ->andReturnUsing(function ($val) { return $val; });
+
+        WP_Mock::userFunction('wp_verify_nonce')
+            ->with('invalid-nonce', 'contai_search_console_action')
+            ->andReturn(false);
+
+        $this->websiteProvider->shouldNotReceive('deleteWebsite');
+        $this->websiteProvider->shouldNotReceive('deleteWebsiteConfig');
+
+        $this->handler->handleRequest();
+
+        $this->assertTrue(true);
+    }
+
+    public function test_disconnect_requires_manage_options_capability(): void
+    {
+        $_POST['contai_search_console_nonce'] = 'valid-nonce';
+        $_POST['contai_disconnect_website'] = '1';
+
+        WP_Mock::userFunction('sanitize_text_field')
+            ->andReturnUsing(function ($val) { return $val; });
+
+        WP_Mock::userFunction('wp_unslash')
+            ->andReturnUsing(function ($val) { return $val; });
+
+        WP_Mock::userFunction('wp_verify_nonce')
+            ->with('valid-nonce', 'contai_search_console_action')
+            ->andReturn(1);
+
+        WP_Mock::userFunction('current_user_can')
+            ->with('manage_options')
+            ->andReturn(false);
+
+        $this->websiteProvider->shouldNotReceive('deleteWebsite');
+        $this->websiteProvider->shouldNotReceive('deleteWebsiteConfig');
+
+        $this->handler->handleRequest();
+
+        $this->assertTrue(true);
+    }
+
+    public function test_disconnect_website_auth_failure_preserves_local_state(): void
+    {
+        $this->mockValidRequest('contai_disconnect_website');
+
+        $this->websiteProvider
+            ->shouldReceive('deleteWebsite')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(false, null, 'Unauthorized', 401));
+
+        $this->websiteProvider
+            ->shouldNotReceive('deleteWebsiteConfig');
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected RedirectException');
+        } catch (RedirectException $e) {
+            $this->assertStringContainsString('contai_sc_type=error', $redirectUrl->url);
+        }
+    }
+
+    private function mockValidRequest(string $action): void
+    {
+        $_POST['contai_search_console_nonce'] = 'valid-nonce';
+        $_POST[$action] = '1';
+
+        WP_Mock::userFunction('sanitize_text_field')
+            ->andReturnUsing(function ($val) { return $val; });
+
+        WP_Mock::userFunction('wp_unslash')
+            ->andReturnUsing(function ($val) { return $val; });
+
+        WP_Mock::userFunction('wp_verify_nonce')
+            ->with('valid-nonce', 'contai_search_console_action')
+            ->andReturn(1);
+
+        WP_Mock::userFunction('current_user_can')
+            ->with('manage_options')
+            ->andReturn(true);
+    }
+
+    private function expectRedirect(): object
+    {
+        $capture = new class { public string $url = ''; };
+
+        WP_Mock::userFunction('admin_url')
+            ->andReturn('http://example.com/wp-admin/admin.php?page=contai-apps&section=search-console');
+
+        WP_Mock::userFunction('add_query_arg')
+            ->andReturnUsing(function ($args, $url) {
+                return $url . '&' . http_build_query($args);
+            });
+
+        WP_Mock::userFunction('wp_safe_redirect')
+            ->once()
+            ->andReturnUsing(function ($url) use ($capture) {
+                $capture->url = $url;
+                throw new RedirectException('redirect');
+            });
+
+        return $capture;
+    }
+}


### PR DESCRIPTION
## Summary
- **Root cause**: `handleDisconnectWebsite()` only deleted the local WordPress option (`contai_user_website`) but did not call the 1Platform API to delete the website. On page reload, `initializeWebsiteStatus()` re-fetched the website from the API and re-saved it locally, making the disconnect appear to have no effect.
- **Fix**: Added `DELETE /api/v1/users/websites/{website_id}` API call before clearing local state. HTTP 404 is treated as "already disconnected". Any other API error preserves local state and shows error notice.
- **Bonus fixes**: Corrected 7 corrupted string literals (`ContaiKeyword` in user-facing messages from v2.3.2 rename), fixed 288 broken unit tests via `class_alias` mappings in test bootstrap.

## Test plan
- [x] 308 unit tests pass (0 failures, 0 errors)
- [x] 6 new regression tests for disconnect flow:
  - Success → API delete + local cleanup + redirect with success
  - API failure (500) → local state preserved + error notice
  - API 404 → treated as already disconnected + local cleanup
  - Invalid nonce → rejected, no API call
  - Missing capability → rejected, no API call
  - Auth failure (401) → local state preserved + error notice
- [ ] Manual: Connect website → Disconnect → verify UI shows initial state
- [ ] Manual: Disconnect with API down → verify error notice, state preserved

Closes #1
Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)