### PR TITLE
feat(agents): AI agent platform integration — v2.4.0

### DIFF
--- a/1platform-content-ai.php
+++ b/1platform-content-ai.php
@@ -4,7 +4,7 @@
  * Plugin Name: 1Platform Content AI
  * Plugin URI: https://1platform.pro/
  * Description: SaaS client for AI-powered content generation, SEO optimization, and site management. All AI processing happens on 1Platform external servers. Includes free local tools: Table of Contents and Internal Links.
- * Version: 2.3.6
+ * Version: 2.4.0
  * Author: 1Platform
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -50,6 +50,16 @@ require_once plugin_dir_path(__FILE__) . 'includes/services/toc/TocFactory.php';
 require_once plugin_dir_path(__FILE__) . 'includes/services/internal-links/InternalLinksWordPressIntegration.php';
 require_once plugin_dir_path(__FILE__) . 'includes/cron/job-processor-cron.php';
 require_once plugin_dir_path(__FILE__) . 'includes/header.php';
+
+// Agent domain
+require_once plugin_dir_path( __FILE__ ) . 'includes/services/agents/ContaiAgentEndpoints.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/services/agents/ContaiAgentApiService.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/services/agents/ContaiAgentSettingsService.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/services/agents/ContaiAgentActionHandler.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/services/agents/ContaiAgentSyncService.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/services/agents/ContaiAgentRestController.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/admin/agents/ContaiAgentsAdminPage.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/cron/agent-actions-cron.php';
 
 require_once plugin_dir_path(__FILE__) . 'includes/database/migrations/CreateKeywordsTable.php';
 require_once plugin_dir_path(__FILE__) . 'includes/database/migrations/CreateAPILogsTable.php';
@@ -99,6 +109,12 @@ function contai_activate_plugin() {
         contai_log("Cron registration error: " . $e->getMessage());
     }
 
+    try {
+        contai_register_agent_actions_cron();
+    } catch (Exception $e) {
+        contai_log("Agent cron registration error: " . $e->getMessage());
+    }
+
     // Set site hardening defaults for existing installs (opt-in for new installs)
     add_option('contai_disable_feeds', '1');
     add_option('contai_disable_author_pages', '1');
@@ -107,6 +123,7 @@ function contai_activate_plugin() {
 register_activation_hook(__FILE__, 'contai_activate_plugin');
 
 register_deactivation_hook(__FILE__, 'contai_unregister_job_processor_cron');
+register_deactivation_hook( __FILE__, 'contai_unregister_agent_actions_cron' );
 
 $toc_integration = ContaiTocFactory::create();
 $toc_integration->register();
@@ -154,9 +171,37 @@ function contai_register_admin_menus() {
     add_submenu_page( 'contai-website-settings', 'Jobs', 'Jobs', 'manage_options', 'contai-job-monitor', 'contai_render_job_monitor_page' );
     add_submenu_page( 'contai-website-settings', 'Billing', 'Billing', 'manage_options', 'contai-billing', 'contai_billing_page' );
     add_submenu_page( 'contai-website-settings', 'Logs', 'Logs', 'manage_options', 'contai-logs', 'contai_logs_page' );
+    add_submenu_page( 'contai-website-settings', 'Agents', 'Agents', 'manage_options', 'contai-agents', 'contai_agents_page' );
     add_submenu_page( 'contai-website-settings', 'License', 'License', 'manage_options', 'contai-licenses', 'contai_licenses_page' );
+
 }
 add_action( 'admin_menu', 'contai_register_admin_menus' );
+
+add_action( 'rest_api_init', function() {
+    $controller = new ContaiAgentRestController();
+    $controller->register_routes();
+} );
+
+/**
+ * Render the Agents admin page.
+ */
+function contai_agents_page() {
+    ContaiAgentsAdminPage::render();
+}
+
+add_action( 'admin_enqueue_scripts', function( $hook ) {
+    if ( strpos( $hook, 'contai-agents' ) === false ) {
+        return;
+    }
+    wp_enqueue_style( 'contai-agents-admin', plugin_dir_url( __FILE__ ) . 'includes/admin/agents/contai-agents-admin.css', array(), '2.3.6' );
+    wp_enqueue_script( 'contai-agents-admin', plugin_dir_url( __FILE__ ) . 'includes/admin/agents/contai-agents-admin.js', array(), '2.3.6', true );
+    wp_localize_script( 'contai-agents-admin', 'contaiAgents', array(
+        'restUrl'  => rest_url( 'contai/v1/' ),
+        'nonce'    => wp_create_nonce( 'wp_rest' ),
+        'settings' => ContaiAgentSettingsService::getAllSettings(),
+        'adminUrl' => admin_url( 'admin.php?page=contai-agents' ),
+    ) );
+} );
 
 /**
  * Render a connection-required notice when the API key is not configured.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to Content AI are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.4.0] - 2026-03-21
+
+### Added
+
+- **Agent platform integration**: Full WordPress admin UI and API integration for the 1Platform AI agent system
+  - **Agents admin page** (`ContaiAgentsAdminPage`): List agents, view runs, trigger executions, and consume human-in-the-loop actions from wp-admin
+  - **Agent API service** (`ContaiAgentApiService`): Client for all agent API endpoints (catalog, wizard, CRUD, runs, actions)
+  - **Agent REST controller** (`ContaiAgentRestController`): WordPress REST API proxy routes under `contai/v1/` for AJAX calls from the admin UI
+  - **Agent settings service** (`ContaiAgentSettingsService`): Manages agent-related WordPress options
+  - **Agent sync service** (`ContaiAgentSyncService`): Synchronizes agent state between WordPress and the 1Platform API
+  - **Action handlers**: `ContaiAgentActionHandler` base class + `ContaiSendEmailActionHandler` for processing agent-generated actions
+  - **Agent actions cron** (`agent-actions-cron.php`): WP-Cron job for polling and processing pending agent actions
+  - **Admin assets**: `contai-agents-admin.css` + `contai-agents-admin.js` for the Agents admin page
+  - **Admin menu**: "Agents" submenu item under 1Platform Content AI settings
+
+### Changed
+
+- **HTTPClientService**: Empty arrays now encode as `{}` instead of `[]` in JSON request bodies (fixes API compatibility for endpoints expecting objects)
+
+### Tests
+
+- `AgentSettingsServiceTest`, `PublishContentActionHandlerTest`, `SendEmailActionHandlerTest`
+
 ## [2.3.5] - 2026-03-17
 
 ### Fixed

--- a/includes/admin/agents/ContaiAgentsAdminPage.php
+++ b/includes/admin/agents/ContaiAgentsAdminPage.php
@@ -1,0 +1,354 @@
+<?php
+/**
+ * Agents admin page controller.
+ *
+ * Renders the server-side HTML shell for every agent view.
+ * JavaScript (contai-agents-admin.js) hydrates the skeletons
+ * with real data fetched from the WP REST proxy endpoints.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+class ContaiAgentsAdminPage {
+
+    /**
+     * Main entry point — called by the submenu page callback.
+     */
+    public static function render() {
+
+        // Gate: require active API connection.
+        if ( function_exists( 'contai_render_connection_required_notice' ) && contai_render_connection_required_notice() ) {
+            return;
+        }
+
+        $view          = isset( $_GET['view'] ) ? sanitize_key( $_GET['view'] ) : 'catalog';
+        $allowed_views = array( 'catalog', 'agents', 'wizard', 'agent-detail', 'runs', 'run-detail', 'actions', 'settings' );
+        if ( ! in_array( $view, $allowed_views, true ) ) {
+            $view = 'catalog';
+        }
+
+        echo '<div class="wrap contai-agents-wrap">';
+        echo '<h1 class="contai-agents-heading"><span class="dashicons dashicons-superhero-alt"></span> Agents</h1>';
+        self::renderNav( $view );
+
+        switch ( $view ) {
+            case 'catalog':      self::renderCatalog(); break;
+            case 'agents':       self::renderAgentList(); break;
+            case 'wizard':       self::renderWizard(); break;
+            case 'agent-detail': self::renderAgentDetail(); break;
+            case 'runs':         self::renderRuns(); break;
+            case 'run-detail':   self::renderRunDetail(); break;
+            case 'actions':      self::renderActions(); break;
+            case 'settings':     self::renderSettings(); break;
+        }
+
+        echo '</div>';
+    }
+
+    /* ── Navigation Tabs ───────────────────────────────────────── */
+
+    private static function renderNav( $current ) {
+        $base = admin_url( 'admin.php?page=contai-agents' );
+        $tabs = array(
+            'catalog'  => array( 'label' => 'Catalog',        'icon' => 'dashicons-screenoptions' ),
+            'agents'   => array( 'label' => 'My Agents',      'icon' => 'dashicons-groups' ),
+            'actions'  => array( 'label' => 'Actions',        'icon' => 'dashicons-list-view' ),
+            'settings' => array( 'label' => 'Settings',       'icon' => 'dashicons-admin-generic' ),
+        );
+
+        echo '<nav class="nav-tab-wrapper contai-agents-nav">';
+        foreach ( $tabs as $slug => $tab ) {
+            $active = ( $current === $slug ) ? ' nav-tab-active' : '';
+            printf(
+                '<a href="%s&view=%s" class="nav-tab%s"><span class="dashicons %s"></span> %s</a>',
+                esc_url( $base ),
+                esc_attr( $slug ),
+                $active,
+                esc_attr( $tab['icon'] ),
+                esc_html( $tab['label'] )
+            );
+        }
+        echo '</nav>';
+    }
+
+    /* ── Catalog (template grid) ───────────────────────────────── */
+
+    private static function renderCatalog() {
+        echo '<div id="contai-agents-catalog" class="contai-agents-section">';
+
+        // Skeleton grid (replaced by JS)
+        echo '<div class="contai-agents-grid contai-skeleton-grid">';
+        for ( $i = 0; $i < 6; $i++ ) {
+            echo '<div class="contai-agent-card contai-skeleton">';
+            echo '<div class="contai-skeleton-icon"></div>';
+            echo '<div class="contai-skeleton-text"></div>';
+            echo '<div class="contai-skeleton-text short"></div>';
+            echo '</div>';
+        }
+        echo '</div>';
+
+        // Empty state (hidden until JS decides to show it)
+        echo '<div class="contai-empty-state" style="display:none;">';
+        echo '<div class="contai-empty-icon-wrap"><span class="dashicons dashicons-portfolio"></span></div>';
+        echo '<p class="contai-empty-title">No templates available</p>';
+        echo '<p class="contai-empty-text">Please try again later.</p>';
+        echo '</div>';
+
+        echo '</div>';
+    }
+
+    /* ── Agent List (table) ────────────────────────────────────── */
+
+    private static function renderAgentList() {
+        echo '<div id="contai-agents-list" class="contai-agents-section">';
+
+        // Toolbar
+        echo '<div class="contai-agents-toolbar">';
+        echo '<a href="' . esc_url( admin_url( 'admin.php?page=contai-agents&view=catalog' ) ) . '" class="button button-primary"><span class="dashicons dashicons-plus-alt2"></span> Create Agent</a>';
+        echo '</div>';
+
+        // Table
+        echo '<div class="contai-table-card">';
+        echo '<div class="contai-table-wrap">';
+        echo '<table class="wp-list-table widefat fixed striped contai-agents-table">';
+        echo '<thead><tr>';
+        echo '<th>Name</th>';
+        echo '<th>Template</th>';
+        echo '<th>Status</th>';
+        echo '<th>Last Run</th>';
+        echo '<th>Actions</th>';
+        echo '</tr></thead>';
+        echo '<tbody id="contai-agents-tbody"><tr><td colspan="5" class="contai-loading-cell"><span class="spinner is-active"></span> Loading agents&hellip;</td></tr></tbody>';
+        echo '</table>';
+        echo '</div>';
+        echo '</div>';
+
+        // Empty state
+        echo '<div class="contai-empty-state" style="display:none;">';
+        echo '<div class="contai-empty-icon-wrap"><span class="dashicons dashicons-groups"></span></div>';
+        echo '<p class="contai-empty-title">No agents yet</p>';
+        echo '<p class="contai-empty-text">Create your first agent from the catalog.</p>';
+        echo '<a href="' . esc_url( admin_url( 'admin.php?page=contai-agents&view=catalog' ) ) . '" class="button button-primary">Go to Catalog</a>';
+        echo '</div>';
+
+        echo '</div>';
+    }
+
+    /* ── Wizard (conversational setup) ─────────────────────────── */
+
+    private static function renderWizard() {
+        $template_slug = isset( $_GET['template'] ) ? sanitize_key( $_GET['template'] ) : '';
+
+        echo '<div id="contai-agents-wizard" class="contai-agents-section" data-template="' . esc_attr( $template_slug ) . '">';
+
+        // Back link
+        echo '<a href="' . esc_url( admin_url( 'admin.php?page=contai-agents&view=catalog' ) ) . '" class="contai-back-link"><span class="dashicons dashicons-arrow-left-alt2"></span> Back to catalog</a>';
+
+        // Stepper
+        echo '<div class="contai-wizard-stepper">';
+        echo '<span class="contai-wizard-step active" data-step="1"><span class="contai-step-num">1</span> Start</span>';
+        echo '<span class="contai-wizard-step-divider"></span>';
+        echo '<span class="contai-wizard-step" data-step="2"><span class="contai-step-num">2</span> Configuration</span>';
+        echo '<span class="contai-wizard-step-divider"></span>';
+        echo '<span class="contai-wizard-step" data-step="3"><span class="contai-step-num">3</span> Confirmation</span>';
+        echo '</div>';
+
+        // Chat area
+        echo '<div class="contai-wizard-content">';
+        echo '<div class="contai-wizard-messages" id="contai-wizard-messages"></div>';
+
+        // Input area
+        echo '<div class="contai-wizard-input">';
+        echo '<label for="contai-wizard-message" class="screen-reader-text">Your answer</label>';
+        echo '<textarea id="contai-wizard-message" rows="3" maxlength="2000" placeholder="Type your answer here..."></textarea>';
+        echo '<div class="contai-wizard-input-actions">';
+        echo '<button id="contai-wizard-send" class="button button-primary" disabled><span class="dashicons dashicons-yes"></span> Send</button>';
+        echo '<button id="contai-wizard-confirm" class="button button-primary contai-btn-success" style="display:none;"><span class="dashicons dashicons-saved"></span> Confirm and Create Agent</button>';
+        echo '</div>';
+        echo '</div>';
+
+        echo '</div>'; // .contai-wizard-content
+        echo '</div>'; // #contai-agents-wizard
+    }
+
+    /* ── Agent Detail ──────────────────────────────────────────── */
+
+    private static function renderAgentDetail() {
+        $agent_id = isset( $_GET['agent_id'] ) ? sanitize_key( $_GET['agent_id'] ) : '';
+
+        echo '<div id="contai-agent-detail" class="contai-agents-section" data-agent-id="' . esc_attr( $agent_id ) . '">';
+
+        // Back link
+        echo '<a href="' . esc_url( admin_url( 'admin.php?page=contai-agents&view=agents' ) ) . '" class="contai-back-link"><span class="dashicons dashicons-arrow-left-alt2"></span> Back to my agents</a>';
+
+        // Skeleton info card
+        echo '<div class="contai-detail-card contai-agent-info contai-skeleton">';
+        echo '<div class="contai-skeleton-text" style="width:40%;height:24px;"></div>';
+        echo '<div class="contai-skeleton-text" style="width:60%;margin-top:12px;"></div>';
+        echo '<div class="contai-skeleton-text short" style="width:30%;margin-top:8px;"></div>';
+        echo '</div>';
+
+        // Action bar
+        echo '<div class="contai-agent-actions-bar">';
+        echo '<button id="contai-run-agent" class="button button-primary" disabled><span class="dashicons dashicons-controls-play"></span> Run Agent</button>';
+        echo '<a id="contai-view-runs" class="button" href="#"><span class="dashicons dashicons-backup"></span> Run History</a>';
+        echo '<button id="contai-delete-agent" class="button contai-btn-danger" disabled><span class="dashicons dashicons-trash"></span> Delete</button>';
+        echo '</div>';
+
+        echo '</div>';
+    }
+
+    /* ── Runs List ─────────────────────────────────────────────── */
+
+    private static function renderRuns() {
+        $agent_id = isset( $_GET['agent_id'] ) ? sanitize_key( $_GET['agent_id'] ) : '';
+
+        echo '<div id="contai-agents-runs" class="contai-agents-section" data-agent-id="' . esc_attr( $agent_id ) . '">';
+
+        // Back link
+        echo '<a href="' . esc_url( admin_url( 'admin.php?page=contai-agents&view=agent-detail&agent_id=' . esc_attr( $agent_id ) ) ) . '" class="contai-back-link"><span class="dashicons dashicons-arrow-left-alt2"></span> Back to agent</a>';
+
+        echo '<h2>Run History</h2>';
+
+        echo '<div class="contai-table-card">';
+        echo '<div class="contai-table-wrap">';
+        echo '<table class="wp-list-table widefat fixed striped">';
+        echo '<thead><tr>';
+        echo '<th>Date</th>';
+        echo '<th>Trigger</th>';
+        echo '<th>Status</th>';
+        echo '<th>Duration</th>';
+        echo '<th>Tokens</th>';
+        echo '<th></th>';
+        echo '</tr></thead>';
+        echo '<tbody id="contai-runs-tbody"><tr><td colspan="6" class="contai-loading-cell"><span class="spinner is-active"></span> Loading runs&hellip;</td></tr></tbody>';
+        echo '</table>';
+        echo '</div>';
+        echo '</div>';
+
+        // Empty state
+        echo '<div class="contai-empty-state" style="display:none;">';
+        echo '<div class="contai-empty-icon-wrap"><span class="dashicons dashicons-backup"></span></div>';
+        echo '<p class="contai-empty-title">No runs yet</p>';
+        echo '<p class="contai-empty-text">This agent has not been executed yet.</p>';
+        echo '</div>';
+
+        echo '</div>';
+    }
+
+    /* ── Run Detail ────────────────────────────────────────────── */
+
+    private static function renderRunDetail() {
+        $agent_id = isset( $_GET['agent_id'] ) ? sanitize_key( $_GET['agent_id'] ) : '';
+        $run_id   = isset( $_GET['run_id'] )   ? sanitize_key( $_GET['run_id'] )   : '';
+
+        echo '<div id="contai-run-detail" class="contai-agents-section" data-agent-id="' . esc_attr( $agent_id ) . '" data-run-id="' . esc_attr( $run_id ) . '">';
+
+        // Back link
+        echo '<a href="' . esc_url( admin_url( 'admin.php?page=contai-agents&view=runs&agent_id=' . esc_attr( $agent_id ) ) ) . '" class="contai-back-link"><span class="dashicons dashicons-arrow-left-alt2"></span> Back to runs</a>';
+
+        // Skeleton
+        echo '<div class="contai-detail-card contai-run-info contai-skeleton">';
+        echo '<div class="contai-skeleton-text" style="width:30%;height:20px;"></div>';
+        echo '<div class="contai-skeleton-text" style="width:50%;margin-top:12px;"></div>';
+        echo '</div>';
+
+        // Iterations container (filled by JS)
+        echo '<div id="contai-run-iterations"></div>';
+
+        echo '</div>';
+    }
+
+    /* ── Actions Queue ─────────────────────────────────────────── */
+
+    private static function renderActions() {
+        echo '<div id="contai-agents-actions" class="contai-agents-section">';
+
+        // Toolbar
+        echo '<div class="contai-agents-toolbar">';
+        echo '<select id="contai-actions-status-filter" class="contai-select">';
+        echo '<option value="">All statuses</option>';
+        echo '<option value="pending" selected>Pending</option>';
+        echo '<option value="consumed">Consumed</option>';
+        echo '</select>';
+        echo '<button id="contai-dismiss-all-actions" class="button contai-btn-danger"><span class="dashicons dashicons-trash"></span> Dismiss All Pending</button>';
+        echo '</div>';
+
+        // Table
+        echo '<div class="contai-table-card">';
+        echo '<div class="contai-table-wrap">';
+        echo '<table class="wp-list-table widefat fixed striped">';
+        echo '<thead><tr>';
+        echo '<th>Type</th>';
+        echo '<th>Agent</th>';
+        echo '<th>Date</th>';
+        echo '<th>Status</th>';
+        echo '<th>Actions</th>';
+        echo '</tr></thead>';
+        echo '<tbody id="contai-actions-tbody"><tr><td colspan="5" class="contai-loading-cell"><span class="spinner is-active"></span> Loading actions&hellip;</td></tr></tbody>';
+        echo '</table>';
+        echo '</div>';
+        echo '</div>';
+
+        // Empty state
+        echo '<div class="contai-empty-state" style="display:none;">';
+        echo '<div class="contai-empty-icon-wrap"><span class="dashicons dashicons-list-view"></span></div>';
+        echo '<p class="contai-empty-title">No actions</p>';
+        echo '<p class="contai-empty-text">No actions match the selected filter.</p>';
+        echo '</div>';
+
+        echo '</div>';
+    }
+
+    /* ── Settings ──────────────────────────────────────────────── */
+
+    private static function renderSettings() {
+        echo '<div id="contai-agents-settings" class="contai-agents-section">';
+        echo '<div class="contai-detail-card">';
+        echo '<h2 class="contai-settings-title"><span class="dashicons dashicons-admin-generic"></span> Agent Settings</h2>';
+        echo '<form id="contai-agents-settings-form">';
+        echo '<table class="form-table">';
+
+        // Publish status
+        echo '<tr>';
+        echo '<th scope="row"><label for="contai-publish-status">Publish status</label></th>';
+        echo '<td>';
+        echo '<select id="contai-publish-status" name="publish_status">';
+        echo '<option value="draft">Draft</option>';
+        echo '<option value="publish">Publish</option>';
+        echo '</select>';
+        echo '<p class="description">Default status when creating content from agents. Auto-consume always creates drafts.</p>';
+        echo '</td>';
+        echo '</tr>';
+
+        // Auto consume
+        echo '<tr>';
+        echo '<th scope="row"><label for="contai-auto-consume">Auto-consume actions</label></th>';
+        echo '<td>';
+        echo '<label class="contai-toggle">';
+        echo '<input type="checkbox" id="contai-auto-consume" name="auto_consume" value="1">';
+        echo '<span class="contai-toggle-slider"></span>';
+        echo '</label>';
+        echo '<p class="description">Automatically process pending agent actions using the publish status above.</p>';
+        echo '</td>';
+        echo '</tr>';
+
+        // Polling interval
+        echo '<tr>';
+        echo '<th scope="row"><label for="contai-polling-interval">Polling interval (seconds)</label></th>';
+        echo '<td>';
+        echo '<input type="number" id="contai-polling-interval" name="polling_interval" min="30" max="3600" value="60" class="small-text">';
+        echo '<p class="description">How often to check for new actions. Minimum 30 seconds.</p>';
+        echo '</td>';
+        echo '</tr>';
+
+        echo '</table>';
+
+        echo '<p class="submit">';
+        echo '<button type="submit" class="button button-primary"><span class="dashicons dashicons-yes"></span> Save Settings</button>';
+        echo '</p>';
+        echo '</form>';
+        echo '</div>';
+        echo '</div>';
+    }
+}

--- a/includes/admin/agents/contai-agents-admin.css
+++ b/includes/admin/agents/contai-agents-admin.css
@@ -1,0 +1,1023 @@
+/* ============================================================
+   Agents Admin — 1Platform Content AI
+   Uses --contai-* design tokens from base.css.
+   ============================================================ */
+
+/* ── Main Wrapper ── */
+.contai-agents-wrap {
+    max-width: 1200px;
+    margin: 20px auto 0;
+    font-family: var(--contai-font-sans, 'Inter', -apple-system, BlinkMacSystemFont, sans-serif);
+}
+
+.contai-agents-heading {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 23px;
+    font-weight: 700;
+    color: var(--contai-neutral-700, #0f172a);
+    margin-bottom: var(--contai-spacing-md, 16px);
+}
+
+.contai-agents-heading .dashicons {
+    font-size: 28px;
+    width: 28px;
+    height: 28px;
+    color: var(--contai-primary, #2563eb);
+}
+
+/* ── Tab Navigation ── */
+.contai-agents-nav.nav-tab-wrapper {
+    border-bottom: 1px solid var(--contai-neutral-200, #e2e8f0);
+    margin-bottom: var(--contai-spacing-lg, 24px);
+    padding: 0;
+}
+
+.contai-agents-nav .nav-tab {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    border: 1px solid transparent;
+    border-bottom: none;
+    padding: 10px 16px;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--contai-neutral-500, #64748b);
+    background: transparent;
+    transition: color 200ms ease, background 200ms ease;
+    margin-left: 0;
+}
+
+.contai-agents-nav .nav-tab .dashicons {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+}
+
+.contai-agents-nav .nav-tab:hover {
+    color: var(--contai-primary, #2563eb);
+    background: var(--contai-primary-glow, rgba(37, 99, 235, 0.08));
+}
+
+.contai-agents-nav .nav-tab:focus-visible {
+    outline: 2px solid var(--contai-primary, #2563eb);
+    outline-offset: -2px;
+    border-radius: var(--contai-radius-sm, 6px) var(--contai-radius-sm, 6px) 0 0;
+}
+
+.contai-agents-nav .nav-tab-active,
+.contai-agents-nav .nav-tab-active:hover {
+    color: var(--contai-primary, #2563eb);
+    background: #fff;
+    border-color: var(--contai-neutral-200, #e2e8f0);
+    border-bottom-color: #fff;
+    font-weight: 600;
+}
+
+/* ── Section container ── */
+.contai-agents-section {
+    margin-top: var(--contai-spacing-md, 16px);
+}
+
+/* ── Toolbar ── */
+.contai-agents-toolbar {
+    display: flex;
+    align-items: center;
+    gap: var(--contai-spacing-sm, 12px);
+    margin-bottom: var(--contai-spacing-md, 16px);
+    flex-wrap: wrap;
+}
+
+.contai-agents-toolbar .button .dashicons {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+    vertical-align: text-bottom;
+    margin-right: 4px;
+}
+
+/* ── Back Link ── */
+.contai-back-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 16px;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--contai-neutral-600, #475569);
+    background: #fff;
+    border: 1px solid var(--contai-neutral-300, #cbd5e1);
+    border-radius: var(--contai-radius-md, 8px);
+    text-decoration: none;
+    transition: background 200ms ease, border-color 200ms ease;
+    margin-bottom: var(--contai-spacing-lg, 24px);
+}
+
+.contai-back-link:hover {
+    background: var(--contai-neutral-50, #f8fafc);
+    border-color: var(--contai-neutral-400, #94a3b8);
+    color: var(--contai-neutral-700, #0f172a);
+}
+
+.contai-back-link .dashicons {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+}
+
+/* ── Select ── */
+.contai-select {
+    padding: 6px 12px;
+    border: 1px solid var(--contai-neutral-300, #cbd5e1);
+    border-radius: var(--contai-radius-md, 8px);
+    font-size: 13px;
+    font-family: var(--contai-font-sans, 'Inter', sans-serif);
+    background: #fff;
+    color: var(--contai-neutral-700, #0f172a);
+}
+
+.contai-select:focus-visible {
+    outline: 2px solid var(--contai-primary, #2563eb);
+    outline-offset: -1px;
+}
+
+/* ============================================================
+   CATALOG GRID
+   ============================================================ */
+.contai-agents-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--contai-spacing-lg, 24px);
+}
+
+.contai-agent-card {
+    background: #fff;
+    border: 1px solid var(--contai-neutral-200, #e2e8f0);
+    border-radius: var(--contai-radius-lg, 12px);
+    padding: 24px;
+    cursor: pointer;
+    transition: border-color 200ms ease,
+                box-shadow 200ms ease,
+                transform 200ms ease;
+    display: flex;
+    flex-direction: column;
+    gap: var(--contai-spacing-sm, 12px);
+    position: relative;
+    overflow: hidden;
+}
+
+.contai-agent-card:hover {
+    border-color: var(--contai-primary-border, #bfdbfe);
+    box-shadow: 0 4px 12px rgba(37, 99, 235, 0.10);
+    transform: translateY(-2px);
+}
+
+.contai-agent-card:focus-visible {
+    outline: 2px solid var(--contai-primary, #2563eb);
+    outline-offset: 2px;
+}
+
+.contai-agent-card-icon {
+    width: 48px;
+    height: 48px;
+    border-radius: var(--contai-radius-md, 8px);
+    background: var(--contai-primary-glow, rgba(37, 99, 235, 0.08));
+    color: var(--contai-primary, #2563eb);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.contai-agent-card-icon .dashicons {
+    font-size: 24px;
+    width: 24px;
+    height: 24px;
+}
+
+.contai-agent-card-title {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--contai-neutral-700, #0f172a);
+    margin: 0;
+    line-height: 1.3;
+}
+
+.contai-agent-card-desc {
+    font-size: 13px;
+    color: var(--contai-neutral-500, #64748b);
+    margin: 0;
+    line-height: 1.5;
+    flex-grow: 1;
+}
+
+.contai-agent-card-cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--contai-primary, #2563eb);
+    margin-top: auto;
+}
+
+.contai-agent-card-cta .dashicons {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+    transition: transform 200ms ease;
+}
+
+.contai-agent-card:hover .contai-agent-card-cta .dashicons {
+    transform: translateX(3px);
+}
+
+/* ============================================================
+   SKELETON LOADING
+   ============================================================ */
+.contai-skeleton {
+    pointer-events: none;
+}
+
+.contai-skeleton-icon {
+    width: 48px;
+    height: 48px;
+    border-radius: var(--contai-radius-md, 8px);
+    background: var(--contai-neutral-100, #f1f5f9);
+    animation: contai-pulse 1.5s ease-in-out infinite;
+}
+
+.contai-skeleton-text {
+    height: 14px;
+    border-radius: var(--contai-radius-sm, 6px);
+    background: var(--contai-neutral-100, #f1f5f9);
+    animation: contai-pulse 1.5s ease-in-out infinite;
+    width: 80%;
+}
+
+.contai-skeleton-text.short {
+    width: 50%;
+}
+
+@keyframes contai-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.4; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .contai-skeleton-icon,
+    .contai-skeleton-text {
+        animation: none;
+        opacity: 0.6;
+    }
+}
+
+/* ============================================================
+   EMPTY STATE
+   ============================================================ */
+.contai-empty-state {
+    text-align: center;
+    padding: 64px var(--contai-spacing-xl, 32px);
+}
+
+.contai-empty-icon-wrap {
+    width: 72px;
+    height: 72px;
+    border-radius: 50%;
+    background: var(--contai-neutral-100, #f1f5f9);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0 auto var(--contai-spacing-md, 16px);
+}
+
+.contai-empty-icon-wrap .dashicons {
+    font-size: 32px;
+    width: 32px;
+    height: 32px;
+    color: var(--contai-neutral-300, #cbd5e1);
+}
+
+.contai-empty-title {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--contai-neutral-700, #0f172a);
+    margin: 0 0 6px;
+}
+
+.contai-empty-text {
+    font-size: 13px;
+    color: var(--contai-neutral-400, #94a3b8);
+    margin: 0 0 var(--contai-spacing-md, 16px);
+}
+
+/* ============================================================
+   TABLE CARD
+   ============================================================ */
+.contai-table-card {
+    background: #fff;
+    border: 1px solid var(--contai-neutral-200, #e2e8f0);
+    border-radius: var(--contai-radius-lg, 12px);
+    overflow: hidden;
+    box-shadow: var(--contai-shadow-xs, 0 1px 2px rgba(0, 0, 0, 0.04));
+}
+
+.contai-table-wrap {
+    overflow-x: auto;
+}
+
+.contai-loading-cell {
+    text-align: center;
+    padding: 32px !important;
+    color: var(--contai-neutral-400, #94a3b8);
+    font-size: 13px;
+}
+
+.contai-loading-cell .spinner {
+    float: none;
+    margin-right: 8px;
+}
+
+/* ============================================================
+   STATUS BADGES
+   ============================================================ */
+.contai-status-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 10px;
+    border-radius: var(--contai-radius-pill, 9999px);
+    font-size: 12px;
+    font-weight: 600;
+    white-space: nowrap;
+    line-height: 1.4;
+}
+
+.contai-status-badge .dashicons {
+    font-size: 14px;
+    width: 14px;
+    height: 14px;
+}
+
+.contai-badge-blue {
+    background: var(--contai-info-bg, #eff6ff);
+    color: var(--contai-info-text, #1e40af);
+    border: 1px solid var(--contai-info-border, #bfdbfe);
+}
+
+.contai-badge-blue .dashicons {
+    animation: contai-spin 1.2s linear infinite;
+}
+
+@keyframes contai-spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .contai-badge-blue .dashicons {
+        animation: none;
+    }
+}
+
+.contai-badge-green {
+    background: var(--contai-success-bg, #f0fdf4);
+    color: var(--contai-success-text, #166534);
+    border: 1px solid var(--contai-success-border, #bbf7d0);
+}
+
+.contai-badge-red {
+    background: var(--contai-error-bg, #fef2f2);
+    color: var(--contai-error-text, #991b1b);
+    border: 1px solid var(--contai-error-border, #fecaca);
+}
+
+.contai-badge-gray {
+    background: var(--contai-neutral-100, #f1f5f9);
+    color: var(--contai-neutral-500, #64748b);
+    border: 1px solid var(--contai-neutral-200, #e2e8f0);
+}
+
+.contai-badge-yellow {
+    background: var(--contai-warning-bg, #fffbeb);
+    color: var(--contai-warning-text, #92400e);
+    border: 1px solid var(--contai-warning-border, #fde68a);
+}
+
+/* ============================================================
+   DETAIL CARD
+   ============================================================ */
+.contai-detail-card {
+    background: #fff;
+    border: 1px solid var(--contai-neutral-200, #e2e8f0);
+    border-radius: var(--contai-radius-lg, 12px);
+    padding: var(--contai-spacing-lg, 24px);
+    box-shadow: var(--contai-shadow-xs, 0 1px 2px rgba(0, 0, 0, 0.04));
+    margin-bottom: var(--contai-spacing-md, 16px);
+}
+
+.contai-detail-card h2 {
+    margin-top: 0;
+}
+
+.contai-detail-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: var(--contai-spacing-lg, 24px);
+    margin-top: var(--contai-spacing-md, 16px);
+}
+
+.contai-detail-field-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--contai-neutral-400, #94a3b8);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 4px;
+}
+
+.contai-detail-field-value {
+    font-size: 14px;
+    color: var(--contai-neutral-700, #0f172a);
+    font-weight: 500;
+}
+
+/* ── Action Bar ── */
+.contai-agent-actions-bar {
+    display: flex;
+    align-items: center;
+    gap: var(--contai-spacing-sm, 12px);
+    flex-wrap: wrap;
+}
+
+.contai-agent-actions-bar .button .dashicons {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+    vertical-align: text-bottom;
+    margin-right: 4px;
+}
+
+.contai-btn-danger {
+    background: var(--contai-error, #dc2626) !important;
+    border-color: var(--contai-error, #dc2626) !important;
+    color: #fff !important;
+}
+
+.contai-btn-danger:hover {
+    background: #b91c1c !important;
+    border-color: #b91c1c !important;
+}
+
+.contai-btn-danger .dashicons {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+    vertical-align: text-bottom;
+    margin-right: 4px;
+}
+
+.contai-stop-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 10px;
+    border-radius: var(--contai-radius-pill, 9999px);
+    font-size: 12px;
+    font-weight: 600;
+    white-space: nowrap;
+    line-height: 1.4;
+    background: var(--contai-error, #dc2626);
+    color: #fff;
+    border: none;
+    cursor: pointer;
+    vertical-align: top;
+    margin-top: 1px;
+}
+
+.contai-stop-btn:hover {
+    background: #b91c1c;
+}
+
+.contai-stop-btn .dashicons {
+    font-size: 14px;
+    width: 14px;
+    height: 14px;
+}
+
+.contai-btn-success {
+    background: var(--contai-success, #059669) !important;
+    border-color: var(--contai-success, #059669) !important;
+    color: #fff !important;
+}
+
+.contai-btn-success:hover {
+    background: #047857 !important;
+    border-color: #047857 !important;
+}
+
+/* ============================================================
+   WIZARD
+   ============================================================ */
+
+/* Stepper */
+.contai-wizard-stepper {
+    display: flex;
+    align-items: center;
+    gap: var(--contai-spacing-sm, 12px);
+    margin-bottom: var(--contai-spacing-lg, 24px);
+    padding: var(--contai-spacing-md, 16px) var(--contai-spacing-lg, 24px);
+    background: #fff;
+    border: 1px solid var(--contai-neutral-200, #e2e8f0);
+    border-radius: var(--contai-radius-lg, 12px);
+}
+
+.contai-wizard-step {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--contai-neutral-400, #94a3b8);
+    transition: color 200ms ease;
+}
+
+.contai-wizard-step.active {
+    color: var(--contai-primary, #2563eb);
+    font-weight: 600;
+}
+
+.contai-wizard-step.completed {
+    color: var(--contai-success, #059669);
+}
+
+.contai-step-num {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    font-size: 12px;
+    font-weight: 700;
+    background: var(--contai-neutral-100, #f1f5f9);
+    color: var(--contai-neutral-400, #94a3b8);
+    transition: background 200ms ease, color 200ms ease;
+}
+
+.contai-wizard-step.active .contai-step-num {
+    background: var(--contai-primary, #2563eb);
+    color: #fff;
+}
+
+.contai-wizard-step.completed .contai-step-num {
+    background: var(--contai-success, #059669);
+    color: #fff;
+}
+
+.contai-wizard-step-divider {
+    flex: 1;
+    height: 2px;
+    background: var(--contai-neutral-200, #e2e8f0);
+    min-width: 20px;
+}
+
+/* Chat messages */
+.contai-wizard-content {
+    background: #fff;
+    border: 1px solid var(--contai-neutral-200, #e2e8f0);
+    border-radius: var(--contai-radius-lg, 12px);
+    overflow: hidden;
+}
+
+.contai-wizard-messages {
+    min-height: 300px;
+    max-height: 500px;
+    overflow-y: auto;
+    padding: var(--contai-spacing-lg, 24px);
+    display: flex;
+    flex-direction: column;
+    gap: var(--contai-spacing-md, 16px);
+}
+
+.contai-wizard-msg {
+    max-width: 80%;
+    padding: 12px 16px;
+    border-radius: var(--contai-radius-lg, 12px);
+    font-size: 14px;
+    line-height: 1.6;
+    word-wrap: break-word;
+}
+
+.contai-wizard-msg.assistant {
+    align-self: flex-start;
+    background: var(--contai-neutral-50, #f8fafc);
+    border: 1px solid var(--contai-neutral-200, #e2e8f0);
+    color: var(--contai-neutral-700, #0f172a);
+}
+
+.contai-wizard-msg.user {
+    align-self: flex-end;
+    background: var(--contai-primary, #2563eb);
+    color: #fff;
+}
+
+.contai-wizard-msg.system {
+    align-self: center;
+    background: var(--contai-warning-bg, #fffbeb);
+    border: 1px solid var(--contai-warning-border, #fde68a);
+    color: var(--contai-warning-text, #92400e);
+    font-size: 13px;
+    text-align: center;
+}
+
+.contai-wizard-msg-typing {
+    align-self: flex-start;
+    padding: 12px 16px;
+}
+
+.contai-wizard-msg-typing span {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--contai-neutral-300, #cbd5e1);
+    margin: 0 2px;
+    animation: contai-typing 1.4s ease-in-out infinite;
+}
+
+.contai-wizard-msg-typing span:nth-child(2) {
+    animation-delay: 0.2s;
+}
+
+.contai-wizard-msg-typing span:nth-child(3) {
+    animation-delay: 0.4s;
+}
+
+@keyframes contai-typing {
+    0%, 80%, 100% { opacity: 0.3; transform: scale(0.8); }
+    40% { opacity: 1; transform: scale(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .contai-wizard-msg-typing span {
+        animation: none;
+        opacity: 0.5;
+    }
+}
+
+/* Input area */
+.contai-wizard-input {
+    padding: var(--contai-spacing-md, 16px) var(--contai-spacing-lg, 24px);
+    border-top: 1px solid var(--contai-neutral-200, #e2e8f0);
+    background: var(--contai-neutral-50, #f8fafc);
+}
+
+.contai-wizard-input textarea {
+    width: 100%;
+    border: 1px solid var(--contai-neutral-300, #cbd5e1);
+    border-radius: var(--contai-radius-md, 8px);
+    padding: 10px 14px;
+    font-size: 14px;
+    font-family: var(--contai-font-sans, 'Inter', sans-serif);
+    resize: vertical;
+    transition: border-color 200ms ease;
+    box-sizing: border-box;
+}
+
+.contai-wizard-input textarea:focus {
+    border-color: var(--contai-primary, #2563eb);
+    outline: none;
+    box-shadow: 0 0 0 2px var(--contai-primary-glow, rgba(37, 99, 235, 0.08));
+}
+
+.contai-wizard-input-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--contai-spacing-xs, 8px);
+    margin-top: var(--contai-spacing-xs, 8px);
+}
+
+.contai-wizard-input-actions .button .dashicons {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+    vertical-align: text-bottom;
+    margin-right: 4px;
+}
+
+/* ============================================================
+   RUN ITERATIONS
+   ============================================================ */
+.contai-iteration-card {
+    background: #fff;
+    border: 1px solid var(--contai-neutral-200, #e2e8f0);
+    border-radius: var(--contai-radius-lg, 12px);
+    margin-bottom: var(--contai-spacing-md, 16px);
+    overflow: hidden;
+}
+
+.contai-iteration-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px var(--contai-spacing-lg, 24px);
+    background: var(--contai-neutral-50, #f8fafc);
+    border-bottom: 1px solid var(--contai-neutral-200, #e2e8f0);
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--contai-neutral-700, #0f172a);
+    cursor: pointer;
+    user-select: none;
+    transition: background 200ms ease;
+}
+
+.contai-iteration-header:hover {
+    background: var(--contai-neutral-100, #f1f5f9);
+}
+
+.contai-iteration-header .dashicons {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+    transition: transform 200ms ease;
+}
+
+.contai-iteration-header.is-open .dashicons {
+    transform: rotate(180deg);
+}
+
+.contai-iteration-body {
+    display: none;
+    padding: var(--contai-spacing-lg, 24px);
+}
+
+.contai-iteration-body.is-open {
+    display: block;
+}
+
+.contai-iteration-output {
+    background: var(--contai-neutral-700, #0f172a);
+    color: #e2e8f0;
+    padding: var(--contai-spacing-md, 16px);
+    border-radius: var(--contai-radius-md, 8px);
+    font-family: var(--contai-font-mono, 'JetBrains Mono', monospace);
+    font-size: 12px;
+    line-height: 1.6;
+    overflow-x: auto;
+    max-height: 400px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+}
+
+/* ============================================================
+   SETTINGS
+   ============================================================ */
+.contai-settings-title {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 18px;
+    font-weight: 700;
+    color: var(--contai-neutral-700, #0f172a);
+}
+
+.contai-settings-title .dashicons {
+    color: var(--contai-primary, #2563eb);
+}
+
+/* Toggle switch */
+.contai-toggle {
+    display: inline-flex;
+    align-items: center;
+    cursor: pointer;
+    position: relative;
+}
+
+.contai-toggle input {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.contai-toggle-slider {
+    width: 44px;
+    height: 24px;
+    background: var(--contai-neutral-300, #cbd5e1);
+    border-radius: 12px;
+    position: relative;
+    transition: background 200ms ease;
+}
+
+.contai-toggle-slider::after {
+    content: '';
+    position: absolute;
+    top: 3px;
+    left: 3px;
+    width: 18px;
+    height: 18px;
+    background: #fff;
+    border-radius: 50%;
+    transition: transform 200ms ease;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+}
+
+.contai-toggle input:checked + .contai-toggle-slider {
+    background: var(--contai-primary, #2563eb);
+}
+
+.contai-toggle input:checked + .contai-toggle-slider::after {
+    transform: translateX(20px);
+}
+
+.contai-toggle input:focus-visible + .contai-toggle-slider {
+    outline: 2px solid var(--contai-primary, #2563eb);
+    outline-offset: 2px;
+}
+
+/* ============================================================
+   TOAST NOTIFICATION
+   ============================================================ */
+.contai-toast {
+    position: fixed;
+    top: 40px;
+    right: 20px;
+    z-index: 160001;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 20px;
+    border-radius: var(--contai-radius-md, 8px);
+    font-size: 13px;
+    font-weight: 500;
+    font-family: var(--contai-font-sans, 'Inter', sans-serif);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+    transform: translateX(120%);
+    transition: transform 300ms ease;
+    max-width: 400px;
+}
+
+.contai-toast.is-visible {
+    transform: translateX(0);
+}
+
+.contai-toast .dashicons {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+    flex-shrink: 0;
+}
+
+.contai-toast-success {
+    background: var(--contai-success-bg, #f0fdf4);
+    color: var(--contai-success-text, #166534);
+    border: 1px solid var(--contai-success-border, #bbf7d0);
+}
+
+.contai-toast-error {
+    background: var(--contai-error-bg, #fef2f2);
+    color: var(--contai-error-text, #991b1b);
+    border: 1px solid var(--contai-error-border, #fecaca);
+}
+
+.contai-toast-info {
+    background: var(--contai-info-bg, #eff6ff);
+    color: var(--contai-info-text, #1e40af);
+    border: 1px solid var(--contai-info-border, #bfdbfe);
+}
+
+/* ============================================================
+   TABLE ACTION LINKS
+   ============================================================ */
+.contai-row-actions {
+    display: flex;
+    gap: var(--contai-spacing-xs, 8px);
+    align-items: center;
+}
+
+.contai-row-actions a,
+.contai-row-actions button {
+    font-size: 12px;
+    font-weight: 500;
+    text-decoration: none;
+    padding: 4px 10px;
+    border-radius: var(--contai-radius-sm, 6px);
+    transition: background 200ms ease, color 200ms ease;
+    border: none;
+    cursor: pointer;
+    font-family: var(--contai-font-sans, 'Inter', sans-serif);
+    background: none;
+}
+
+.contai-row-actions a:hover {
+    background: var(--contai-primary-glow, rgba(37, 99, 235, 0.08));
+    color: var(--contai-primary, #2563eb);
+}
+
+.contai-row-action-primary {
+    color: var(--contai-primary, #2563eb) !important;
+}
+
+.contai-row-action-danger {
+    color: var(--contai-error, #dc2626) !important;
+}
+
+.contai-row-action-danger:hover {
+    background: var(--contai-error-bg, #fef2f2) !important;
+}
+
+.contai-row-action-success {
+    color: var(--contai-success, #059669) !important;
+}
+
+.contai-row-action-success:hover {
+    background: var(--contai-success-bg, #f0fdf4) !important;
+    color: var(--contai-success, #059669) !important;
+}
+
+.contai-row-action-danger {
+    color: var(--contai-error, #dc2626) !important;
+}
+
+.contai-row-action-danger:hover {
+    background: var(--contai-error-bg, #fef2f2) !important;
+    color: var(--contai-error, #dc2626) !important;
+}
+
+/* ============================================================
+   BUTTON LOADING STATE
+   ============================================================ */
+.contai-btn-loading {
+    pointer-events: none;
+    opacity: 0.7;
+}
+
+.contai-btn-loading .dashicons {
+    animation: contai-spin 1s linear infinite;
+}
+
+/* ============================================================
+   RESPONSIVE
+   ============================================================ */
+@media (max-width: 1200px) {
+    .contai-agents-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (max-width: 768px) {
+    .contai-agents-wrap {
+        margin: 10px;
+    }
+
+    .contai-agents-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .contai-agents-toolbar {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .contai-wizard-msg {
+        max-width: 95%;
+    }
+
+    .contai-wizard-stepper {
+        flex-wrap: wrap;
+        gap: 8px;
+    }
+
+    .contai-wizard-step-divider {
+        display: none;
+    }
+
+    .contai-agent-actions-bar {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .contai-detail-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .contai-row-actions {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}
+
+/* ============================================================
+   FOCUS VISIBLE (a11y)
+   ============================================================ */
+.contai-agents-wrap a:focus-visible,
+.contai-agents-wrap button:focus-visible,
+.contai-agents-wrap input:focus-visible,
+.contai-agents-wrap select:focus-visible,
+.contai-agents-wrap textarea:focus-visible {
+    outline: 2px solid var(--contai-primary, #2563eb);
+    outline-offset: 2px;
+}

--- a/includes/admin/agents/contai-agents-admin.js
+++ b/includes/admin/agents/contai-agents-admin.js
@@ -1,0 +1,1018 @@
+/**
+ * Agents Admin UI — 1Platform Content AI
+ *
+ * Vanilla JS that hydrates the server-rendered HTML skeletons with data
+ * fetched from the WP REST proxy (contai/v1/).  Each view is initialised
+ * by detecting the corresponding container element on the page.
+ */
+(function () {
+    'use strict';
+
+    /* ================================================================
+       GLOBALS
+       ================================================================ */
+    var API      = contaiAgents.restUrl;   // e.g. "https://example.com/wp-json/contai/v1/"
+    var NONCE    = contaiAgents.nonce;
+    var SETTINGS = contaiAgents.settings;  // hydrated from PHP
+    var ADMIN    = contaiAgents.adminUrl;  // admin.php?page=contai-agents
+
+    /* ================================================================
+       HELPERS
+       ================================================================ */
+
+    /**
+     * Fetch wrapper that talks to the WP REST proxy.
+     * Returns parsed JSON or throws a WP_Error-shaped object.
+     */
+    function apiFetch(endpoint, options) {
+        options = options || {};
+        var url = API + endpoint;
+        var headers = {
+            'X-WP-Nonce': NONCE,
+            'Content-Type': 'application/json'
+        };
+        var cfg = {
+            headers: headers,
+            credentials: 'same-origin'
+        };
+        // merge options
+        Object.keys(options).forEach(function (k) {
+            if (k === 'headers') {
+                Object.keys(options.headers).forEach(function (h) {
+                    cfg.headers[h] = options.headers[h];
+                });
+            } else {
+                cfg[k] = options[k];
+            }
+        });
+        return fetch(url, cfg)
+            .then(function (r) {
+                if (!r.ok) {
+                    return r.json().then(function (body) {
+                        var err = new Error(body.message || 'Error ' + r.status);
+                        err.code = body.code || 'api_error';
+                        err.status = r.status;
+                        throw err;
+                    });
+                }
+                return r.json();
+            });
+    }
+
+    /** Build a query-string (without leading ?) from a plain object. */
+    function qs(params) {
+        var parts = [];
+        Object.keys(params).forEach(function (k) {
+            if (params[k] !== '' && params[k] !== null && params[k] !== undefined) {
+                parts.push(encodeURIComponent(k) + '=' + encodeURIComponent(params[k]));
+            }
+        });
+        return parts.length ? '?' + parts.join('&') : '';
+    }
+
+    /** Simple HTML escaping (text content only). */
+    function esc(str) {
+        var d = document.createElement('div');
+        d.appendChild(document.createTextNode(str || ''));
+        return d.innerHTML;
+    }
+
+    /** HTML attribute escaping (safe for href, data-*, etc.). */
+    function escAttr(str) {
+        return String(str || '').replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+
+    /** Format an ISO date string to a human-readable form. */
+    function fmtDate(iso) {
+        if (!iso) return '-';
+        var d = new Date(iso);
+        if (isNaN(d.getTime())) return iso;
+        return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
+             + ' ' + d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' });
+    }
+
+    /** Format seconds to a duration string. */
+    function fmtDuration(seconds) {
+        if (seconds === null || seconds === undefined) return '-';
+        seconds = Math.round(seconds);
+        if (seconds < 60) return seconds + 's';
+        var m = Math.floor(seconds / 60);
+        var s = seconds % 60;
+        return m + 'm ' + s + 's';
+    }
+
+    /** Build a status badge HTML string. */
+    function statusBadge(status) {
+        var map = {
+            running:   { cls: 'blue',   icon: 'dashicons-update',   label: 'Running' },
+            completed: { cls: 'green',  icon: 'dashicons-yes-alt',  label: 'Completed' },
+            failed:    { cls: 'red',    icon: 'dashicons-dismiss',  label: 'Failed' },
+            pending:   { cls: 'gray',   icon: 'dashicons-clock',    label: 'Pending' },
+            consumed:  { cls: 'green',  icon: 'dashicons-yes-alt',  label: 'Consumed' },
+            active:    { cls: 'green',  icon: 'dashicons-yes-alt',  label: 'Active' },
+            stopped:   { cls: 'yellow', icon: 'dashicons-controls-pause', label: 'Stopped' },
+            paused:    { cls: 'yellow', icon: 'dashicons-controls-pause', label: 'Paused' },
+            error:     { cls: 'red',    icon: 'dashicons-dismiss',  label: 'Error' }
+        };
+        var s = map[(status || '').toLowerCase()] || map.pending;
+        return '<span class="contai-status-badge contai-badge-' + s.cls + '">' +
+               '<span class="dashicons ' + s.icon + '"></span> ' + esc(s.label) +
+               '</span>';
+    }
+
+    /** Show a toast notification. */
+    function showToast(message, type) {
+        type = type || 'success';
+        var iconMap = { success: 'dashicons-yes-alt', error: 'dashicons-dismiss', info: 'dashicons-info' };
+        var el = document.createElement('div');
+        el.className = 'contai-toast contai-toast-' + type;
+        el.setAttribute('role', 'alert');
+        el.innerHTML = '<span class="dashicons ' + (iconMap[type] || iconMap.info) + '"></span> ' + esc(message);
+        document.body.appendChild(el);
+        // trigger reflow then animate in
+        void el.offsetWidth;
+        el.classList.add('is-visible');
+        setTimeout(function () {
+            el.classList.remove('is-visible');
+            setTimeout(function () { el.remove(); }, 350);
+        }, 4000);
+    }
+
+    /** Template icon mapping — maps common slugs to dashicons. */
+    function templateIcon(slug) {
+        var map = {
+            'blog-writer':     'dashicons-edit',
+            'seo-optimizer':   'dashicons-search',
+            'social-media':    'dashicons-share',
+            'email-writer':    'dashicons-email',
+            'product-writer':  'dashicons-cart',
+            'content-planner': 'dashicons-calendar-alt',
+            'link-builder':    'dashicons-admin-links',
+            'keyword-agent':   'dashicons-tag',
+            'image-agent':     'dashicons-format-image'
+        };
+        return map[slug] || 'dashicons-superhero-alt';
+    }
+
+    /** Set a button to loading state. */
+    function btnLoading(btn, loading) {
+        if (loading) {
+            btn.classList.add('contai-btn-loading');
+            btn.disabled = true;
+            btn._prevHTML = btn.innerHTML;
+            btn.innerHTML = '<span class="dashicons dashicons-update"></span> Processing...';
+        } else {
+            btn.classList.remove('contai-btn-loading');
+            btn.disabled = false;
+            if (btn._prevHTML) {
+                btn.innerHTML = btn._prevHTML;
+                delete btn._prevHTML;
+            }
+        }
+    }
+
+    /* ================================================================
+       INIT ROUTER
+       ================================================================ */
+    function init() {
+        if (document.getElementById('contai-agents-catalog'))       initCatalog();
+        if (document.getElementById('contai-agents-list'))          initAgentList();
+        if (document.getElementById('contai-agents-wizard'))        initWizard();
+        if (document.getElementById('contai-agent-detail'))         initAgentDetail();
+        if (document.getElementById('contai-agents-runs'))          initRuns();
+        if (document.getElementById('contai-run-detail'))           initRunDetail();
+        if (document.getElementById('contai-agents-actions'))       initActions();
+        if (document.getElementById('contai-agents-settings-form')) initSettings();
+    }
+
+    /* ================================================================
+       CATALOG
+       ================================================================ */
+    function initCatalog() {
+        var container = document.getElementById('contai-agents-catalog');
+        var grid      = container.querySelector('.contai-agents-grid');
+        var empty     = container.querySelector('.contai-empty-state');
+
+        apiFetch('agents/catalog')
+            .then(function (data) {
+                var templates = Array.isArray(data) ? data : (data.templates || data.items || []);
+                if (!templates.length) {
+                    grid.style.display = 'none';
+                    empty.style.display = '';
+                    return;
+                }
+                grid.classList.remove('contai-skeleton-grid');
+                grid.innerHTML = '';
+                templates.forEach(function (t) {
+                    var slug = t.slug || t.id || '';
+                    var href = ADMIN + '&view=wizard&template=' + encodeURIComponent(slug);
+                    var icon = t.icon || templateIcon(slug);
+                    var card = document.createElement('a');
+                    card.href = href;
+                    card.className = 'contai-agent-card';
+                    card.innerHTML =
+                        '<div class="contai-agent-card-icon"><span class="dashicons ' + escAttr(icon) + '"></span></div>' +
+                        '<h3 class="contai-agent-card-title">' + esc(t.name || t.title || slug) + '</h3>' +
+                        '<p class="contai-agent-card-desc">' + esc(t.description || '') + '</p>' +
+                        '<span class="contai-agent-card-cta">Create agent <span class="dashicons dashicons-arrow-right-alt2"></span></span>';
+                    grid.appendChild(card);
+                });
+            })
+            .catch(function (err) {
+                grid.style.display = 'none';
+                empty.querySelector('.contai-empty-title').textContent = 'Error loading templates';
+                empty.querySelector('.contai-empty-text').textContent = err.message || 'Please try again.';
+                empty.style.display = '';
+                showToast(err.message || 'Could not load catalog.', 'error');
+            });
+    }
+
+    /* ================================================================
+       AGENT LIST
+       ================================================================ */
+    function initAgentList() {
+        var container = document.getElementById('contai-agents-list');
+        var tbody     = document.getElementById('contai-agents-tbody');
+        var tableCard = container.querySelector('.contai-table-card');
+        var empty     = container.querySelector('.contai-empty-state');
+
+        apiFetch('agents')
+            .then(function (data) {
+                var agents = Array.isArray(data) ? data : (data.agents || data.items || []);
+                if (!agents.length) {
+                    tableCard.style.display = 'none';
+                    empty.style.display = '';
+                    return;
+                }
+                tbody.innerHTML = '';
+                agents.forEach(function (a) {
+                    var id   = a.id || a._id || '';
+                    var name = a.name || a.title || 'Unnamed';
+                    var tmpl = a.template_slug || a.template || '-';
+                    var st   = a.status || 'active';
+                    var last = a.last_run_at || a.last_run || null;
+                    var tr   = document.createElement('tr');
+                    tr.innerHTML =
+                        '<td><strong>' + esc(name) + '</strong></td>' +
+                        '<td>' + esc(tmpl) + '</td>' +
+                        '<td>' + statusBadge(st) + '</td>' +
+                        '<td>' + fmtDate(last) + '</td>' +
+                        '<td><div class="contai-row-actions">' +
+                            '<a href="' + escAttr(ADMIN + '&view=agent-detail&agent_id=' + id) + '" class="contai-row-action-primary">View</a>' +
+                            '<a href="' + escAttr(ADMIN + '&view=runs&agent_id=' + id) + '" class="contai-row-action-primary">Runs</a>' +
+                        '</div></td>';
+                    tbody.appendChild(tr);
+                });
+            })
+            .catch(function (err) {
+                tbody.innerHTML = '<tr><td colspan="5" style="color:#dc2626;text-align:center;">Error: ' + esc(err.message) + '</td></tr>';
+                showToast('Error loading agents: ' + err.message, 'error');
+            });
+    }
+
+    /* ================================================================
+       WIZARD
+       ================================================================ */
+    function initWizard() {
+        var container    = document.getElementById('contai-agents-wizard');
+        var templateSlug = container.getAttribute('data-template') || '';
+        var messagesEl   = document.getElementById('contai-wizard-messages');
+        var textarea     = document.getElementById('contai-wizard-message');
+        var sendBtn      = document.getElementById('contai-wizard-send');
+        var confirmBtn   = document.getElementById('contai-wizard-confirm');
+        var steps        = container.querySelectorAll('.contai-wizard-step');
+
+        var sessionId    = null;
+        var isReady      = false;  // wizard flagged as ready_to_confirm
+        var sending      = false;
+
+        // Enable send when textarea has content
+        textarea.addEventListener('input', function () {
+            sendBtn.disabled = sending || textarea.value.trim().length === 0;
+        });
+
+        // Send on Enter (without Shift)
+        textarea.addEventListener('keydown', function (e) {
+            if (e.key === 'Enter' && !e.shiftKey && !sendBtn.disabled) {
+                e.preventDefault();
+                sendBtn.click();
+            }
+        });
+
+        /** Add a message bubble to the chat. */
+        function addMessage(text, role) {
+            var div = document.createElement('div');
+            div.className = 'contai-wizard-msg ' + (role || 'assistant');
+            div.textContent = text;
+            messagesEl.appendChild(div);
+            messagesEl.scrollTop = messagesEl.scrollHeight;
+        }
+
+        /** Show typing indicator. */
+        function showTyping() {
+            var div = document.createElement('div');
+            div.className = 'contai-wizard-msg assistant contai-wizard-msg-typing';
+            div.id = 'contai-typing';
+            div.innerHTML = '<span></span><span></span><span></span>';
+            messagesEl.appendChild(div);
+            messagesEl.scrollTop = messagesEl.scrollHeight;
+        }
+
+        function hideTyping() {
+            var t = document.getElementById('contai-typing');
+            if (t) t.remove();
+        }
+
+        /** Update the stepper to reflect the current step. */
+        function setStep(num) {
+            steps.forEach(function (s) {
+                var sn = parseInt(s.getAttribute('data-step'), 10);
+                s.classList.remove('active', 'completed');
+                if (sn < num) s.classList.add('completed');
+                if (sn === num) s.classList.add('active');
+            });
+        }
+
+        /** Re-enable the input area after resuming a session. */
+        function enableInput() {
+            sendBtn.disabled = textarea.value.trim().length === 0;
+            textarea.style.display = '';
+            sendBtn.style.display = '';
+            confirmBtn.style.display = 'none';
+            setStep(2);
+        }
+
+        /** Handle wizard API response (start, respond). */
+        function handleWizardResponse(data) {
+            hideTyping();
+
+            // Save session ID and persist to localStorage
+            if (data.id) {
+                sessionId = data.id;
+                localStorage.setItem('contai_wizard_session_id', sessionId);
+            }
+
+            // Show the last assistant message from the messages array
+            if (data.messages && data.messages.length > 0) {
+                var lastMsg = data.messages[data.messages.length - 1];
+                if (lastMsg.role === 'assistant' && lastMsg.content) {
+                    addMessage(lastMsg.content, 'assistant');
+                }
+            }
+
+            // Check if wizard is ready to confirm
+            if (data.generated_config || data.status === 'completed') {
+                isReady = true;
+                setStep(3);
+                textarea.style.display = 'none';
+                sendBtn.style.display = 'none';
+                confirmBtn.style.display = '';
+                // Show config summary if available
+                if (data.summary || data.config_summary) {
+                    addMessage(data.summary || data.config_summary, 'system');
+                }
+            } else {
+                // Advance stepper
+                var stepNum = data.current_step || data.step_number || 2;
+                if (typeof stepNum === 'number' && stepNum > 1) {
+                    setStep(Math.min(stepNum, 2));
+                } else {
+                    setStep(2);
+                }
+            }
+        }
+
+        // ── Start a fresh wizard session ──
+        function startNewSession() {
+            var startPayload = {};
+            if (templateSlug) {
+                startPayload.template_slug = templateSlug;
+            }
+
+            showTyping();
+            apiFetch('agents/wizard/start', {
+                method: 'POST',
+                body: JSON.stringify(startPayload)
+            })
+            .then(function (data) {
+                setStep(1);
+                handleWizardResponse(data);
+            })
+            .catch(function (err) {
+                hideTyping();
+                addMessage('Error starting the wizard: ' + (err.message || 'unknown'), 'system');
+                showToast('Could not start the wizard.', 'error');
+            });
+        }
+
+        // ── Resume or start session ──
+        // Check localStorage for a saved session (persists across page reloads).
+        var savedSessionId = localStorage.getItem('contai_wizard_session_id');
+        if (savedSessionId && !templateSlug) {
+            sessionId = savedSessionId;
+            // Try to resume the saved session.
+            apiFetch('agents/wizard/' + sessionId)
+                .then(function (data) {
+                    if (data && data.status === 'in_progress') {
+                        // Resume session — render existing messages.
+                        if (data.messages) {
+                            data.messages.forEach(function (msg) {
+                                addMessage(msg.content, msg.role);
+                            });
+                        }
+                        enableInput();
+                    } else {
+                        localStorage.removeItem('contai_wizard_session_id');
+                        startNewSession();
+                    }
+                })
+                .catch(function () {
+                    localStorage.removeItem('contai_wizard_session_id');
+                    startNewSession();
+                });
+        } else {
+            startNewSession();
+        }
+
+        // ── Send response ──
+        sendBtn.addEventListener('click', function () {
+            var answer = textarea.value.trim();
+            if (!answer || !sessionId || sending) return;
+
+            sending = true;
+            sendBtn.disabled = true;
+            addMessage(answer, 'user');
+            textarea.value = '';
+            showTyping();
+
+            apiFetch('agents/wizard/' + sessionId + '/respond', {
+                method: 'POST',
+                body: JSON.stringify({ message: answer })
+            })
+            .then(function (data) {
+                sending = false;
+                handleWizardResponse(data);
+            })
+            .catch(function (err) {
+                sending = false;
+                hideTyping();
+                addMessage('Error: ' + (err.message || 'Could not send the response.'), 'system');
+                sendBtn.disabled = false;
+                showToast(err.message || 'Error sending response.', 'error');
+            });
+        });
+
+        // ── Confirm and create agent ──
+        confirmBtn.addEventListener('click', function () {
+            if (!sessionId) return;
+            btnLoading(confirmBtn, true);
+
+            apiFetch('agents/wizard/' + sessionId + '/confirm', {
+                method: 'POST',
+                body: JSON.stringify({})
+            })
+            .then(function (data) {
+                btnLoading(confirmBtn, false);
+                var agentId = data.id || data._id || data.agent_id || '';
+                localStorage.removeItem('contai_wizard_session_id');
+                showToast('Agent created successfully.', 'success');
+                addMessage('Agent created successfully. Redirecting...', 'system');
+
+                setTimeout(function () {
+                    if (agentId) {
+                        window.location.href = ADMIN + '&view=agent-detail&agent_id=' + agentId;
+                    } else {
+                        window.location.href = ADMIN + '&view=agents';
+                    }
+                }, 1500);
+            })
+            .catch(function (err) {
+                btnLoading(confirmBtn, false);
+                addMessage('Error creating agent: ' + (err.message || 'unknown'), 'system');
+                showToast(err.message || 'Error confirming.', 'error');
+            });
+        });
+    }
+
+    /* ================================================================
+       AGENT DETAIL
+       ================================================================ */
+    function initAgentDetail() {
+        var container = document.getElementById('contai-agent-detail');
+        var agentId   = container.getAttribute('data-agent-id');
+        var infoEl    = container.querySelector('.contai-agent-info');
+        var runBtn    = document.getElementById('contai-run-agent');
+        var runsLink  = document.getElementById('contai-view-runs');
+        var deleteBtn = document.getElementById('contai-delete-agent');
+
+        if (!agentId) {
+            infoEl.innerHTML = '<p style="color:#dc2626;">No agent ID specified.</p>';
+            infoEl.classList.remove('contai-skeleton');
+            return;
+        }
+
+        // Update runs link
+        runsLink.href = ADMIN + '&view=runs&agent_id=' + agentId;
+
+        apiFetch('agents/' + agentId)
+            .then(function (agent) {
+                infoEl.classList.remove('contai-skeleton');
+                var name   = agent.name || agent.title || 'Agent';
+                var tmpl   = agent.template_slug || agent.template || '-';
+                var st     = agent.status || 'active';
+                var desc   = agent.description || agent.config_summary || '';
+                var created = agent.created_at || agent.created || '';
+
+                infoEl.innerHTML =
+                    '<h2 style="margin-top:0;">' + esc(name) + ' ' + statusBadge(st) + '</h2>' +
+                    (desc ? '<p style="color:#64748b;margin:8px 0;">' + esc(desc) + '</p>' : '') +
+                    '<div class="contai-detail-grid">' +
+                        '<div><div class="contai-detail-field-label">Template</div><div class="contai-detail-field-value">' + esc(tmpl) + '</div></div>' +
+                        '<div><div class="contai-detail-field-label">Created</div><div class="contai-detail-field-value">' + fmtDate(created) + '</div></div>' +
+                        '<div><div class="contai-detail-field-label">Last Run</div><div class="contai-detail-field-value">' + fmtDate(agent.last_run_at || agent.last_run) + '</div></div>' +
+                    '</div>';
+
+                // Show config if present
+                if (agent.config && typeof agent.config === 'object') {
+                    var configHTML = '<div style="margin-top:16px;"><div class="contai-detail-field-label">Configuration</div>';
+                    configHTML += '<div class="contai-iteration-output">' + esc(JSON.stringify(agent.config, null, 2)) + '</div>';
+                    configHTML += '</div>';
+                    infoEl.innerHTML += configHTML;
+                }
+
+                runBtn.disabled = false;
+                deleteBtn.disabled = false;
+            })
+            .catch(function (err) {
+                infoEl.classList.remove('contai-skeleton');
+                infoEl.innerHTML = '<p style="color:#dc2626;">Error: ' + esc(err.message) + '</p>';
+                showToast('Could not load the agent.', 'error');
+            });
+
+        // ── Run Agent ──
+        runBtn.addEventListener('click', function () {
+            btnLoading(runBtn, true);
+            apiFetch('agents/' + agentId + '/run', {
+                method: 'POST',
+                body: JSON.stringify({})
+            })
+            .then(function (data) {
+                btnLoading(runBtn, false);
+                showToast('Execution started.', 'success');
+                // Redirect to runs after a short delay
+                setTimeout(function () {
+                    window.location.href = ADMIN + '&view=runs&agent_id=' + agentId;
+                }, 1000);
+            })
+            .catch(function (err) {
+                btnLoading(runBtn, false);
+                showToast('Error running agent: ' + (err.message || 'unknown'), 'error');
+            });
+        });
+
+        // ── Delete Agent ──
+        deleteBtn.addEventListener('click', function () {
+            if (!window.confirm('Are you sure you want to delete this agent? This action cannot be undone.')) {
+                return;
+            }
+            btnLoading(deleteBtn, true);
+            apiFetch('agents/' + agentId, { method: 'DELETE' })
+                .then(function () {
+                    showToast('Agent deleted.', 'success');
+                    setTimeout(function () {
+                        window.location.href = ADMIN + '&view=agents';
+                    }, 1000);
+                })
+                .catch(function (err) {
+                    btnLoading(deleteBtn, false);
+                    showToast('Error deleting agent: ' + (err.message || 'unknown'), 'error');
+                });
+        });
+    }
+
+    /* ================================================================
+       RUNS LIST
+       ================================================================ */
+    function initRuns() {
+        var container = document.getElementById('contai-agents-runs');
+        var agentId   = container.getAttribute('data-agent-id');
+        var tbody     = document.getElementById('contai-runs-tbody');
+        var tableCard = container.querySelector('.contai-table-card');
+        var empty     = container.querySelector('.contai-empty-state');
+        var refreshTimer = null;
+
+        function loadRuns() {
+            apiFetch('agents/' + agentId + '/runs')
+                .then(function (data) {
+                    var runs = Array.isArray(data) ? data : (data.runs || data.items || []);
+                    if (!runs.length) {
+                        tableCard.style.display = 'none';
+                        empty.style.display = '';
+                        stopAutoRefresh();
+                        return;
+                    }
+
+                    tableCard.style.display = '';
+                    empty.style.display = 'none';
+                    tbody.innerHTML = '';
+
+                    var hasRunning = false;
+                    runs.forEach(function (r) {
+                        var rid     = r.id || r._id || '';
+                        var st      = r.status || 'pending';
+                        var trigger = r.trigger || r.triggered_by || 'manual';
+                        var dur     = r.duration_seconds || r.duration || null;
+                        var tokens  = r.total_tokens || r.tokens_used || null;
+                        var date    = r.created_at || r.started_at || '';
+
+                        if (st === 'running') hasRunning = true;
+
+                        var tr = document.createElement('tr');
+                        tr.innerHTML =
+                            '<td>' + fmtDate(date) + '</td>' +
+                            '<td>' + esc(trigger) + '</td>' +
+                            '<td>' + statusBadge(st) + '</td>' +
+                            '<td>' + fmtDuration(dur) + '</td>' +
+                            '<td>' + (tokens !== null ? esc(String(tokens)) : '-') + '</td>' +
+                            '<td><div class="contai-row-actions">' +
+                                '<a href="' + escAttr(ADMIN + '&view=run-detail&agent_id=' + agentId + '&run_id=' + rid) + '" class="contai-row-action-primary">Details</a>' +
+                            '</div></td>';
+                        tbody.appendChild(tr);
+                    });
+
+                    // Auto-refresh if any run is RUNNING
+                    if (hasRunning) {
+                        startAutoRefresh();
+                    } else {
+                        stopAutoRefresh();
+                    }
+                })
+                .catch(function (err) {
+                    tbody.innerHTML = '<tr><td colspan="6" style="color:#dc2626;text-align:center;">Error: ' + esc(err.message) + '</td></tr>';
+                    stopAutoRefresh();
+                });
+        }
+
+        function startAutoRefresh() {
+            if (refreshTimer) return;
+            refreshTimer = setInterval(loadRuns, 5000);
+        }
+
+        function stopAutoRefresh() {
+            if (refreshTimer) {
+                clearInterval(refreshTimer);
+                refreshTimer = null;
+            }
+        }
+
+        if (agentId) {
+            loadRuns();
+        } else {
+            tbody.innerHTML = '<tr><td colspan="6" style="color:#dc2626;text-align:center;">No agent specified.</td></tr>';
+        }
+    }
+
+    /* ================================================================
+       RUN DETAIL
+       ================================================================ */
+    function initRunDetail() {
+        var container     = document.getElementById('contai-run-detail');
+        var agentId       = container.getAttribute('data-agent-id');
+        var runId         = container.getAttribute('data-run-id');
+        var infoEl        = container.querySelector('.contai-run-info');
+        var iterationsEl  = document.getElementById('contai-run-iterations');
+
+        if (!agentId || !runId) {
+            infoEl.classList.remove('contai-skeleton');
+            infoEl.innerHTML = '<p style="color:#dc2626;">Missing parameters (agent_id or run_id).</p>';
+            return;
+        }
+
+        apiFetch('agents/' + agentId + '/runs/' + runId)
+            .then(function (run) {
+                infoEl.classList.remove('contai-skeleton');
+
+                var st      = run.status || 'pending';
+                var trigger = run.trigger || run.triggered_by || 'manual';
+                var dur     = run.duration_seconds || run.duration || null;
+                var tokens  = run.total_tokens || run.tokens_used || null;
+                var date    = run.created_at || run.started_at || '';
+                var err     = run.error || run.error_message || '';
+
+                var canStop = (st === 'running' || st === 'pending');
+                var stopBtnHTML = canStop
+                    ? ' <button id="contai-stop-run-btn" class="contai-stop-btn">' +
+                      '<span class="dashicons dashicons-controls-pause"></span> Stop Run</button>'
+                    : '';
+
+                infoEl.innerHTML =
+                    '<h2 style="margin-top:0;">Run ' + statusBadge(st) + stopBtnHTML + '</h2>' +
+                    '<div class="contai-detail-grid">' +
+                        '<div><div class="contai-detail-field-label">Date</div><div class="contai-detail-field-value">' + fmtDate(date) + '</div></div>' +
+                        '<div><div class="contai-detail-field-label">Trigger</div><div class="contai-detail-field-value">' + esc(trigger) + '</div></div>' +
+                        '<div><div class="contai-detail-field-label">Duration</div><div class="contai-detail-field-value">' + fmtDuration(dur) + '</div></div>' +
+                        '<div><div class="contai-detail-field-label">Tokens</div><div class="contai-detail-field-value">' + (tokens !== null ? esc(String(tokens)) : '-') + '</div></div>' +
+                    '</div>' +
+                    (err ? '<div style="margin-top:16px;"><div class="contai-detail-field-label">Error</div><div class="contai-iteration-output" style="color:#fca5a5;">' + esc(err) + '</div></div>' : '');
+
+                // Bind stop button
+                if (canStop) {
+                    var stopBtn = document.getElementById('contai-stop-run-btn');
+                    stopBtn.addEventListener('click', function () {
+                        if (!window.confirm('Are you sure you want to stop this run?')) return;
+                        btnLoading(stopBtn, true);
+                        apiFetch('agents/' + agentId + '/runs/' + runId + '/stop', { method: 'POST', body: JSON.stringify({}) })
+                            .then(function () {
+                                showToast('Run stopped successfully.', 'success');
+                                window.location.reload();
+                            })
+                            .catch(function (err) {
+                                btnLoading(stopBtn, false);
+                                showToast('Error stopping run: ' + (err.message || 'unknown'), 'error');
+                            });
+                    });
+                }
+
+                // Render iterations
+                var iterations = run.iterations || run.steps || [];
+                if (iterations.length) {
+                    iterationsEl.innerHTML = '<h3>Iterations (' + iterations.length + ')</h3>';
+                    iterations.forEach(function (it, idx) {
+                        var card = document.createElement('div');
+                        card.className = 'contai-iteration-card';
+
+                        var itStatus = it.status || 'completed';
+                        var itLabel  = it.name || it.label || ('Iteration ' + (idx + 1));
+
+                        var header = document.createElement('div');
+                        header.className = 'contai-iteration-header';
+                        header.innerHTML = '<span>' + esc(itLabel) + ' ' + statusBadge(itStatus) + '</span><span class="dashicons dashicons-arrow-down-alt2"></span>';
+
+                        var body = document.createElement('div');
+                        body.className = 'contai-iteration-body';
+
+                        // Build body content
+                        var bodyHTML = '';
+                        if (it.input)  bodyHTML += '<div class="contai-detail-field-label">Input</div><div class="contai-iteration-output">' + esc(typeof it.input === 'string' ? it.input : JSON.stringify(it.input, null, 2)) + '</div>';
+                        if (it.output) bodyHTML += '<div class="contai-detail-field-label" style="margin-top:12px;">Output</div><div class="contai-iteration-output">' + esc(typeof it.output === 'string' ? it.output : JSON.stringify(it.output, null, 2)) + '</div>';
+                        if (it.error)  bodyHTML += '<div class="contai-detail-field-label" style="margin-top:12px;">Error</div><div class="contai-iteration-output" style="color:#fca5a5;">' + esc(it.error) + '</div>';
+                        if (!bodyHTML)  bodyHTML = '<p style="color:#94a3b8;">No iteration data.</p>';
+                        body.innerHTML = bodyHTML;
+
+                        // Toggle
+                        header.addEventListener('click', function () {
+                            header.classList.toggle('is-open');
+                            body.classList.toggle('is-open');
+                        });
+
+                        card.appendChild(header);
+                        card.appendChild(body);
+                        iterationsEl.appendChild(card);
+                    });
+
+                    // Auto-open first iteration
+                    var firstHeader = iterationsEl.querySelector('.contai-iteration-header');
+                    var firstBody   = iterationsEl.querySelector('.contai-iteration-body');
+                    if (firstHeader && firstBody) {
+                        firstHeader.classList.add('is-open');
+                        firstBody.classList.add('is-open');
+                    }
+                }
+
+                // Auto-refresh if still running
+                if (st === 'running') {
+                    setTimeout(function () {
+                        window.location.reload();
+                    }, 5000);
+                }
+            })
+            .catch(function (err) {
+                infoEl.classList.remove('contai-skeleton');
+                infoEl.innerHTML = '<p style="color:#dc2626;">Error: ' + esc(err.message) + '</p>';
+                showToast('Could not load the run.', 'error');
+            });
+    }
+
+    /* ================================================================
+       ACTIONS
+       ================================================================ */
+    function initActions() {
+        var container = document.getElementById('contai-agents-actions');
+        var tbody     = document.getElementById('contai-actions-tbody');
+        var tableCard = container.querySelector('.contai-table-card');
+        var empty     = container.querySelector('.contai-empty-state');
+        var filter    = document.getElementById('contai-actions-status-filter');
+
+        function loadActions() {
+            var status = filter.value;
+            var endpoint = 'agent-actions' + qs({ status: status });
+
+            apiFetch(endpoint)
+                .then(function (data) {
+                    var actions = Array.isArray(data) ? data : (data.actions || data.items || []);
+                    if (!actions.length) {
+                        tableCard.style.display = 'none';
+                        empty.style.display = '';
+                        return;
+                    }
+
+                    tableCard.style.display = '';
+                    empty.style.display = 'none';
+                    tbody.innerHTML = '';
+
+                    actions.forEach(function (a) {
+                        var aid    = a.id || a._id || '';
+                        var type   = a.type || a.action_type || '-';
+                        var agent  = a.agent_name || a.agent_id || '-';
+                        var date   = a.created_at || '';
+                        var st     = a.status || 'pending';
+
+                        var tr = document.createElement('tr');
+                        var actionsHTML = '';
+                        if (st === 'pending') {
+                            actionsHTML = '<button class="contai-row-action-success contai-consume-btn" data-action-id="' + escAttr(aid) + '">Consume</button>' +
+                                ' <button class="contai-row-action-danger contai-dismiss-btn" data-action-id="' + escAttr(aid) + '">Dismiss</button>';
+                        } else {
+                            actionsHTML = '<span style="color:#94a3b8;">-</span>';
+                        }
+
+                        tr.innerHTML =
+                            '<td><strong>' + esc(type) + '</strong></td>' +
+                            '<td>' + esc(agent) + '</td>' +
+                            '<td>' + fmtDate(date) + '</td>' +
+                            '<td>' + statusBadge(st) + '</td>' +
+                            '<td><div class="contai-row-actions">' + actionsHTML + '</div></td>';
+                        tbody.appendChild(tr);
+                    });
+
+                    // Bind consume buttons
+                    var consumeBtns = tbody.querySelectorAll('.contai-consume-btn');
+                    consumeBtns.forEach(function (btn) {
+                        btn.addEventListener('click', function () {
+                            handleConsume(btn);
+                        });
+                    });
+
+                    // Bind dismiss buttons
+                    var dismissBtns = tbody.querySelectorAll('.contai-dismiss-btn');
+                    dismissBtns.forEach(function (btn) {
+                        btn.addEventListener('click', function () {
+                            handleDismiss(btn);
+                        });
+                    });
+                })
+                .catch(function (err) {
+                    tableCard.style.display = '';
+                    empty.style.display = 'none';
+                    tbody.innerHTML = '<tr><td colspan="5" style="color:#dc2626;text-align:center;">Error: ' + esc(err.message) + '</td></tr>';
+                    showToast('Error loading actions: ' + err.message, 'error');
+                });
+        }
+
+        function handleConsume(btn) {
+            var actionId = btn.getAttribute('data-action-id');
+            if (!window.confirm('Consume this action? Content will be created in WordPress.')) {
+                return;
+            }
+            btn.disabled = true;
+            btn.textContent = 'Processing...';
+
+            apiFetch('agent-actions/' + actionId + '/consume', {
+                method: 'PATCH',
+                body: JSON.stringify({})
+            })
+            .then(function () {
+                showToast('Action consumed successfully.', 'success');
+                loadActions(); // refresh the table
+            })
+            .catch(function (err) {
+                btn.disabled = false;
+                btn.textContent = 'Consume';
+                showToast('Error consuming action: ' + (err.message || 'unknown'), 'error');
+            });
+        }
+
+        function handleDismiss(btn) {
+            var actionId = btn.getAttribute('data-action-id');
+            if (!window.confirm('Dismiss this action? It will be marked as consumed without creating content.')) {
+                return;
+            }
+            btn.disabled = true;
+            btn.textContent = 'Dismissing...';
+
+            apiFetch('agent-actions/' + actionId + '/dismiss', {
+                method: 'PATCH',
+                body: JSON.stringify({})
+            })
+            .then(function () {
+                showToast('Action dismissed.', 'success');
+                loadActions();
+            })
+            .catch(function (err) {
+                btn.disabled = false;
+                btn.textContent = 'Dismiss';
+                showToast('Error dismissing action: ' + (err.message || 'unknown'), 'error');
+            });
+        }
+
+        // Dismiss All button
+        var dismissAllBtn = document.getElementById('contai-dismiss-all-actions');
+        if (dismissAllBtn) {
+            dismissAllBtn.addEventListener('click', function () {
+                if (!window.confirm('Dismiss ALL pending actions? They will be marked as consumed without creating content.')) {
+                    return;
+                }
+                btnLoading(dismissAllBtn, true);
+
+                apiFetch('agent-actions/dismiss-all', {
+                    method: 'POST',
+                    body: JSON.stringify({})
+                })
+                .then(function (data) {
+                    var count = (data && data.dismissed) || 0;
+                    var errors = (data && data.errors) || 0;
+                    var msg = count + ' action(s) dismissed.';
+                    if (errors > 0) msg += ' ' + errors + ' error(s).';
+                    showToast(msg, errors > 0 ? 'error' : 'success');
+                    loadActions();
+                })
+                .catch(function (err) {
+                    showToast('Error dismissing actions: ' + (err.message || 'unknown'), 'error');
+                })
+                .finally(function () {
+                    btnLoading(dismissAllBtn, false);
+                });
+            });
+        }
+
+        // Filter change
+        filter.addEventListener('change', loadActions);
+
+        // Initial load
+        loadActions();
+    }
+
+    /* ================================================================
+       SETTINGS
+       ================================================================ */
+    function initSettings() {
+        var form     = document.getElementById('contai-agents-settings-form');
+        var pubSel   = document.getElementById('contai-publish-status');
+        var autoChk  = document.getElementById('contai-auto-consume');
+        var pollIn   = document.getElementById('contai-polling-interval');
+
+        // Hydrate from server-side settings
+        if (SETTINGS) {
+            if (SETTINGS.publish_status) pubSel.value = SETTINGS.publish_status;
+            if (SETTINGS.auto_consume)   autoChk.checked = true;
+            if (SETTINGS.polling_interval) pollIn.value = SETTINGS.polling_interval;
+        }
+
+        // Also fetch fresh from API in case they changed
+        apiFetch('agents/settings')
+            .then(function (s) {
+                if (s.publish_status)   pubSel.value = s.publish_status;
+                autoChk.checked = !!s.auto_consume;
+                if (s.polling_interval) pollIn.value = s.polling_interval;
+            })
+            .catch(function () {
+                // Silently use server-side defaults
+            });
+
+        form.addEventListener('submit', function (e) {
+            e.preventDefault();
+            var submitBtn = form.querySelector('button[type="submit"]');
+            btnLoading(submitBtn, true);
+
+            var pollingVal = parseInt(pollIn.value, 10);
+            if (isNaN(pollingVal) || pollingVal < 30) pollingVal = 30;
+            if (pollingVal > 3600) pollingVal = 3600;
+
+            var payload = {
+                publish_status:   pubSel.value,
+                auto_consume:     autoChk.checked,
+                polling_interval: pollingVal
+            };
+
+            apiFetch('agents/settings', {
+                method: 'POST',
+                body: JSON.stringify(payload)
+            })
+            .then(function (data) {
+                btnLoading(submitBtn, false);
+                // Update local reference
+                SETTINGS = data;
+                showToast('Settings saved.', 'success');
+            })
+            .catch(function (err) {
+                btnLoading(submitBtn, false);
+                showToast('Error: ' + (err.message || 'Could not save settings.'), 'error');
+            });
+        });
+    }
+
+    /* ================================================================
+       BOOT
+       ================================================================ */
+    document.addEventListener('DOMContentLoaded', init);
+})();

--- a/includes/cron/agent-actions-cron.php
+++ b/includes/cron/agent-actions-cron.php
@@ -1,0 +1,27 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+function contai_register_agent_actions_cron() {
+    if ( ! wp_next_scheduled( 'contai_agent_actions_poll' ) ) {
+        wp_schedule_event( time(), 'contai_every_minute', 'contai_agent_actions_poll' );
+    }
+}
+
+function contai_unregister_agent_actions_cron() {
+    wp_clear_scheduled_hook( 'contai_agent_actions_poll' );
+}
+
+function contai_agent_actions_poll_callback() {
+    // Only run if auto-consume is enabled
+    require_once dirname( __DIR__ ) . '/services/agents/ContaiAgentSettingsService.php';
+    if ( ! ContaiAgentSettingsService::isAutoConsumeEnabled() ) {
+        return;
+    }
+
+    require_once dirname( __DIR__ ) . '/services/agents/ContaiAgentSyncService.php';
+    $sync = ContaiAgentSyncService::create();
+    $sync->pollAndProcessActions();
+}
+
+add_action( 'contai_agent_actions_poll', 'contai_agent_actions_poll_callback' );

--- a/includes/services/agents/ContaiAgentActionHandler.php
+++ b/includes/services/agents/ContaiAgentActionHandler.php
@@ -1,0 +1,256 @@
+<?php
+/**
+ * Agent action handler interface and built-in implementations.
+ *
+ * ContaiAgentActionHandlerInterface defines the contract every handler must
+ * fulfil.  ContaiPublishContentActionHandler is the default implementation
+ * for the 'publish_content' action type emitted by the 1Platform Agent API.
+ *
+ * Handler contract:
+ *   canHandle( $type ) — return true when this handler owns the given type.
+ *   handle( $action, $settings ) — execute the action; return an array with
+ *     at minimum ['success' => bool].  On success include 'post_id' and
+ *     'permalink'.  On failure include 'error' with a human-readable message.
+ *
+ * Security model:
+ *   All data received from the API payload is treated as untrusted input and
+ *   sanitised before being written to the database (defense in depth), even
+ *   though the source is our own API.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+// ── Interface ────────────────────────────────────────────────────────────────
+
+interface ContaiAgentActionHandlerInterface {
+
+	/**
+	 * Returns true when this handler can process actions of the given type.
+	 *
+	 * @param string $type Action type identifier (e.g. 'publish_content').
+	 * @return bool
+	 */
+	public function canHandle( $type );
+
+	/**
+	 * Processes the action and returns a result array.
+	 *
+	 * @param array $action   Full action object from the API (id, type, payload, …).
+	 * @param array $settings Plugin settings context from ContaiAgentSettingsService::getAllSettings()
+	 *                        plus any runtime flags (e.g. 'is_auto_consume').
+	 * @return array{success: bool, error?: string, post_id?: int, permalink?: string, post_status?: string}
+	 */
+	public function handle( array $action, array $settings );
+}
+
+// ── publish_content handler ──────────────────────────────────────────────────
+
+/**
+ * Handles the 'publish_content' agent action type.
+ *
+ * Expected action payload keys:
+ *   title             (string, required) — post title
+ *   body              (string, required) — post HTML content
+ *   slug              (string, optional) — desired URL slug
+ *   excerpt           (string, optional) — post excerpt
+ *   publish_date      (string, optional) — ISO 8601 / strtotime-compatible date
+ *   metatitle         (string, optional) — SEO meta title
+ *   categories        (string[], optional) — category names (created if missing)
+ *   featured_image_url (string, optional) — remote image URL to sideload
+ *   metadata          (array, optional)  — arbitrary post_meta key/value pairs
+ */
+class ContaiPublishContentActionHandler implements ContaiAgentActionHandlerInterface {
+
+	/** Maximum allowed date drift from "now" (used to reject nonsensical dates). */
+	const MAX_DATE_DRIFT_SECONDS = 365 * DAY_IN_SECONDS;
+
+	private $post_creator;
+
+	public function __construct( ContaiWordPressPostCreator $post_creator ) {
+		$this->post_creator = $post_creator;
+	}
+
+	public function canHandle( $type ) {
+		return 'publish_content' === $type;
+	}
+
+	public function handle( array $action, array $settings ) {
+		$payload = isset( $action['payload'] ) && is_array( $action['payload'] )
+			? $action['payload']
+			: array();
+
+		// ── Required field validation ────────────────────────────
+		if ( empty( $payload['title'] ) || empty( $payload['body'] ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'Missing required fields: title, body',
+			);
+		}
+
+		// ── Duplicate check ──────────────────────────────────────
+		$existing = get_posts( array(
+			'post_type'   => 'post',
+			'post_status' => array( 'publish', 'draft', 'pending' ),
+			'title'       => sanitize_text_field( $payload['title'] ),
+			'numberposts' => 1,
+		) );
+		if ( ! empty( $existing ) ) {
+			return array(
+				'success' => false,
+				'error'   => 'A post with this title already exists (ID: ' . $existing[0]->ID . ')',
+			);
+		}
+
+		// ── Sanitise all inputs (defense in depth) ───────────────
+		$title     = sanitize_text_field( $payload['title'] );
+		$body      = wp_kses_post( $payload['body'] );
+		$slug      = isset( $payload['slug'] ) ? sanitize_title( $payload['slug'] ) : null;
+		$excerpt   = isset( $payload['excerpt'] ) ? wp_kses_post( $payload['excerpt'] ) : '';
+		$date      = isset( $payload['publish_date'] ) ? $this->validateDate( $payload['publish_date'] ) : null;
+		$metatitle = isset( $payload['metatitle'] ) ? sanitize_text_field( $payload['metatitle'] ) : null;
+
+		// ── Determine post status ────────────────────────────────
+		$post_status = isset( $settings['publish_status'] ) ? $settings['publish_status'] : 'publish';
+
+		try {
+			// ── Create post with correct status from the start ───
+			// Build the post array directly so the post is never momentarily
+			// published before being changed to draft (prevents RSS/ping/email
+			// hooks from firing with an unintended status).
+			$post_data = array(
+				'post_title'   => $title,
+				'post_content' => $body,
+				'post_status'  => $post_status,
+				'post_type'    => 'post',
+			);
+			if ( $slug ) {
+				$post_data['post_name'] = $slug;
+			}
+			if ( $date ) {
+				$post_data['post_date_gmt'] = $date;
+				$post_data['post_date']     = get_date_from_gmt( $date );
+			}
+			if ( $excerpt ) {
+				$post_data['post_excerpt'] = $excerpt;
+			}
+
+			$post_id = wp_insert_post( $post_data, true );
+			if ( is_wp_error( $post_id ) ) {
+				return array( 'success' => false, 'error' => $post_id->get_error_message() );
+			}
+
+			// Save metatitle
+			if ( $metatitle ) {
+				update_post_meta( $post_id, '_contai_metatitle', $metatitle );
+			}
+
+			// ── Categories ───────────────────────────────────────
+			// Use existing post creator method for categories.
+			if ( ! empty( $payload['categories'] ) && is_array( $payload['categories'] ) ) {
+				$cat_names = array_map( 'sanitize_text_field', $payload['categories'] );
+				foreach ( $cat_names as $cat_name ) {
+					if ( empty( $cat_name ) ) continue;
+					$term = term_exists( $cat_name, 'category' );
+					if ( ! $term ) {
+						$term = wp_insert_term( $cat_name, 'category' );
+					}
+					if ( ! is_wp_error( $term ) ) {
+						$cat_id = is_array( $term ) ? (int) $term['term_id'] : (int) $term;
+						$this->post_creator->assignCategory( $post_id, $cat_id );
+					}
+				}
+			}
+
+			// ── Featured image (sideload from URL) ───────────────
+			if ( ! empty( $payload['featured_image_url'] ) ) {
+				$image_url = esc_url_raw( $payload['featured_image_url'] );
+				if ( $image_url ) {
+					require_once ABSPATH . 'wp-admin/includes/media.php';
+					require_once ABSPATH . 'wp-admin/includes/file.php';
+					require_once ABSPATH . 'wp-admin/includes/image.php';
+					$attachment_id = media_sideload_image( $image_url, $post_id, null, 'id' );
+					if ( ! is_wp_error( $attachment_id ) ) {
+						$this->post_creator->setFeaturedImage( $post_id, $attachment_id );
+					}
+				}
+			}
+
+			// ── Arbitrary metadata ───────────────────────────────
+			if ( ! empty( $payload['metadata'] ) && is_array( $payload['metadata'] ) ) {
+				$this->post_creator->saveMetadata( $post_id, $this->sanitizeMetadata( $payload['metadata'] ) );
+			}
+
+			$permalink = $this->post_creator->getPermalink( $post_id );
+
+			return array(
+				'success'     => true,
+				'post_id'     => $post_id,
+				'permalink'   => $permalink,
+				'post_status' => $post_status,
+			);
+
+		} catch ( Exception $e ) {
+			return array(
+				'success' => false,
+				'error'   => $e->getMessage(), // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+			);
+		}
+	}
+
+	// ── Private helpers ──────────────────────────────────────────────────────
+
+	/**
+	 * Recursively sanitizes metadata values before writing to post_meta.
+	 *
+	 * Strings are passed through sanitize_text_field; array keys through
+	 * sanitize_key.  Scalar types (int, float, bool) are returned as-is.
+	 * Any other type is coerced to an empty string.
+	 *
+	 * @param mixed $data
+	 * @return mixed
+	 */
+	private function sanitizeMetadata( $data ) {
+		if ( is_string( $data ) ) {
+			return sanitize_text_field( $data );
+		}
+		if ( is_array( $data ) ) {
+			$clean = array();
+			foreach ( $data as $key => $value ) {
+				$clean_key           = sanitize_key( $key );
+				$clean[ $clean_key ] = $this->sanitizeMetadata( $value );
+			}
+			return $clean;
+		}
+		if ( is_int( $data ) || is_float( $data ) || is_bool( $data ) ) {
+			return $data;
+		}
+		return '';
+	}
+
+	/**
+	 * Validates a date string and returns a MySQL-formatted datetime or null.
+	 *
+	 * Rejects dates that are more than one year in the past or future to guard
+	 * against malformed or malicious values being written to post_date.
+	 *
+	 * @param string $date_str
+	 * @return string|null 'Y-m-d H:i:s' on success, null on invalid/out-of-range input.
+	 */
+	private function validateDate( $date_str ) {
+		$timestamp = strtotime( $date_str );
+		if ( ! $timestamp ) {
+			return null;
+		}
+
+		$now = time();
+		if (
+			$timestamp < ( $now - self::MAX_DATE_DRIFT_SECONDS ) ||
+			$timestamp > ( $now + self::MAX_DATE_DRIFT_SECONDS )
+		) {
+			return null;
+		}
+
+		return gmdate( 'Y-m-d H:i:s', $timestamp );
+	}
+
+}

--- a/includes/services/agents/ContaiAgentApiService.php
+++ b/includes/services/agents/ContaiAgentApiService.php
@@ -1,0 +1,328 @@
+<?php
+/**
+ * Agent API service — communicates with the 1Platform Agent API.
+ *
+ * Wraps ContaiOnePlatformClient to provide typed, named methods for every
+ * agent-related endpoint.  All responses are normalised through handleResponse()
+ * which returns the 'data' payload on success or null on failure (with logging).
+ *
+ * The catalog endpoint is cached for one hour via WordPress transients to avoid
+ * redundant round-trips on pages that render the agent selection UI.
+ *
+ * cURL examples (import to Postman):
+ *
+ * # List catalog
+ * curl -X GET https://api-qa.1platform.pro/api/v1/agents/catalog \
+ *   -H "Authorization: Bearer <APP_TOKEN>" \
+ *   -H "x-user-token: <USER_TOKEN>"
+ *
+ * # Start wizard
+ * curl -X POST https://api-qa.1platform.pro/api/v1/agents/wizard/start \
+ *   -H "Content-Type: application/json" \
+ *   -H "Authorization: Bearer <APP_TOKEN>" \
+ *   -H "x-user-token: <USER_TOKEN>" \
+ *   -d '{"template_slug":"blog-writer"}'
+ *
+ * # List pending actions
+ * curl -X GET "https://api-qa.1platform.pro/api/v1/agent-actions?status=pending" \
+ *   -H "Authorization: Bearer <APP_TOKEN>" \
+ *   -H "x-user-token: <USER_TOKEN>"
+ *
+ * # Consume action
+ * curl -X PATCH https://api-qa.1platform.pro/api/v1/agent-actions/<ID>/consume \
+ *   -H "Content-Type: application/json" \
+ *   -H "Authorization: Bearer <APP_TOKEN>" \
+ *   -H "x-user-token: <USER_TOKEN>" \
+ *   -d '{"result":{},"consumed_by":"wordpress-plugin"}'
+ */
+
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+require_once __DIR__ . '/ContaiAgentEndpoints.php';
+
+class ContaiAgentApiService {
+
+	const CATALOG_TRANSIENT_KEY = 'contai_agents_catalog';
+
+	private ContaiOnePlatformClient $client;
+
+	public function __construct( ContaiOnePlatformClient $client ) {
+		$this->client = $client;
+	}
+
+	public static function create() {
+		return new self( ContaiOnePlatformClient::create() );
+	}
+
+	// ── Catalog ─────────────────────────────────────────────────
+
+	/**
+	 * Returns the full agent template catalog.
+	 * Result is cached in a transient for one hour to reduce API load.
+	 *
+	 * @return array|null Catalog data on success, null on failure.
+	 */
+	public function getCatalog() {
+		$cached = get_transient( self::CATALOG_TRANSIENT_KEY );
+		if ( false !== $cached ) {
+			return $cached;
+		}
+
+		$response = $this->client->get( ContaiAgentEndpoints::CATALOG );
+		$result   = $this->handleResponse( $response, 'getCatalog' );
+
+		if ( ! is_wp_error( $result ) && ! empty( $result ) ) {
+			set_transient( self::CATALOG_TRANSIENT_KEY, $result, HOUR_IN_SECONDS );
+		} else {
+			delete_transient( self::CATALOG_TRANSIENT_KEY );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Returns a single catalog template by slug.
+	 *
+	 * @param string $slug Template slug.
+	 * @return array|null
+	 */
+	public function getCatalogTemplate( $slug ) {
+		$endpoint = ContaiAgentEndpoints::CATALOG_TEMPLATE . rawurlencode( $slug );
+		$response = $this->client->get( $endpoint );
+		return $this->handleResponse( $response, 'getCatalogTemplate' );
+	}
+
+	// ── Wizard ──────────────────────────────────────────────────
+
+	/**
+	 * Starts a new wizard session for the given template.
+	 *
+	 * @param array $payload e.g. ['template_slug' => 'blog-writer']
+	 * @return array|null Session data (including session_id) on success.
+	 */
+	public function startWizard( array $payload ) {
+		$response = $this->client->post( ContaiAgentEndpoints::WIZARD_START, $payload );
+		return $this->handleResponse( $response, 'startWizard' );
+	}
+
+	/**
+	 * Submits a user response to an active wizard session.
+	 *
+	 * @param string $session_id
+	 * @param array  $payload    e.g. ['answer' => '...']
+	 * @return array|null
+	 */
+	public function respondWizard( $session_id, array $payload ) {
+		$endpoint = ContaiAgentEndpoints::wizardRespond( $session_id );
+		$response = $this->client->post( $endpoint, $payload );
+		return $this->handleResponse( $response, 'respondWizard' );
+	}
+
+	/**
+	 * Confirms and finalises a wizard session, creating the agent.
+	 *
+	 * @param string $session_id
+	 * @return array|null Created agent data on success.
+	 */
+	public function confirmWizard( $session_id ) {
+		$endpoint = ContaiAgentEndpoints::wizardConfirm( $session_id );
+		$response = $this->client->post( $endpoint, array(
+			'site_url' => get_site_url(),
+		) );
+		return $this->handleResponse( $response, 'confirmWizard' );
+	}
+
+	/**
+	 * Fetches the current state of a wizard session.
+	 *
+	 * @param string $session_id
+	 * @return array|null
+	 */
+	public function getWizardSession( $session_id ) {
+		$endpoint = ContaiAgentEndpoints::wizardGet( $session_id );
+		$response = $this->client->get( $endpoint );
+		return $this->handleResponse( $response, 'getWizardSession' );
+	}
+
+	// ── Agent CRUD ───────────────────────────────────────────────
+
+	/**
+	 * Creates a new agent.
+	 *
+	 * @param array $payload Agent definition.
+	 * @return array|null
+	 */
+	public function createAgent( array $payload ) {
+		$response = $this->client->post( ContaiAgentEndpoints::AGENTS, $payload );
+		return $this->handleResponse( $response, 'createAgent' );
+	}
+
+	/**
+	 * Lists agents for the authenticated user.
+	 *
+	 * @param array $params Optional query params (e.g. ['page' => 1, 'limit' => 20]).
+	 * @return array|null
+	 */
+	public function listAgents( array $params = array() ) {
+		$response = $this->client->get( ContaiAgentEndpoints::AGENTS, $params );
+		return $this->handleResponse( $response, 'listAgents' );
+	}
+
+	/**
+	 * Fetches a single agent by ID.
+	 *
+	 * @param string $id Agent ID.
+	 * @return array|null
+	 */
+	public function getAgent( $id ) {
+		$endpoint = ContaiAgentEndpoints::agentById( $id );
+		$response = $this->client->get( $endpoint );
+		return $this->handleResponse( $response, 'getAgent' );
+	}
+
+	/**
+	 * Replaces an agent's configuration.
+	 *
+	 * @param string $id      Agent ID.
+	 * @param array  $payload Updated agent definition.
+	 * @return array|null
+	 */
+	public function updateAgent( $id, array $payload ) {
+		$endpoint = ContaiAgentEndpoints::agentById( $id );
+		$response = $this->client->put( $endpoint, $payload );
+		return $this->handleResponse( $response, 'updateAgent' );
+	}
+
+	/**
+	 * Deletes an agent.
+	 *
+	 * @param string $id Agent ID.
+	 * @return array|null
+	 */
+	public function deleteAgent( $id ) {
+		$endpoint = ContaiAgentEndpoints::agentById( $id );
+		$response = $this->client->delete( $endpoint );
+		return $this->handleResponse( $response, 'deleteAgent' );
+	}
+
+	// ── Runs ────────────────────────────────────────────────────
+
+	/**
+	 * Triggers a new run for the given agent.
+	 *
+	 * @param string $id      Agent ID.
+	 * @param array  $payload Optional run parameters.
+	 * @return array|null
+	 */
+	public function runAgent( $id, array $payload = array() ) {
+		$endpoint = ContaiAgentEndpoints::agentRun( $id );
+		$response = $this->client->post( $endpoint, $payload );
+		return $this->handleResponse( $response, 'runAgent' );
+	}
+
+	/**
+	 * Lists all runs for an agent.
+	 *
+	 * @param string $id     Agent ID.
+	 * @param array  $params Optional query params.
+	 * @return array|null
+	 */
+	public function listRuns( $id, array $params = array() ) {
+		$endpoint = ContaiAgentEndpoints::agentRuns( $id );
+		$response = $this->client->get( $endpoint, $params );
+		return $this->handleResponse( $response, 'listRuns' );
+	}
+
+	/**
+	 * Fetches a single run by ID.
+	 *
+	 * @param string $id     Agent ID.
+	 * @param string $run_id Run ID.
+	 * @return array|null
+	 */
+	public function getRun( $id, $run_id ) {
+		$endpoint = ContaiAgentEndpoints::agentRunById( $id, $run_id );
+		$response = $this->client->get( $endpoint );
+		return $this->handleResponse( $response, 'getRun' );
+	}
+
+	/**
+	 * Stops a running or pending agent run.
+	 *
+	 * @param string $id     Agent ID.
+	 * @param string $run_id Run ID.
+	 * @return array|null
+	 */
+	public function stopRun( $id, $run_id ) {
+		$endpoint = ContaiAgentEndpoints::agentRunStop( $id, $run_id );
+		$response = $this->client->post( $endpoint, array() );
+		return $this->handleResponse( $response, 'stopRun' );
+	}
+
+	// ── Actions ──────────────────────────────────────────────────
+
+	/**
+	 * Lists agent actions, optionally filtered by status.
+	 *
+	 * @param array $params e.g. ['status' => 'pending']
+	 * @return array|null
+	 */
+	public function listActions( array $params = array() ) {
+		$response = $this->client->get( ContaiAgentEndpoints::AGENT_ACTIONS, $params );
+		return $this->handleResponse( $response, 'listActions' );
+	}
+
+	/**
+	 * Fetches a single action by ID.
+	 *
+	 * @param string $action_id
+	 * @return array|null
+	 */
+	public function getAction( $action_id ) {
+		$endpoint = ContaiAgentEndpoints::actionById( $action_id );
+		$response = $this->client->get( $endpoint );
+		return $this->handleResponse( $response, 'getAction' );
+	}
+
+	/**
+	 * Marks an action as consumed and records the processing result.
+	 *
+	 * @param string $action_id
+	 * @param array  $payload   e.g. ['result' => [...], 'consumed_by' => 'wordpress-plugin']
+	 * @return array|null
+	 */
+	public function consumeAction( $action_id, array $payload = array() ) {
+		$endpoint = ContaiAgentEndpoints::actionConsume( $action_id );
+		$response = $this->client->patch( $endpoint, $payload );
+		return $this->handleResponse( $response, 'consumeAction' );
+	}
+
+	// ── Private Helpers ──────────────────────────────────────────
+
+	/**
+	 * Normalises a ContaiOnePlatformResponse into either a data array or a WP_Error.
+	 *
+	 * Returns a WP_Error on transport failure or a non-success HTTP status so
+	 * callers can propagate structured error information to REST responses.
+	 *
+	 * @param ContaiOnePlatformResponse|null $response
+	 * @param string                         $context  Method name for log messages.
+	 * @return array|\WP_Error Data payload on success, WP_Error on failure.
+	 */
+	private function handleResponse( $response, $context ) {
+		if ( null === $response ) {
+			contai_log( "AgentApiService::{$context} — null response (transport error)", 'warning' );
+			return new \WP_Error( 'transport_error', 'Could not connect to 1Platform API', array( 'status' => 502 ) );
+		}
+
+		if ( $response->isSuccess() ) {
+			return $response->getData();
+		}
+
+		$status  = $response->getStatusCode();
+		$message = $response->getMessage() ?: 'Unknown error from 1Platform API';
+		contai_log( "AgentApiService::{$context} — HTTP {$status}: {$message}", 'warning' );
+
+		return new \WP_Error( 'api_error', $message, array( 'status' => $status ?: 500 ) );
+	}
+}

--- a/includes/services/agents/ContaiAgentEndpoints.php
+++ b/includes/services/agents/ContaiAgentEndpoints.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Centralized agent API endpoint definitions.
+ *
+ * All agent-related endpoint paths consumed by this plugin are defined here.
+ * Base URL (e.g. https://api.1platform.pro/api/v1) is configured in Config.php.
+ * These paths are appended to the base URL by ContaiOnePlatformClient.
+ *
+ * OpenAPI source: 1Platform API v1 — Agents module
+ */
+
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+class ContaiAgentEndpoints {
+
+	// ── Catalog ─────────────────────────────────────────────────
+	const CATALOG          = '/agents/catalog';
+	const CATALOG_TEMPLATE = '/agents/catalog/'; // append slug
+
+	// ── Wizard ──────────────────────────────────────────────────
+	const WIZARD_START   = '/agents/wizard/start';
+
+	// ── Agents CRUD ─────────────────────────────────────────────
+	const AGENTS = '/agents';
+
+	// ── Agent Actions ───────────────────────────────────────────
+	const AGENT_ACTIONS = '/agent-actions';
+
+	// ── Parameterized Paths ─────────────────────────────────────
+
+	public static function wizardRespond( $session_id ) {
+		return '/agents/wizard/' . $session_id . '/respond';
+	}
+
+	public static function wizardConfirm( $session_id ) {
+		return '/agents/wizard/' . $session_id . '/confirm';
+	}
+
+	public static function wizardGet( $session_id ) {
+		return '/agents/wizard/' . $session_id;
+	}
+
+	public static function agentById( $id ) {
+		return '/agents/' . $id;
+	}
+
+	public static function agentRun( $id ) {
+		return '/agents/' . $id . '/run';
+	}
+
+	public static function agentRuns( $id ) {
+		return '/agents/' . $id . '/runs';
+	}
+
+	public static function agentRunById( $id, $run_id ) {
+		return '/agents/' . $id . '/runs/' . $run_id;
+	}
+
+	public static function agentRunStop( $id, $run_id ) {
+		return '/agents/' . $id . '/runs/' . $run_id . '/stop';
+	}
+
+	public static function actionById( $action_id ) {
+		return '/agent-actions/' . $action_id;
+	}
+
+	public static function actionConsume( $action_id ) {
+		return '/agent-actions/' . $action_id . '/consume';
+	}
+}

--- a/includes/services/agents/ContaiAgentRestController.php
+++ b/includes/services/agents/ContaiAgentRestController.php
@@ -1,0 +1,782 @@
+<?php
+/**
+ * REST API controller for the Agents module.
+ *
+ * Proxies requests from the WP admin UI to the 1Platform API via
+ * ContaiAgentApiService. All routes are registered under the 'contai/v1'
+ * namespace and are restricted to users with 'manage_options' capability.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+require_once __DIR__ . '/ContaiAgentApiService.php';
+require_once __DIR__ . '/ContaiAgentSettingsService.php';
+require_once __DIR__ . '/ContaiAgentSyncService.php';
+
+class ContaiAgentRestController {
+
+    private $namespace = 'contai/v1';
+
+    /** @var ContaiAgentApiService */
+    private $api_service;
+
+    public function __construct() {
+        $this->api_service = ContaiAgentApiService::create();
+    }
+
+    // ── Route Registration ───────────────────────────────────────────────────
+
+    public function register_routes() {
+
+        // Catalog
+        register_rest_route( $this->namespace, '/agents/catalog', array(
+            'methods'             => 'GET',
+            'callback'            => array( $this, 'get_catalog' ),
+            'permission_callback' => array( $this, 'check_permissions' ),
+        ) );
+
+        register_rest_route( $this->namespace, '/agents/catalog/(?P<slug>[a-z0-9-]+)', array(
+            'methods'             => 'GET',
+            'callback'            => array( $this, 'get_catalog_template' ),
+            'permission_callback' => array( $this, 'check_permissions' ),
+            'args'                => array(
+                'slug' => array(
+                    'required'          => true,
+                    'sanitize_callback' => 'sanitize_key',
+                ),
+            ),
+        ) );
+
+        // Wizard
+        register_rest_route( $this->namespace, '/agents/wizard/start', array(
+            'methods'             => 'POST',
+            'callback'            => array( $this, 'start_wizard' ),
+            'permission_callback' => array( $this, 'check_permissions' ),
+            'show_in_index'       => false,
+        ) );
+
+        register_rest_route( $this->namespace, '/agents/wizard/(?P<session_id>[a-f0-9]{24})/respond', array(
+            'methods'             => 'POST',
+            'callback'            => array( $this, 'respond_wizard' ),
+            'permission_callback' => array( $this, 'check_permissions' ),
+            'show_in_index'       => false,
+            'args'                => $this->get_mongo_id_args( 'session_id' ),
+        ) );
+
+        register_rest_route( $this->namespace, '/agents/wizard/(?P<session_id>[a-f0-9]{24})/confirm', array(
+            'methods'             => 'POST',
+            'callback'            => array( $this, 'confirm_wizard' ),
+            'permission_callback' => array( $this, 'check_permissions' ),
+            'show_in_index'       => false,
+            'args'                => $this->get_mongo_id_args( 'session_id' ),
+        ) );
+
+        register_rest_route( $this->namespace, '/agents/wizard/(?P<session_id>[a-f0-9]{24})', array(
+            'methods'             => 'GET',
+            'callback'            => array( $this, 'get_wizard_session' ),
+            'permission_callback' => array( $this, 'check_permissions' ),
+            'show_in_index'       => false,
+            'args'                => $this->get_mongo_id_args( 'session_id' ),
+        ) );
+
+        // CRUD
+        register_rest_route( $this->namespace, '/agents', array(
+            array(
+                'methods'             => 'GET',
+                'callback'            => array( $this, 'list_agents' ),
+                'permission_callback' => array( $this, 'check_permissions' ),
+            ),
+            array(
+                'methods'             => 'POST',
+                'callback'            => array( $this, 'create_agent' ),
+                'permission_callback' => array( $this, 'check_permissions' ),
+            ),
+        ) );
+
+        register_rest_route( $this->namespace, '/agents/(?P<id>[a-f0-9]{24})', array(
+            array(
+                'methods'             => 'GET',
+                'callback'            => array( $this, 'get_agent' ),
+                'permission_callback' => array( $this, 'check_permissions' ),
+                'args'                => $this->get_mongo_id_args( 'id' ),
+            ),
+            array(
+                'methods'             => 'PUT',
+                'callback'            => array( $this, 'update_agent' ),
+                'permission_callback' => array( $this, 'check_permissions' ),
+                'args'                => $this->get_mongo_id_args( 'id' ),
+            ),
+            array(
+                'methods'             => 'DELETE',
+                'callback'            => array( $this, 'delete_agent' ),
+                'permission_callback' => array( $this, 'check_permissions' ),
+                'args'                => $this->get_mongo_id_args( 'id' ),
+            ),
+        ) );
+
+        // Execution
+        register_rest_route( $this->namespace, '/agents/(?P<id>[a-f0-9]{24})/run', array(
+            'methods'             => 'POST',
+            'callback'            => array( $this, 'run_agent' ),
+            'permission_callback' => array( $this, 'check_permissions' ),
+            'show_in_index'       => false,
+            'args'                => $this->get_mongo_id_args( 'id' ),
+        ) );
+
+        register_rest_route( $this->namespace, '/agents/(?P<id>[a-f0-9]{24})/runs', array(
+            'methods'             => 'GET',
+            'callback'            => array( $this, 'list_runs' ),
+            'permission_callback' => array( $this, 'check_permissions' ),
+            'args'                => $this->get_mongo_id_args( 'id' ),
+        ) );
+
+        register_rest_route( $this->namespace, '/agents/(?P<id>[a-f0-9]{24})/runs/(?P<run_id>[a-f0-9]{24})', array(
+            'methods'             => 'GET',
+            'callback'            => array( $this, 'get_run' ),
+            'permission_callback' => array( $this, 'check_permissions' ),
+            'args'                => array_merge( $this->get_mongo_id_args( 'id' ), $this->get_mongo_id_args( 'run_id' ) ),
+        ) );
+
+        register_rest_route( $this->namespace, '/agents/(?P<id>[a-f0-9]{24})/runs/(?P<run_id>[a-f0-9]{24})/stop', array(
+            'methods'             => 'POST',
+            'callback'            => array( $this, 'stop_run' ),
+            'permission_callback' => array( $this, 'check_permissions' ),
+            'show_in_index'       => false,
+            'args'                => array_merge( $this->get_mongo_id_args( 'id' ), $this->get_mongo_id_args( 'run_id' ) ),
+        ) );
+
+        // Actions
+        register_rest_route( $this->namespace, '/agent-actions', array(
+            'methods'             => 'GET',
+            'callback'            => array( $this, 'list_actions' ),
+            'permission_callback' => array( $this, 'check_permissions' ),
+        ) );
+
+        register_rest_route( $this->namespace, '/agent-actions/(?P<action_id>[a-f0-9]{24})', array(
+            'methods'             => 'GET',
+            'callback'            => array( $this, 'get_action' ),
+            'permission_callback' => array( $this, 'check_permissions' ),
+            'args'                => $this->get_mongo_id_args( 'action_id' ),
+        ) );
+
+        register_rest_route( $this->namespace, '/agent-actions/(?P<action_id>[a-f0-9]{24})/consume', array(
+            'methods'             => 'PATCH',
+            'callback'            => array( $this, 'consume_action' ),
+            'permission_callback' => array( $this, 'check_permissions' ),
+            'show_in_index'       => false,
+            'args'                => $this->get_mongo_id_args( 'action_id' ),
+        ) );
+
+        register_rest_route( $this->namespace, '/agent-actions/(?P<action_id>[a-f0-9]{24})/dismiss', array(
+            'methods'             => 'PATCH',
+            'callback'            => array( $this, 'dismiss_action' ),
+            'permission_callback' => array( $this, 'check_permissions' ),
+            'show_in_index'       => false,
+            'args'                => $this->get_mongo_id_args( 'action_id' ),
+        ) );
+
+        register_rest_route( $this->namespace, '/agent-actions/dismiss-all', array(
+            'methods'             => 'POST',
+            'callback'            => array( $this, 'dismiss_all_actions' ),
+            'permission_callback' => array( $this, 'check_permissions' ),
+            'show_in_index'       => false,
+        ) );
+
+        // Settings
+        register_rest_route( $this->namespace, '/agents/settings', array(
+            array(
+                'methods'             => 'GET',
+                'callback'            => array( $this, 'get_settings' ),
+                'permission_callback' => array( $this, 'check_permissions' ),
+            ),
+            array(
+                'methods'             => 'POST',
+                'callback'            => array( $this, 'update_settings' ),
+                'permission_callback' => array( $this, 'check_permissions' ),
+            ),
+        ) );
+    }
+
+    // ── Permission Callback ──────────────────────────────────────────────────
+
+    /**
+     * Restricts all agent routes to site administrators.
+     *
+     * @return bool
+     */
+    public function check_permissions() {
+        return current_user_can( 'manage_options' );
+    }
+
+    // ── Shared Helpers ───────────────────────────────────────────────────────
+
+    /**
+     * Returns the route args definition that validates a MongoDB ObjectId
+     * URL parameter by name.
+     *
+     * @param string $name Parameter name (e.g. 'id', 'session_id', 'run_id').
+     * @return array
+     */
+    private function get_mongo_id_args( $name ) {
+        return array(
+            $name => array(
+                'required'          => true,
+                'validate_callback' => function( $value ) {
+                    return (bool) preg_match( '/^[a-f0-9]{24}$/', $value );
+                },
+                'sanitize_callback' => 'sanitize_text_field',
+            ),
+        );
+    }
+
+    /**
+     * Builds a WP_Error from an API service response that returned null or
+     * from an error message string.
+     *
+     * @param string $code    WP error code.
+     * @param string $message Human-readable error message.
+     * @param int    $status  HTTP status code to send with the error.
+     * @return WP_Error
+     */
+    private function error( $code, $message, $status = 500 ) {
+        return new WP_Error( $code, $message, array( 'status' => $status ) );
+    }
+
+    /**
+     * Converts a WP_Error API result into a WP_REST_Response with the correct
+     * HTTP status.  Returns null when the result is NOT a WP_Error so callers
+     * can short-circuit cleanly.
+     *
+     * Usage:
+     *   if ( $err = $this->error_from_api( $data ) ) return $err;
+     *
+     * @param mixed $result Value returned by the API service method.
+     * @return WP_REST_Response|null
+     */
+    private function error_from_api( $result ) {
+        if ( is_wp_error( $result ) ) {
+            $status = $result->get_error_data()['status'] ?? 500;
+            return new \WP_REST_Response(
+                array( 'code' => $result->get_error_code(), 'message' => $result->get_error_message() ),
+                $status
+            );
+        }
+        return null; // Not an error
+    }
+
+    // ── Catalog Callbacks ────────────────────────────────────────────────────
+
+    /**
+     * GET /agents/catalog
+     * Returns the full agent template catalog from the 1Platform API.
+     *
+     * @param WP_REST_Request $request
+     * @return WP_REST_Response|WP_Error
+     */
+    public function get_catalog( $request ) {
+        $data = $this->api_service->getCatalog();
+
+        if ( $err = $this->error_from_api( $data ) ) {
+            return $err;
+        }
+
+        return new WP_REST_Response( $data, 200 );
+    }
+
+    /**
+     * GET /agents/catalog/{slug}
+     * Returns a single agent template from the catalog by its slug.
+     *
+     * @param WP_REST_Request $request
+     * @return WP_REST_Response|WP_Error
+     */
+    public function get_catalog_template( $request ) {
+        $slug = sanitize_key( $request->get_param( 'slug' ) );
+
+        $data = $this->api_service->getCatalogTemplate( $slug );
+
+        if ( $err = $this->error_from_api( $data ) ) {
+            return $err;
+        }
+
+        return new WP_REST_Response( $data, 200 );
+    }
+
+    // ── Wizard Callbacks ─────────────────────────────────────────────────────
+
+    /**
+     * POST /agents/wizard/start
+     * Initiates a new wizard session for guided agent configuration.
+     *
+     * Expected JSON body forwarded as-is to the API (e.g. { "template_slug": "..." }).
+     *
+     * @param WP_REST_Request $request
+     * @return WP_REST_Response|WP_Error
+     */
+    public function start_wizard( $request ) {
+        $body = $request->get_json_params();
+
+        if ( empty( $body ) ) {
+            $body = array();
+        }
+
+        $data = $this->api_service->startWizard( $body );
+
+        if ( $err = $this->error_from_api( $data ) ) {
+            return $err;
+        }
+
+        return new WP_REST_Response( $data, 201 );
+    }
+
+    /**
+     * POST /agents/wizard/{session_id}/respond
+     * Submits a user response to the current wizard step.
+     *
+     * @param WP_REST_Request $request
+     * @return WP_REST_Response|WP_Error
+     */
+    public function respond_wizard( $request ) {
+        $session_id = sanitize_text_field( $request->get_param( 'session_id' ) );
+        $body       = $request->get_json_params();
+
+        if ( empty( $body ) ) {
+            $body = array();
+        }
+
+        $data = $this->api_service->respondWizard( $session_id, $body );
+
+        if ( $err = $this->error_from_api( $data ) ) {
+            return $err;
+        }
+
+        return new WP_REST_Response( $data, 200 );
+    }
+
+    /**
+     * POST /agents/wizard/{session_id}/confirm
+     * Confirms the completed wizard session and creates the agent.
+     *
+     * @param WP_REST_Request $request
+     * @return WP_REST_Response|WP_Error
+     */
+    public function confirm_wizard( $request ) {
+        $session_id = sanitize_text_field( $request->get_param( 'session_id' ) );
+        $data       = $this->api_service->confirmWizard( $session_id );
+
+        if ( $err = $this->error_from_api( $data ) ) {
+            return $err;
+        }
+
+        return new WP_REST_Response( $data, 201 );
+    }
+
+    /**
+     * GET /agents/wizard/{session_id}
+     * Retrieves the current state of an in-progress wizard session.
+     *
+     * @param WP_REST_Request $request
+     * @return WP_REST_Response|WP_Error
+     */
+    public function get_wizard_session( $request ) {
+        $session_id = sanitize_text_field( $request->get_param( 'session_id' ) );
+
+        $data = $this->api_service->getWizardSession( $session_id );
+
+        if ( $err = $this->error_from_api( $data ) ) {
+            return $err;
+        }
+
+        return new WP_REST_Response( $data, 200 );
+    }
+
+    // ── CRUD Callbacks ───────────────────────────────────────────────────────
+
+    /**
+     * GET /agents
+     * Returns a paginated list of agents for the authenticated account.
+     *
+     * Supported query params: page, limit, status (forwarded to API).
+     *
+     * @param WP_REST_Request $request
+     * @return WP_REST_Response|WP_Error
+     */
+    public function list_agents( $request ) {
+        $query = array();
+
+        $page = $request->get_param( 'page' );
+        if ( null !== $page ) {
+            $query['page'] = absint( $page );
+        }
+
+        $limit = $request->get_param( 'limit' );
+        if ( null !== $limit ) {
+            $query['limit'] = absint( $limit );
+        }
+
+        $status = $request->get_param( 'status' );
+        if ( null !== $status ) {
+            $query['status'] = sanitize_text_field( $status );
+        }
+
+        $data = $this->api_service->listAgents( $query );
+
+        if ( $err = $this->error_from_api( $data ) ) {
+            return $err;
+        }
+
+        return new WP_REST_Response( $data, 200 );
+    }
+
+    /**
+     * POST /agents
+     * Creates a new agent using the provided configuration body.
+     *
+     * @param WP_REST_Request $request
+     * @return WP_REST_Response|WP_Error
+     */
+    public function create_agent( $request ) {
+        $body = $request->get_json_params();
+
+        if ( empty( $body ) ) {
+            return $this->error( 'missing_body', 'Request body is required.', 400 );
+        }
+
+        $data = $this->api_service->createAgent( $body );
+
+        if ( $err = $this->error_from_api( $data ) ) {
+            return $err;
+        }
+
+        return new WP_REST_Response( $data, 201 );
+    }
+
+    /**
+     * GET /agents/{id}
+     * Returns a single agent by its MongoDB ObjectId.
+     *
+     * @param WP_REST_Request $request
+     * @return WP_REST_Response|WP_Error
+     */
+    public function get_agent( $request ) {
+        $id = sanitize_text_field( $request->get_param( 'id' ) );
+
+        $data = $this->api_service->getAgent( $id );
+
+        if ( $err = $this->error_from_api( $data ) ) {
+            return $err;
+        }
+
+        return new WP_REST_Response( $data, 200 );
+    }
+
+    /**
+     * PUT /agents/{id}
+     * Replaces an agent's configuration with the provided body.
+     *
+     * @param WP_REST_Request $request
+     * @return WP_REST_Response|WP_Error
+     */
+    public function update_agent( $request ) {
+        $id   = sanitize_text_field( $request->get_param( 'id' ) );
+        $body = $request->get_json_params();
+
+        if ( empty( $body ) ) {
+            return $this->error( 'missing_body', 'Request body is required.', 400 );
+        }
+
+        $data = $this->api_service->updateAgent( $id, $body );
+
+        if ( $err = $this->error_from_api( $data ) ) {
+            return $err;
+        }
+
+        return new WP_REST_Response( $data, 200 );
+    }
+
+    /**
+     * DELETE /agents/{id}
+     * Deletes an agent permanently.
+     *
+     * @param WP_REST_Request $request
+     * @return WP_REST_Response|WP_Error
+     */
+    public function delete_agent( $request ) {
+        $id = sanitize_text_field( $request->get_param( 'id' ) );
+
+        $data = $this->api_service->deleteAgent( $id );
+
+        if ( $err = $this->error_from_api( $data ) ) {
+            return $err;
+        }
+
+        return new WP_REST_Response( $data, 200 );
+    }
+
+    // ── Execution Callbacks ──────────────────────────────────────────────────
+
+    /**
+     * POST /agents/{id}/run
+     * Triggers an on-demand execution run for the given agent.
+     *
+     * An optional JSON body may carry runtime overrides forwarded to the API.
+     *
+     * @param WP_REST_Request $request
+     * @return WP_REST_Response|WP_Error
+     */
+    public function run_agent( $request ) {
+        $id   = sanitize_text_field( $request->get_param( 'id' ) );
+        $body = $request->get_json_params();
+
+        if ( empty( $body ) || ! is_array( $body ) ) {
+            $body = array();
+        }
+
+        $data = $this->api_service->runAgent( $id, $body );
+
+        if ( $err = $this->error_from_api( $data ) ) {
+            return $err;
+        }
+
+        return new WP_REST_Response( $data, 202 );
+    }
+
+    /**
+     * GET /agents/{id}/runs
+     * Returns the execution history for the given agent.
+     *
+     * Supported query params: page, limit (forwarded to API).
+     *
+     * @param WP_REST_Request $request
+     * @return WP_REST_Response|WP_Error
+     */
+    public function list_runs( $request ) {
+        $id    = sanitize_text_field( $request->get_param( 'id' ) );
+        $query = array();
+
+        $page = $request->get_param( 'page' );
+        if ( null !== $page ) {
+            $query['page'] = absint( $page );
+        }
+
+        $limit = $request->get_param( 'limit' );
+        if ( null !== $limit ) {
+            $query['limit'] = absint( $limit );
+        }
+
+        $data = $this->api_service->listRuns( $id, $query );
+
+        if ( $err = $this->error_from_api( $data ) ) {
+            return $err;
+        }
+
+        return new WP_REST_Response( $data, 200 );
+    }
+
+    /**
+     * GET /agents/{id}/runs/{run_id}
+     * Returns the details of a single execution run.
+     *
+     * @param WP_REST_Request $request
+     * @return WP_REST_Response|WP_Error
+     */
+    public function get_run( $request ) {
+        $id     = sanitize_text_field( $request->get_param( 'id' ) );
+        $run_id = sanitize_text_field( $request->get_param( 'run_id' ) );
+
+        $data = $this->api_service->getRun( $id, $run_id );
+
+        if ( $err = $this->error_from_api( $data ) ) {
+            return $err;
+        }
+
+        return new WP_REST_Response( $data, 200 );
+    }
+
+    /**
+     * POST /agents/{id}/runs/{run_id}/stop
+     * Stops a running or pending agent run.
+     *
+     * @param WP_REST_Request $request
+     * @return WP_REST_Response|WP_Error
+     */
+    public function stop_run( $request ) {
+        $id     = sanitize_text_field( $request->get_param( 'id' ) );
+        $run_id = sanitize_text_field( $request->get_param( 'run_id' ) );
+
+        $data = $this->api_service->stopRun( $id, $run_id );
+
+        if ( $err = $this->error_from_api( $data ) ) {
+            return $err;
+        }
+
+        return new WP_REST_Response( $data, 200 );
+    }
+
+    // ── Action Callbacks ─────────────────────────────────────────────────────
+
+    /**
+     * GET /agent-actions
+     * Returns a list of pending or recent agent actions for this site.
+     *
+     * Supported query params: status, page, limit (forwarded to API).
+     *
+     * @param WP_REST_Request $request
+     * @return WP_REST_Response|WP_Error
+     */
+    public function list_actions( $request ) {
+        $query = array();
+
+        $status = $request->get_param( 'status' );
+        if ( null !== $status ) {
+            $query['status'] = sanitize_text_field( $status );
+        }
+
+        $page = $request->get_param( 'page' );
+        if ( null !== $page ) {
+            $query['page'] = absint( $page );
+        }
+
+        $limit = $request->get_param( 'limit' );
+        if ( null !== $limit ) {
+            $query['limit'] = absint( $limit );
+        }
+
+        $data = $this->api_service->listActions( $query );
+
+        if ( $err = $this->error_from_api( $data ) ) {
+            return $err;
+        }
+
+        return new WP_REST_Response( $data, 200 );
+    }
+
+    /**
+     * GET /agent-actions/{action_id}
+     * Returns a single action by its MongoDB ObjectId.
+     *
+     * @param WP_REST_Request $request
+     * @return WP_REST_Response|WP_Error
+     */
+    public function get_action( $request ) {
+        $action_id = sanitize_text_field( $request->get_param( 'action_id' ) );
+
+        $data = $this->api_service->getAction( $action_id );
+
+        if ( $err = $this->error_from_api( $data ) ) {
+            return $err;
+        }
+
+        return new WP_REST_Response( $data, 200 );
+    }
+
+    /**
+     * PATCH /agent-actions/{action_id}/consume
+     * Manually consumes a pending action.
+     *
+     * Orchestration is delegated to ContaiAgentSyncService::consumeActionManually()
+     * which fetches the action, processes it if pending, and returns the
+     * refreshed action state.
+     *
+     * @param WP_REST_Request $request
+     * @return WP_REST_Response|WP_Error
+     */
+    public function consume_action( $request ) {
+        $action_id = sanitize_text_field( $request->get_param( 'action_id' ) );
+        $sync      = ContaiAgentSyncService::create();
+        $result    = $sync->consumeActionManually( $action_id );
+
+        if ( $err = $this->error_from_api( $result ) ) {
+            return $err;
+        }
+        if ( null === $result ) {
+            return $this->error( 'not_found', 'Action not found', 404 );
+        }
+        return new WP_REST_Response( $result, 200 );
+    }
+
+    /**
+     * PATCH /agent-actions/{action_id}/dismiss
+     * Dismisses a pending action without creating content.
+     *
+     * @param WP_REST_Request $request
+     * @return WP_REST_Response|WP_Error
+     */
+    public function dismiss_action( $request ) {
+        $action_id = sanitize_text_field( $request->get_param( 'action_id' ) );
+        $sync      = ContaiAgentSyncService::create();
+        $result    = $sync->dismissAction( $action_id );
+
+        if ( $err = $this->error_from_api( $result ) ) {
+            return $err;
+        }
+        if ( null === $result ) {
+            return $this->error( 'not_found', 'Action not found', 404 );
+        }
+        return new WP_REST_Response( $result, 200 );
+    }
+
+    /**
+     * POST /agent-actions/dismiss-all
+     * Dismisses all pending actions in bulk.
+     *
+     * @param WP_REST_Request $request
+     * @return WP_REST_Response
+     */
+    public function dismiss_all_actions( $request ) {
+        $sync   = ContaiAgentSyncService::create();
+        $result = $sync->dismissAllPendingActions();
+        return new WP_REST_Response( $result, 200 );
+    }
+
+    // ── Settings Callbacks ───────────────────────────────────────────────────
+
+    /**
+     * GET /agents/settings
+     * Returns the locally stored agent preferences (wp_options).
+     *
+     * @param WP_REST_Request $request
+     * @return WP_REST_Response
+     */
+    public function get_settings( $request ) {
+        $settings = ContaiAgentSettingsService::getAllSettings();
+        return new WP_REST_Response( $settings, 200 );
+    }
+
+    /**
+     * POST /agents/settings
+     * Persists one or more agent preference values to wp_options.
+     *
+     * Accepted keys: publish_status, auto_consume, polling_interval.
+     * Unknown keys are silently ignored by ContaiAgentSettingsService.
+     *
+     * @param WP_REST_Request $request
+     * @return WP_REST_Response|WP_Error
+     */
+    public function update_settings( $request ) {
+        $body = $request->get_json_params();
+
+        if ( empty( $body ) || ! is_array( $body ) ) {
+            return $this->error( 'missing_body', 'Request body must be a JSON object.', 400 );
+        }
+
+        // Sanitize recognised scalar fields before passing to the service.
+        $clean = array();
+
+        if ( isset( $body['publish_status'] ) ) {
+            $clean['publish_status'] = sanitize_text_field( $body['publish_status'] );
+        }
+
+        if ( isset( $body['auto_consume'] ) ) {
+            $clean['auto_consume'] = (bool) $body['auto_consume'];
+        }
+
+        if ( isset( $body['polling_interval'] ) ) {
+            $clean['polling_interval'] = absint( $body['polling_interval'] );
+        }
+
+        ContaiAgentSettingsService::updateSettings( $clean );
+
+        return new WP_REST_Response( ContaiAgentSettingsService::getAllSettings(), 200 );
+    }
+}

--- a/includes/services/agents/ContaiAgentSettingsService.php
+++ b/includes/services/agents/ContaiAgentSettingsService.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Manages local agent preferences stored in wp_options.
+ *
+ * All settings are prefixed with 'contai_agents_' to avoid collisions.
+ * Provides typed getters/setters for each preference and a bulk
+ * getAllSettings / updateSettings pair used by the admin UI and sync service.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+class ContaiAgentSettingsService {
+
+	const OPTION_PREFIX = 'contai_agents_';
+
+	// ── Publish Status ───────────────────────────────────────────
+
+	/**
+	 * Returns the default post status applied when an agent publishes content.
+	 * Defaults to 'publish'. Change to 'draft' in settings to require review.
+	 *
+	 * @return string 'draft'|'publish'|'pending'
+	 */
+	public static function getPublishStatus() {
+		return get_option( self::OPTION_PREFIX . 'publish_status', 'publish' );
+	}
+
+	/**
+	 * @param string $status Accepted values: 'draft', 'publish', 'pending'.
+	 */
+	public static function setPublishStatus( $status ) {
+		$allowed = array( 'draft', 'publish', 'pending' );
+		$status  = sanitize_text_field( $status );
+		if ( ! in_array( $status, $allowed, true ) ) {
+			$status = 'draft';
+		}
+		update_option( self::OPTION_PREFIX . 'publish_status', $status );
+	}
+
+	// ── Auto-Consume ─────────────────────────────────────────────
+
+	/**
+	 * Returns whether pending agent actions should be consumed automatically
+	 * by the background cron job without manual approval.
+	 *
+	 * @return bool
+	 */
+	public static function isAutoConsumeEnabled() {
+		return (bool) get_option( self::OPTION_PREFIX . 'auto_consume', true );
+	}
+
+	/**
+	 * @param bool $enabled
+	 */
+	public static function setAutoConsume( $enabled ) {
+		update_option( self::OPTION_PREFIX . 'auto_consume', (bool) $enabled );
+	}
+
+	// ── Polling Interval ─────────────────────────────────────────
+
+	/**
+	 * Returns the number of seconds between action-polling cycles.
+	 * Defaults to 60 s. The sync service enforces a hard minimum of 30 s.
+	 *
+	 * @return int
+	 */
+	public static function getPollingInterval() {
+		return (int) get_option( self::OPTION_PREFIX . 'polling_interval', 60 );
+	}
+
+	/**
+	 * @param int $seconds Must be a positive integer.
+	 */
+	public static function setPollingInterval( $seconds ) {
+		update_option( self::OPTION_PREFIX . 'polling_interval', absint( $seconds ) );
+	}
+
+	// ── Last Poll Time ───────────────────────────────────────────
+
+	/**
+	 * Returns the Unix timestamp of the last completed poll cycle.
+	 * Defaults to 0 (never polled).
+	 *
+	 * @return int
+	 */
+	public static function getLastPollTime() {
+		return (int) get_option( self::OPTION_PREFIX . 'last_poll_time', 0 );
+	}
+
+	/**
+	 * @param int $time Unix timestamp.
+	 */
+	public static function setLastPollTime( $time ) {
+		update_option( self::OPTION_PREFIX . 'last_poll_time', absint( $time ) );
+	}
+
+	// ── Bulk Access ──────────────────────────────────────────────
+
+	/**
+	 * Returns all agent settings as a flat associative array.
+	 * Suitable for passing to action handlers as a $settings context.
+	 *
+	 * @return array{
+	 *   publish_status: string,
+	 *   auto_consume: bool,
+	 *   polling_interval: int,
+	 *   last_poll_time: int
+	 * }
+	 */
+	public static function getAllSettings() {
+		return array(
+			'publish_status'   => self::getPublishStatus(),
+			'auto_consume'     => self::isAutoConsumeEnabled(),
+			'polling_interval' => self::getPollingInterval(),
+			'last_poll_time'   => self::getLastPollTime(),
+		);
+	}
+
+	/**
+	 * Bulk-updates any recognised settings keys present in $settings.
+	 * Unknown keys are silently ignored.
+	 *
+	 * @param array $settings Associative array of setting key => value pairs.
+	 */
+	public static function updateSettings( array $settings ) {
+		if ( isset( $settings['publish_status'] ) ) {
+			self::setPublishStatus( $settings['publish_status'] );
+		}
+
+		if ( isset( $settings['auto_consume'] ) ) {
+			self::setAutoConsume( $settings['auto_consume'] );
+		}
+
+		if ( isset( $settings['polling_interval'] ) ) {
+			self::setPollingInterval( $settings['polling_interval'] );
+		}
+
+		if ( isset( $settings['last_poll_time'] ) ) {
+			self::setLastPollTime( $settings['last_poll_time'] );
+		}
+	}
+}

--- a/includes/services/agents/ContaiAgentSyncService.php
+++ b/includes/services/agents/ContaiAgentSyncService.php
@@ -1,0 +1,271 @@
+<?php
+/**
+ * Agent sync service — polls the 1Platform API for pending actions and
+ * dispatches each one to the appropriate registered handler.
+ *
+ * This service is designed to be invoked by a WordPress cron event.
+ * A hard minimum of 30 seconds between polls is enforced regardless of the
+ * configured polling interval to prevent runaway requests.
+ *
+ * Handler registration:
+ *   Default handlers (ContaiPublishContentActionHandler) are registered in
+ *   registerDefaultHandlers().  Additional handlers can be registered at
+ *   runtime via registerHandler().
+ *
+ * Action lifecycle:
+ *   1. listActions( ['status' => 'pending'] ) — fetch pending actions from API.
+ *   2. For each action, find a matching handler via canHandle().
+ *   3. Call handler->handle(); on success, call consumeAction() to mark it done.
+ *   4. Log the outcome via contai_log().
+ */
+
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+require_once __DIR__ . '/ContaiAgentApiService.php';
+require_once __DIR__ . '/ContaiAgentSettingsService.php';
+require_once __DIR__ . '/ContaiAgentActionHandler.php';
+
+class ContaiAgentSyncService {
+
+	/** Hard minimum seconds between poll cycles (rate-limit guard). */
+	const MIN_POLL_INTERVAL_SECONDS = 30;
+
+	private $api_service;
+
+	/** @var ContaiAgentActionHandlerInterface[] */
+	private $handlers = array();
+
+	public function __construct( ContaiAgentApiService $api_service ) {
+		$this->api_service = $api_service;
+		$this->registerDefaultHandlers();
+	}
+
+	public static function create() {
+		return new self( ContaiAgentApiService::create() );
+	}
+
+	// ── Handler registration ─────────────────────────────────────────────────
+
+	/**
+	 * Registers additional action handlers at runtime.
+	 *
+	 * Handlers are evaluated in registration order; the first handler whose
+	 * canHandle() returns true wins.
+	 *
+	 * @param ContaiAgentActionHandlerInterface $handler
+	 */
+	public function registerHandler( ContaiAgentActionHandlerInterface $handler ) {
+		$this->handlers[] = $handler;
+	}
+
+	// ── Polling ──────────────────────────────────────────────────────────────
+
+	/**
+	 * Fetches all pending agent actions from the API and processes them.
+	 *
+	 * Rate-limited: exits immediately if fewer than MIN_POLL_INTERVAL_SECONDS
+	 * have elapsed since the last poll, regardless of cron schedule.
+	 */
+	public function pollAndProcessActions() {
+		$last_poll = ContaiAgentSettingsService::getLastPollTime();
+
+		$interval = max( self::MIN_POLL_INTERVAL_SECONDS, ContaiAgentSettingsService::getPollingInterval() );
+		if ( ( time() - $last_poll ) < $interval ) {
+			return;
+		}
+
+		// Acquire exclusive lock to prevent concurrent polling.
+		global $wpdb;
+		$lock_name = 'contai_agent_poll_lock';
+		$got_lock  = $wpdb->get_var( $wpdb->prepare( "SELECT GET_LOCK(%s, 0)", $lock_name ) );
+		if ( '1' !== (string) $got_lock ) {
+			return; // Another process is already polling.
+		}
+
+		// Mark last poll time BEFORE the API call to prevent TOCTOU race.
+		ContaiAgentSettingsService::setLastPollTime( time() );
+
+		try {
+			$result = $this->api_service->listActions( array( 'status' => 'pending' ) );
+
+			if ( empty( $result['actions'] ) || ! is_array( $result['actions'] ) ) {
+				return;
+			}
+
+			// Cron-triggered runs use the configured publish_status via settings.
+			$settings                    = ContaiAgentSettingsService::getAllSettings();
+			$settings['is_auto_consume'] = true;
+
+			foreach ( $result['actions'] as $action ) {
+				if ( ! is_array( $action ) ) {
+					continue;
+				}
+				// Skip actions that are not pending (prevent double processing).
+				if ( 'pending' !== ( $action['status'] ?? '' ) ) {
+					continue;
+				}
+				$this->processAction( $action, $settings );
+			}
+		} finally {
+			// Always release lock, even if processAction() throws.
+			$wpdb->query( $wpdb->prepare( "SELECT RELEASE_LOCK(%s)", $lock_name ) );
+		}
+	}
+
+	// ── Manual consume ───────────────────────────────────────────────────────
+
+	/**
+	 * Fetches a single action and, if it is still pending, processes it
+	 * immediately as a manual (non-auto) consume.  Returns the refreshed
+	 * action state from the API after processing, or a WP_Error on failure.
+	 *
+	 * @param string $action_id MongoDB ObjectId of the action.
+	 * @return array|\WP_Error
+	 */
+	public function consumeActionManually( $action_id ) {
+		$action = $this->api_service->getAction( $action_id );
+		if ( is_wp_error( $action ) || null === $action ) {
+			return $action;
+		}
+
+		$status = $action['status'] ?? '';
+
+		if ( 'pending' !== $status ) {
+			return $action; // Already consumed, return current state.
+		}
+
+		$settings                    = ContaiAgentSettingsService::getAllSettings();
+		$settings['is_auto_consume'] = false; // Manual = respects publish preference.
+
+		$this->processAction( $action, $settings );
+
+		// Return fresh state.
+		return $this->api_service->getAction( $action_id );
+	}
+
+	// ── Dismiss ─────────────────────────────────────────────────────────────
+
+	/**
+	 * Dismisses a single pending action by consuming it on the API with a
+	 * "dismissed" marker, without creating any WordPress content.
+	 *
+	 * @param string $action_id MongoDB ObjectId of the action.
+	 * @return array|\WP_Error Refreshed action state or WP_Error on failure.
+	 */
+	public function dismissAction( $action_id ) {
+		$action = $this->api_service->getAction( $action_id );
+		if ( is_wp_error( $action ) || null === $action ) {
+			return $action;
+		}
+
+		if ( 'pending' !== ( $action['status'] ?? '' ) ) {
+			return $action;
+		}
+
+		$consume_payload = array(
+			'result'      => array( 'dismissed' => true ),
+			'consumed_by' => 'wordpress-plugin-dismissed',
+		);
+		$result = $this->api_service->consumeAction( $action_id, $consume_payload );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		contai_log( 'Agent action dismissed: ' . $action_id );
+
+		return $this->api_service->getAction( $action_id );
+	}
+
+	/**
+	 * Dismisses all currently pending actions in bulk.
+	 *
+	 * @return array{dismissed: int, errors: int}
+	 */
+	public function dismissAllPendingActions() {
+		$result = $this->api_service->listActions( array( 'status' => 'pending', 'limit' => 100 ) );
+
+		$actions = array();
+		if ( ! is_wp_error( $result ) && ! empty( $result['actions'] ) && is_array( $result['actions'] ) ) {
+			$actions = $result['actions'];
+		}
+
+		$dismissed = 0;
+		$errors    = 0;
+
+		foreach ( $actions as $action ) {
+			if ( ! is_array( $action ) || 'pending' !== ( $action['status'] ?? '' ) ) {
+				continue;
+			}
+			$action_id       = isset( $action['id'] ) ? $action['id'] : ( isset( $action['_id'] ) ? $action['_id'] : '' );
+			$consume_payload = array(
+				'result'      => array( 'dismissed' => true ),
+				'consumed_by' => 'wordpress-plugin-dismissed',
+			);
+			$res = $this->api_service->consumeAction( $action_id, $consume_payload );
+			if ( is_wp_error( $res ) ) {
+				$errors++;
+			} else {
+				$dismissed++;
+			}
+		}
+
+		contai_log( "Bulk dismiss: {$dismissed} dismissed, {$errors} errors" );
+
+		return array( 'dismissed' => $dismissed, 'errors' => $errors );
+	}
+
+	// ── Action dispatch ──────────────────────────────────────────────────────
+
+	/**
+	 * Dispatches a single action to its registered handler.
+	 *
+	 * If the handler succeeds the action is consumed remotely via the API.
+	 * Failures are logged but do not throw — the poll cycle continues with
+	 * the remaining actions.
+	 *
+	 * @param array $action   Full action object from the API.
+	 * @param array $settings Settings context (from getAllSettings() + overrides).
+	 */
+	public function processAction( array $action, array $settings ) {
+		$type      = isset( $action['type'] ) ? $action['type'] : '';
+		$action_id = isset( $action['id'] ) ? $action['id'] : '';
+
+		foreach ( $this->handlers as $handler ) {
+			if ( ! $handler->canHandle( $type ) ) {
+				continue;
+			}
+
+			$result = $handler->handle( $action, $settings );
+
+			if ( ! empty( $result['success'] ) ) {
+				$consume_payload = array(
+					'result'      => $result,
+					'consumed_by' => 'wordpress-plugin',
+				);
+				$this->api_service->consumeAction( $action_id, $consume_payload );
+				contai_log( 'Agent action consumed: ' . $action_id . ' type=' . $type );
+			} else {
+				$error = isset( $result['error'] ) ? $result['error'] : 'unknown';
+				contai_log( 'Agent action failed: ' . $action_id . ' error=' . $error, 'warning' );
+			}
+
+			return;
+		}
+
+		contai_log( 'No handler for agent action type: ' . $type, 'warning' );
+	}
+
+	// ── Private ──────────────────────────────────────────────────────────────
+
+	/**
+	 * Registers the built-in action handlers.
+	 * Called once during construction before any external handlers are added.
+	 */
+	private function registerDefaultHandlers() {
+		require_once dirname( __DIR__ ) . '/post/WordPressPostCreator.php';
+		$this->handlers[] = new ContaiPublishContentActionHandler( new ContaiWordPressPostCreator() );
+
+		require_once __DIR__ . '/ContaiSendEmailActionHandler.php';
+		$this->handlers[] = new ContaiSendEmailActionHandler();
+	}
+}

--- a/includes/services/agents/ContaiSendEmailActionHandler.php
+++ b/includes/services/agents/ContaiSendEmailActionHandler.php
@@ -1,0 +1,111 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+/**
+ * Handles "send_email" actions created by agents.
+ *
+ * Delegates to WordPress wp_mail() — no external email service required.
+ * The email is sent using whatever SMTP/transport WordPress has configured.
+ */
+class ContaiSendEmailActionHandler implements ContaiAgentActionHandlerInterface {
+
+	const RATE_LIMIT_OPTION = 'contai_agent_email_hourly_count';
+	const RATE_LIMIT_MAX    = 20;
+
+	/**
+	 * @param string $type Action type identifier.
+	 * @return bool
+	 */
+	public function canHandle( $type ) {
+		return 'send_email' === $type;
+	}
+
+	/**
+	 * Send an email using wp_mail().
+	 *
+	 * Expected payload keys in $action['payload']['metadata']:
+	 *   - to      (string, required) — recipient email address
+	 *   - subject (string, required) — email subject line
+	 *   - body    (string, required) — email body (plain text or HTML)
+	 *   - cc      (string, optional) — CC address
+	 *   - headers (array, optional)  — additional email headers
+	 *
+	 * @param array $action   The full action document from the API.
+	 * @param array $settings Local plugin settings (unused for email).
+	 * @return array Result with 'success' key.
+	 */
+	public function handle( array $action, array $settings ) {
+		$payload  = $action['payload'] ?? array();
+		$metadata = $payload['metadata'] ?? $payload;
+
+		$to      = sanitize_email( $metadata['to'] ?? '' );
+		$subject = sanitize_text_field( $metadata['subject'] ?? '' );
+		$body    = $metadata['body'] ?? '';
+
+		if ( empty( $to ) || ! is_email( $to ) ) {
+			return array( 'success' => false, 'error' => 'Invalid or missing recipient email address' );
+		}
+		if ( empty( $subject ) ) {
+			return array( 'success' => false, 'error' => 'Missing email subject' );
+		}
+		if ( empty( $body ) ) {
+			return array( 'success' => false, 'error' => 'Missing email body' );
+		}
+
+		// Rate limit: max N emails per hour
+		if ( $this->isRateLimited() ) {
+			contai_log( 'Agent email rate limit reached (' . self::RATE_LIMIT_MAX . '/hour)', 'warning' );
+			return array( 'success' => false, 'error' => 'Hourly email rate limit reached (' . self::RATE_LIMIT_MAX . ')' );
+		}
+
+		// Build headers
+		$headers = array( 'Content-Type: text/html; charset=UTF-8' );
+		if ( ! empty( $metadata['cc'] ) ) {
+			$cc = sanitize_email( $metadata['cc'] );
+			if ( is_email( $cc ) ) {
+				$headers[] = 'Cc: ' . $cc;
+			}
+		}
+
+		// Sanitize body (allow basic HTML)
+		$body = wp_kses_post( $body );
+
+		// Add agent context to subject
+		if ( strpos( $subject, '[' ) !== 0 ) {
+			$subject = '[1Platform] ' . $subject;
+		}
+
+		$sent = wp_mail( $to, $subject, $body, $headers );
+
+		if ( $sent ) {
+			$this->incrementRateCounter();
+			contai_log( 'Agent email sent to ' . $to . ' subject="' . $subject . '"' );
+			return array(
+				'success' => true,
+				'to'      => $to,
+				'subject' => $subject,
+			);
+		}
+
+		contai_log( 'Agent email failed to ' . $to, 'warning' );
+		return array( 'success' => false, 'error' => 'wp_mail() returned false' );
+	}
+
+	/**
+	 * Checks if the hourly email rate limit has been reached.
+	 *
+	 * @return bool
+	 */
+	private function isRateLimited() {
+		$count = (int) get_transient( self::RATE_LIMIT_OPTION );
+		return $count >= self::RATE_LIMIT_MAX;
+	}
+
+	/**
+	 * Increments the hourly email counter.
+	 */
+	private function incrementRateCounter() {
+		$count = (int) get_transient( self::RATE_LIMIT_OPTION );
+		set_transient( self::RATE_LIMIT_OPTION, $count + 1, HOUR_IN_SECONDS );
+	}
+}

--- a/includes/services/http/HTTPClientService.php
+++ b/includes/services/http/HTTPClientService.php
@@ -70,7 +70,10 @@ class ContaiHTTPClientService {
         ];
 
         if ($this->shouldIncludeBody($method, $data)) {
-            $args['body'] = is_string($data) ? $data : wp_json_encode($data);
+            // Cast empty arrays to stdClass so they encode as {} instead of []
+            $args['body'] = is_string($data) ? $data : wp_json_encode(
+                (is_array($data) && empty($data)) ? new \stdClass() : $data
+            );
         }
 
         $response = wp_remote_request($url, $args);

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai content, seo, content generation, internal links, table of contents
 Requires at least: 5.9
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.3.6
+Stable tag: 2.4.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,6 +3,8 @@
 define('ABSPATH', '/tmp/wordpress/');
 define('OBJECT', 'OBJECT');
 define('ARRAY_A', 'ARRAY_A');
+define('DAY_IN_SECONDS', 86400);
+define('HOUR_IN_SECONDS', 3600);
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
@@ -60,6 +62,12 @@ class_alias('ContaiRateLimiter', 'RateLimiter');
 require_once __DIR__ . '/../includes/providers/UserProvider.php';
 
 class_alias('ContaiUserProvider', 'UserProvider');
+
+// ── Agents ───────────────────────────────────────────────────
+require_once __DIR__ . '/../includes/services/agents/ContaiAgentEndpoints.php';
+require_once __DIR__ . '/../includes/services/agents/ContaiAgentSettingsService.php';
+require_once __DIR__ . '/../includes/services/agents/ContaiAgentActionHandler.php';
+require_once __DIR__ . '/../includes/services/agents/ContaiSendEmailActionHandler.php';
 
 // ── API & Search Console ────────────────────────────────────────
 require_once __DIR__ . '/../includes/services/http/HTTPClientService.php';

--- a/tests/unit/services/agents/AgentSettingsServiceTest.php
+++ b/tests/unit/services/agents/AgentSettingsServiceTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace ContAI\Tests\Unit\Services\Agents;
+
+use WP_Mock;
+use PHPUnit\Framework\TestCase;
+
+class AgentSettingsServiceTest extends TestCase {
+
+    public function setUp(): void {
+        parent::setUp();
+        WP_Mock::setUp();
+    }
+
+    public function tearDown(): void {
+        WP_Mock::tearDown();
+        parent::tearDown();
+    }
+
+    // ── getPublishStatus ─────────────────────────────────────────
+
+    public function test_get_publish_status_defaults_to_publish(): void {
+        WP_Mock::userFunction( 'get_option' )
+            ->with( 'contai_agents_publish_status', 'publish' )
+            ->andReturn( 'publish' );
+
+        $this->assertSame( 'publish', \ContaiAgentSettingsService::getPublishStatus() );
+    }
+
+    // ── setPublishStatus ─────────────────────────────────────────
+
+    public function test_set_publish_status_rejects_invalid_values(): void {
+        WP_Mock::userFunction( 'sanitize_text_field' )->andReturnUsing( function( $v ) { return $v; } );
+        WP_Mock::userFunction( 'update_option' )
+            ->once()
+            ->with( 'contai_agents_publish_status', 'draft' );
+
+        \ContaiAgentSettingsService::setPublishStatus( 'invalid_status' );
+        $this->assertSame( 1, 1 ); // WP_Mock verifies the expectation
+    }
+
+    public function test_set_publish_status_accepts_valid_values(): void {
+        WP_Mock::userFunction( 'sanitize_text_field' )->andReturnUsing( function( $v ) { return $v; } );
+
+        foreach ( array( 'draft', 'publish', 'pending' ) as $status ) {
+            WP_Mock::userFunction( 'update_option' )
+                ->once()
+                ->with( 'contai_agents_publish_status', $status );
+
+            \ContaiAgentSettingsService::setPublishStatus( $status );
+        }
+        $this->assertSame( 3, 3 ); // WP_Mock verifies the expectations
+    }
+
+    // ── isAutoConsumeEnabled ─────────────────────────────────────
+
+    public function test_auto_consume_defaults_to_true(): void {
+        WP_Mock::userFunction( 'get_option' )
+            ->with( 'contai_agents_auto_consume', true )
+            ->andReturn( true );
+
+        $this->assertTrue( \ContaiAgentSettingsService::isAutoConsumeEnabled() );
+    }
+
+    // ── getPollingInterval ───────────────────────────────────────
+
+    public function test_polling_interval_defaults_to_60(): void {
+        WP_Mock::userFunction( 'get_option' )
+            ->with( 'contai_agents_polling_interval', 60 )
+            ->andReturn( 60 );
+
+        $this->assertSame( 60, \ContaiAgentSettingsService::getPollingInterval() );
+    }
+
+    // ── getAllSettings ────────────────────────────────────────────
+
+    public function test_get_all_settings_returns_all_keys(): void {
+        WP_Mock::userFunction( 'get_option' )->andReturnUsing( function( $key, $default ) {
+            return $default;
+        } );
+
+        $settings = \ContaiAgentSettingsService::getAllSettings();
+
+        $this->assertArrayHasKey( 'publish_status', $settings );
+        $this->assertArrayHasKey( 'auto_consume', $settings );
+        $this->assertArrayHasKey( 'polling_interval', $settings );
+        $this->assertArrayHasKey( 'last_poll_time', $settings );
+    }
+
+    // ── updateSettings ───────────────────────────────────────────
+
+    public function test_update_settings_ignores_unknown_keys(): void {
+        // update_option should NOT be called for unknown keys
+        WP_Mock::userFunction( 'update_option' )->never();
+        WP_Mock::userFunction( 'sanitize_text_field' )->never();
+
+        \ContaiAgentSettingsService::updateSettings( array( 'unknown_key' => 'value' ) );
+
+        $this->assertTrue( true ); // No exception = pass
+    }
+}

--- a/tests/unit/services/agents/PublishContentActionHandlerTest.php
+++ b/tests/unit/services/agents/PublishContentActionHandlerTest.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace ContAI\Tests\Unit\Services\Agents;
+
+use WP_Mock;
+use PHPUnit\Framework\TestCase;
+use Mockery;
+
+class PublishContentActionHandlerTest extends TestCase {
+
+    private $post_creator;
+    private $handler;
+
+    public function setUp(): void {
+        parent::setUp();
+        WP_Mock::setUp();
+
+        $this->post_creator = Mockery::mock('ContaiWordPressPostCreator');
+        $this->handler = new \ContaiPublishContentActionHandler( $this->post_creator );
+    }
+
+    public function tearDown(): void {
+        WP_Mock::tearDown();
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    // ── canHandle ────────────────────────────────────────────────
+
+    public function test_can_handle_returns_true_for_publish_content(): void {
+        $this->assertTrue( $this->handler->canHandle( 'publish_content' ) );
+    }
+
+    public function test_can_handle_returns_false_for_other_types(): void {
+        $this->assertFalse( $this->handler->canHandle( 'send_email' ) );
+        $this->assertFalse( $this->handler->canHandle( '' ) );
+    }
+
+    // ── Required field validation ────────────────────────────────
+
+    public function test_handle_fails_when_title_is_missing(): void {
+        $action = array( 'payload' => array( 'body' => '<p>content</p>' ) );
+        $result = $this->handler->handle( $action, array() );
+
+        $this->assertFalse( $result['success'] );
+        $this->assertStringContainsString( 'title', $result['error'] );
+    }
+
+    public function test_handle_fails_when_body_is_missing(): void {
+        $action = array( 'payload' => array( 'title' => 'Test Post' ) );
+        $result = $this->handler->handle( $action, array() );
+
+        $this->assertFalse( $result['success'] );
+        $this->assertStringContainsString( 'body', $result['error'] );
+    }
+
+    public function test_handle_fails_when_payload_is_empty(): void {
+        $action = array( 'payload' => array() );
+        $result = $this->handler->handle( $action, array() );
+
+        $this->assertFalse( $result['success'] );
+    }
+
+    public function test_handle_fails_when_payload_key_is_missing(): void {
+        $action = array();
+        $result = $this->handler->handle( $action, array() );
+
+        $this->assertFalse( $result['success'] );
+    }
+
+    // ── Duplicate check ──────────────────────────────────────────
+
+    public function test_handle_fails_on_duplicate_title(): void {
+        $existing = new \stdClass();
+        $existing->ID = 42;
+
+        WP_Mock::userFunction( 'sanitize_text_field' )->andReturnUsing( function( $v ) { return $v; } );
+        WP_Mock::userFunction( 'get_posts' )->once()->andReturn( array( $existing ) );
+
+        $action = array( 'payload' => array( 'title' => 'Existing Post', 'body' => '<p>test</p>' ) );
+        $result = $this->handler->handle( $action, array() );
+
+        $this->assertFalse( $result['success'] );
+        $this->assertStringContainsString( 'already exists', $result['error'] );
+    }
+
+    // ── post_date timezone fix ───────────────────────────────────
+
+    public function test_post_date_uses_get_date_from_gmt(): void {
+        $utc_date   = '2026-06-15 14:00:00';
+        $local_date = '2026-06-15 08:00:00'; // simulated UTC-6
+
+        WP_Mock::userFunction( 'sanitize_text_field' )->andReturnUsing( function( $v ) { return $v; } );
+        WP_Mock::userFunction( 'wp_kses_post' )->andReturnUsing( function( $v ) { return $v; } );
+        WP_Mock::userFunction( 'get_posts' )->andReturn( array() );
+        WP_Mock::userFunction( 'get_date_from_gmt' )
+            ->once()
+            ->with( $utc_date )
+            ->andReturn( $local_date );
+        WP_Mock::userFunction( 'is_wp_error' )->andReturn( false );
+
+        $captured_post_data = null;
+        WP_Mock::userFunction( 'wp_insert_post' )
+            ->once()
+            ->andReturnUsing( function( $data ) use ( &$captured_post_data ) {
+                $captured_post_data = $data;
+                return 100;
+            } );
+
+        WP_Mock::userFunction( 'update_post_meta' )->andReturn( true );
+        $this->post_creator->shouldReceive( 'getPermalink' )->andReturn( 'https://example.com/test' );
+
+        $action = array(
+            'payload' => array(
+                'title'        => 'Timezone Test',
+                'body'         => '<p>content</p>',
+                'publish_date' => '2026-06-15T14:00:00Z',
+            ),
+        );
+
+        $result = $this->handler->handle( $action, array( 'publish_status' => 'publish' ) );
+
+        $this->assertTrue( $result['success'] );
+        $this->assertSame( $utc_date, $captured_post_data['post_date_gmt'] );
+        $this->assertSame( $local_date, $captured_post_data['post_date'] );
+    }
+
+    public function test_post_date_omitted_when_no_publish_date(): void {
+        WP_Mock::userFunction( 'sanitize_text_field' )->andReturnUsing( function( $v ) { return $v; } );
+        WP_Mock::userFunction( 'wp_kses_post' )->andReturnUsing( function( $v ) { return $v; } );
+        WP_Mock::userFunction( 'get_posts' )->andReturn( array() );
+        WP_Mock::userFunction( 'is_wp_error' )->andReturn( false );
+
+        $captured_post_data = null;
+        WP_Mock::userFunction( 'wp_insert_post' )
+            ->once()
+            ->andReturnUsing( function( $data ) use ( &$captured_post_data ) {
+                $captured_post_data = $data;
+                return 101;
+            } );
+
+        $this->post_creator->shouldReceive( 'getPermalink' )->andReturn( 'https://example.com/test' );
+
+        $action = array(
+            'payload' => array(
+                'title' => 'No Date Test',
+                'body'  => '<p>content</p>',
+            ),
+        );
+
+        $result = $this->handler->handle( $action, array( 'publish_status' => 'draft' ) );
+
+        $this->assertTrue( $result['success'] );
+        $this->assertArrayNotHasKey( 'post_date', $captured_post_data );
+        $this->assertArrayNotHasKey( 'post_date_gmt', $captured_post_data );
+    }
+
+    // ── validateDate edge cases ──────────────────────────────────
+
+    public function test_invalid_date_is_ignored(): void {
+        WP_Mock::userFunction( 'sanitize_text_field' )->andReturnUsing( function( $v ) { return $v; } );
+        WP_Mock::userFunction( 'wp_kses_post' )->andReturnUsing( function( $v ) { return $v; } );
+        WP_Mock::userFunction( 'get_posts' )->andReturn( array() );
+        WP_Mock::userFunction( 'is_wp_error' )->andReturn( false );
+
+        $captured = null;
+        WP_Mock::userFunction( 'wp_insert_post' )
+            ->once()
+            ->andReturnUsing( function( $data ) use ( &$captured ) {
+                $captured = $data;
+                return 102;
+            } );
+
+        $this->post_creator->shouldReceive( 'getPermalink' )->andReturn( 'https://example.com/test' );
+
+        $action = array(
+            'payload' => array(
+                'title'        => 'Bad Date',
+                'body'         => '<p>content</p>',
+                'publish_date' => 'not-a-date',
+            ),
+        );
+
+        $result = $this->handler->handle( $action, array( 'publish_status' => 'draft' ) );
+
+        $this->assertTrue( $result['success'] );
+        $this->assertArrayNotHasKey( 'post_date_gmt', $captured );
+    }
+
+    // ── Post status from settings ────────────────────────────────
+
+    public function test_post_status_comes_from_settings(): void {
+        WP_Mock::userFunction( 'sanitize_text_field' )->andReturnUsing( function( $v ) { return $v; } );
+        WP_Mock::userFunction( 'wp_kses_post' )->andReturnUsing( function( $v ) { return $v; } );
+        WP_Mock::userFunction( 'get_posts' )->andReturn( array() );
+        WP_Mock::userFunction( 'is_wp_error' )->andReturn( false );
+
+        $captured = null;
+        WP_Mock::userFunction( 'wp_insert_post' )
+            ->once()
+            ->andReturnUsing( function( $data ) use ( &$captured ) {
+                $captured = $data;
+                return 103;
+            } );
+
+        $this->post_creator->shouldReceive( 'getPermalink' )->andReturn( 'https://example.com/test' );
+
+        $action = array(
+            'payload' => array( 'title' => 'Draft Test', 'body' => '<p>draft</p>' ),
+        );
+
+        $result = $this->handler->handle( $action, array( 'publish_status' => 'draft' ) );
+
+        $this->assertTrue( $result['success'] );
+        $this->assertSame( 'draft', $captured['post_status'] );
+        $this->assertSame( 'draft', $result['post_status'] );
+    }
+}

--- a/tests/unit/services/agents/SendEmailActionHandlerTest.php
+++ b/tests/unit/services/agents/SendEmailActionHandlerTest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace ContAI\Tests\Unit\Services\Agents;
+
+use WP_Mock;
+use PHPUnit\Framework\TestCase;
+
+class SendEmailActionHandlerTest extends TestCase {
+
+    private $handler;
+
+    public function setUp(): void {
+        parent::setUp();
+        WP_Mock::setUp();
+        $this->handler = new \ContaiSendEmailActionHandler();
+    }
+
+    public function tearDown(): void {
+        WP_Mock::tearDown();
+        parent::tearDown();
+    }
+
+    // ── canHandle ────────────────────────────────────────────────
+
+    public function test_can_handle_returns_true_for_send_email(): void {
+        $this->assertTrue( $this->handler->canHandle( 'send_email' ) );
+    }
+
+    public function test_can_handle_returns_false_for_other_types(): void {
+        $this->assertFalse( $this->handler->canHandle( 'publish_content' ) );
+        $this->assertFalse( $this->handler->canHandle( '' ) );
+    }
+
+    // ── Validation ───────────────────────────────────────────────
+
+    public function test_handle_fails_with_invalid_email(): void {
+        WP_Mock::userFunction( 'sanitize_email' )->andReturn( '' );
+        WP_Mock::userFunction( 'sanitize_text_field' )->andReturnUsing( function( $v ) { return $v; } );
+        WP_Mock::userFunction( 'is_email' )->andReturn( false );
+
+        $action = array( 'payload' => array( 'metadata' => array(
+            'to' => 'invalid', 'subject' => 'Test', 'body' => 'Hi',
+        ) ) );
+
+        $result = $this->handler->handle( $action, array() );
+        $this->assertFalse( $result['success'] );
+        $this->assertStringContainsString( 'email', $result['error'] );
+    }
+
+    public function test_handle_fails_with_missing_subject(): void {
+        WP_Mock::userFunction( 'sanitize_email' )->andReturn( 'test@example.com' );
+        WP_Mock::userFunction( 'sanitize_text_field' )->andReturn( '' );
+        WP_Mock::userFunction( 'is_email' )->andReturn( true );
+
+        $action = array( 'payload' => array( 'metadata' => array(
+            'to' => 'test@example.com', 'subject' => '', 'body' => 'Hi',
+        ) ) );
+
+        $result = $this->handler->handle( $action, array() );
+        $this->assertFalse( $result['success'] );
+        $this->assertStringContainsString( 'subject', $result['error'] );
+    }
+
+    public function test_handle_fails_with_missing_body(): void {
+        WP_Mock::userFunction( 'sanitize_email' )->andReturn( 'test@example.com' );
+        WP_Mock::userFunction( 'sanitize_text_field' )->andReturnUsing( function( $v ) { return $v; } );
+        WP_Mock::userFunction( 'is_email' )->andReturn( true );
+
+        $action = array( 'payload' => array( 'metadata' => array(
+            'to' => 'test@example.com', 'subject' => 'Test', 'body' => '',
+        ) ) );
+
+        $result = $this->handler->handle( $action, array() );
+        $this->assertFalse( $result['success'] );
+        $this->assertStringContainsString( 'body', $result['error'] );
+    }
+
+    // ── Rate limiting ────────────────────────────────────────────
+
+    public function test_handle_fails_when_rate_limited(): void {
+        WP_Mock::userFunction( 'sanitize_email' )->andReturn( 'test@example.com' );
+        WP_Mock::userFunction( 'sanitize_text_field' )->andReturnUsing( function( $v ) { return $v; } );
+        WP_Mock::userFunction( 'is_email' )->andReturn( true );
+        WP_Mock::userFunction( 'get_transient' )
+            ->with( \ContaiSendEmailActionHandler::RATE_LIMIT_OPTION )
+            ->andReturn( \ContaiSendEmailActionHandler::RATE_LIMIT_MAX );
+        WP_Mock::userFunction( 'contai_log' )->andReturn( null );
+
+        $action = array( 'payload' => array( 'metadata' => array(
+            'to' => 'test@example.com', 'subject' => 'Test', 'body' => '<p>Hi</p>',
+        ) ) );
+
+        $result = $this->handler->handle( $action, array() );
+        $this->assertFalse( $result['success'] );
+        $this->assertStringContainsString( 'rate limit', $result['error'] );
+    }
+
+    public function test_handle_allows_when_under_rate_limit(): void {
+        WP_Mock::userFunction( 'sanitize_email' )->andReturn( 'test@example.com' );
+        WP_Mock::userFunction( 'sanitize_text_field' )->andReturnUsing( function( $v ) { return $v; } );
+        WP_Mock::userFunction( 'is_email' )->andReturn( true );
+        WP_Mock::userFunction( 'wp_kses_post' )->andReturnUsing( function( $v ) { return $v; } );
+        WP_Mock::userFunction( 'get_transient' )
+            ->with( \ContaiSendEmailActionHandler::RATE_LIMIT_OPTION )
+            ->andReturn( 5 );
+        WP_Mock::userFunction( 'set_transient' )->andReturn( true );
+        WP_Mock::userFunction( 'wp_mail' )->once()->andReturn( true );
+        WP_Mock::userFunction( 'contai_log' )->andReturn( null );
+
+
+        $action = array( 'payload' => array( 'metadata' => array(
+            'to' => 'test@example.com', 'subject' => 'Test', 'body' => '<p>Hello</p>',
+        ) ) );
+
+        $result = $this->handler->handle( $action, array() );
+        $this->assertTrue( $result['success'] );
+        $this->assertSame( 'test@example.com', $result['to'] );
+    }
+
+    // ── Successful send ──────────────────────────────────────────
+
+    public function test_handle_sends_email_successfully(): void {
+        WP_Mock::userFunction( 'sanitize_email' )->andReturnUsing( function( $v ) { return $v; } );
+        WP_Mock::userFunction( 'sanitize_text_field' )->andReturnUsing( function( $v ) { return $v; } );
+        WP_Mock::userFunction( 'is_email' )->andReturn( true );
+        WP_Mock::userFunction( 'wp_kses_post' )->andReturnUsing( function( $v ) { return $v; } );
+        WP_Mock::userFunction( 'get_transient' )->andReturn( 0 );
+        WP_Mock::userFunction( 'set_transient' )->andReturn( true );
+        WP_Mock::userFunction( 'wp_mail' )->once()->andReturn( true );
+        WP_Mock::userFunction( 'contai_log' )->andReturn( null );
+
+
+        $action = array( 'payload' => array( 'metadata' => array(
+            'to'      => 'admin@example.com',
+            'subject' => 'Agent Report',
+            'body'    => '<p>Report content</p>',
+        ) ) );
+
+        $result = $this->handler->handle( $action, array() );
+        $this->assertTrue( $result['success'] );
+        $this->assertSame( 'admin@example.com', $result['to'] );
+        $this->assertSame( '[1Platform] Agent Report', $result['subject'] );
+    }
+
+    // ── wp_mail failure ──────────────────────────────────────────
+
+    public function test_handle_returns_failure_when_wp_mail_fails(): void {
+        WP_Mock::userFunction( 'sanitize_email' )->andReturnUsing( function( $v ) { return $v; } );
+        WP_Mock::userFunction( 'sanitize_text_field' )->andReturnUsing( function( $v ) { return $v; } );
+        WP_Mock::userFunction( 'is_email' )->andReturn( true );
+        WP_Mock::userFunction( 'wp_kses_post' )->andReturnUsing( function( $v ) { return $v; } );
+        WP_Mock::userFunction( 'get_transient' )->andReturn( 0 );
+        WP_Mock::userFunction( 'wp_mail' )->once()->andReturn( false );
+        WP_Mock::userFunction( 'contai_log' )->andReturn( null );
+
+
+        $action = array( 'payload' => array( 'metadata' => array(
+            'to' => 'fail@example.com', 'subject' => 'Test', 'body' => '<p>Hi</p>',
+        ) ) );
+
+        $result = $this->handler->handle( $action, array() );
+        $this->assertFalse( $result['success'] );
+        $this->assertStringContainsString( 'wp_mail()', $result['error'] );
+    }
+}


### PR DESCRIPTION
## Summary

- **Agent admin page**: List agents, view runs, trigger executions, and consume human-in-the-loop actions from wp-admin
- **Agent API service**: Client for all 1Platform agent API endpoints (catalog, wizard, CRUD, runs, actions)
- **Agent REST controller**: WordPress REST API proxy routes under `contai/v1/` for admin AJAX calls
- **Agent services**: Settings, sync, and action handlers (email) with WP-Cron polling
- **HTTPClientService fix**: Empty arrays now encode as `{}` instead of `[]` in JSON bodies
- Bumps version to **2.4.0**

### New files: 15 | Modified files: 3 | Total: 18 files changed, ~4.9k lines added

## Test plan

- [ ] Verify "Agents" submenu appears under 1Platform Content AI
- [ ] Verify agent list loads from the API
- [ ] Verify agent run trigger works from admin UI
- [ ] Verify action consume flow (approve/reject)
- [ ] Verify agent actions cron activates on plugin activation
- [ ] Verify cron deregisters on plugin deactivation
- [ ] Run `phpunit` — all existing + 3 new test files pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)