### PR TITLE
fix(billing): show merchant currency in transaction history (v2.3.5)

### DIFF
--- a/1platform-content-ai.php
+++ b/1platform-content-ai.php
@@ -4,7 +4,7 @@
  * Plugin Name: 1Platform Content AI
  * Plugin URI: https://1platform.pro/
  * Description: SaaS client for AI-powered content generation, SEO optimization, and site management. All AI processing happens on 1Platform external servers. Includes free local tools: Table of Contents and Internal Links.
- * Version: 2.3.3
+ * Version: 2.3.5
  * Author: 1Platform
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Content AI are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.3.5] - 2026-03-17
+
+### Fixed
+
+- **BillingHistoryPanel**: `_format_transaction_row()` ahora muestra la moneda del merchant (`currency`) directamente desde la transacción, en lugar de forzar `USD` cuando `usd_amount` está presente — alinea el plugin con el sistema multi-moneda de la API
+
 ## [2.3.4] - 2026-03-15
 
 ### Added

--- a/includes/admin/billing/panels/BillingHistoryPanel.php
+++ b/includes/admin/billing/panels/BillingHistoryPanel.php
@@ -135,14 +135,9 @@ class ContaiBillingHistoryPanel
     {
         $created_at = $transaction['created_at'] ?? '';
 
-        // Priorizar usd_amount si existe
-        if (isset($transaction['usd_amount']) || isset($transaction['usdAmount'])) {
-            $amount = $transaction['usd_amount'] ?? $transaction['usdAmount'] ?? 0;
-            $currency = 'USD';
-        } else {
-            $amount = $transaction['amount'] ?? 0;
-            $currency = $transaction['currency'] ?? '';
-        }
+        // Priorizar usd_amount (monto original del merchant) si existe
+        $amount = $transaction['usd_amount'] ?? $transaction['usdAmount'] ?? $transaction['amount'] ?? 0;
+        $currency = $transaction['currency'] ?? '';
 
         $status = $transaction['status'] ?? '';
         $description = $transaction['description'] ?? '';

--- a/includes/services/logs/ContaiClientLogReporter.php
+++ b/includes/services/logs/ContaiClientLogReporter.php
@@ -142,7 +142,7 @@ class ContaiClientLogReporter {
                 'wp_error_message' => substr($error->get_error_message(), 0, 200),
                 'php_version'      => PHP_VERSION,
                 'wp_version'       => get_bloginfo('version'),
-                'plugin_version'   => defined('CONTAI_VERSION') ? CONTAI_VERSION : '2.3.3',
+                'plugin_version'   => defined('CONTAI_VERSION') ? CONTAI_VERSION : '2.3.5',
             ],
         ];
     }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai content, seo, content generation, internal links, table of contents
 Requires at least: 5.9
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.3.3
+Stable tag: 2.3.5
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -158,6 +158,13 @@ The plugin sends your site URL, API key, and content generation parameters (keyw
 7. Tools — Google Search Console, Publisuites, and Ads Manager integrations.
 
 == Changelog ==
+
+= 2.3.5 =
+* Fix: BillingHistoryPanel now shows the correct merchant currency instead of hardcoding USD when usd_amount is present
+
+= 2.3.4 =
+* Added client-side logging system (ContaiClientLogReporter, Logs admin panel)
+* Added API trace ID propagation for error traceability
 
 = 2.3.3 =
 * Fix: Search Console Disconnect Website now properly deletes the website from the 1Platform API before clearing local state


### PR DESCRIPTION
## Summary

- Removes hardcoded `USD` logic from `BillingHistoryPanel::_format_transaction_row()`
- The API's multi-currency system now stores the merchant's chosen currency (USD, GTQ, MXN, etc.) in `transaction.currency` — the panel was overriding it with `USD` when `usd_amount` was present
- Simplifies the amount/currency resolution to a single null-coalescing chain

## Changes

| File | Change |
|---|---|
| `includes/admin/billing/panels/BillingHistoryPanel.php` | Remove `USD` hardcode, read `currency` from transaction |
| `1platform-content-ai.php` | Version bump → 2.3.5 |
| `CHANGELOG.md` | Add [2.3.5] entry |
| `readme.txt` | Stable tag → 2.3.5 |
| `ContaiClientLogReporter.php` | Version fallback → 2.3.5 |

## Context

Related to the multi-currency payment system added to `1platform-api` (PR #20). Transactions now carry the merchant's chosen currency in `transaction.currency` instead of always being USD-denominated.

## Test plan

- [ ] Open Billing admin panel → Transaction History
- [ ] Verify GTQ transactions show GTQ (not USD)
- [ ] Verify USD transactions still show USD
- [ ] Verify transactions without `usd_amount` still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)