### PR TITLE
feat(keywords): topic-based keyword extraction + site generator redesign — v2.8.0

### DIFF
--- a/1platform-content-ai.php
+++ b/1platform-content-ai.php
@@ -4,7 +4,7 @@
  * Plugin Name: 1Platform Content AI
  * Plugin URI: https://1platform.pro/
  * Description: SaaS client for AI-powered content generation, SEO optimization, and site management. All AI processing happens on 1Platform external servers. Includes free local tools: Table of Contents and Internal Links.
- * Version: 2.7.0
+ * Version: 2.8.0
  * Author: 1Platform
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to Content AI are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.8.0] - 2026-03-24
+
+### Added
+
+- **Topic-based keyword extraction**: Keyword extractor now discovers keywords by topic/theme instead of domain URL, using the new `POST /posts/keywords/topic/` API endpoint
+- **`KeywordExtractorService::extractByTopicAndSave()`**: New method for topic-based extraction via `POSTS_KEYWORDS_TOPIC` endpoint
+- **`POSTS_KEYWORDS_TOPIC` endpoint constant**: Added `/posts/keywords/topic/` to `OnePlatformEndpoints`
+- **AdSense publisher ID early save**: Publisher ID is now saved immediately on form submission (before background job), fixing #12 where the ID wasn't available in Ads Manager until the job completed
+
+### Changed
+
+- **Keyword extractor UI**: Replaced domain URL input with topic/theme text field in the keyword extraction panel (`keyword-extractor.php`)
+- **`KeywordExtractionHandler`**: Validates topic (3-200 chars) instead of URL, sends `topic` field to API
+- **`KeywordExtractionJob`**: Uses `extractByTopicAndSave()` instead of `extractAndSaveKeywords()`
+- **Site Generator form**: Replaced "Source URL" with "Source Topic" field (`source_url` → `source_topic`), redesigned form layout and CSS
+- **`SiteGenerationJob`**: Uses topic-based extraction for keyword discovery step
+- **Error message encoding**: Removed redundant `urlencode()` from error redirect messages (WordPress handles encoding)
+
 ## [2.6.0] - 2026-03-22
 
 ### Added

--- a/includes/admin/admin-ai-site-generator.php
+++ b/includes/admin/admin-ai-site-generator.php
@@ -51,7 +51,7 @@ function contai_handle_ai_site_generator_submission() {
 				array(
 					'page' => 'contai-ai-site-generator',
 					'error' => 1,
-					'message' => urlencode( 'Please select a category before starting the site generation process.' ),
+					'message' => 'Please select a category before starting the site generation process.',
 				),
 				admin_url( 'admin.php' )
 			)
@@ -68,7 +68,7 @@ function contai_handle_ai_site_generator_submission() {
 				array(
 					'page' => 'contai-ai-site-generator',
 					'error' => 1,
-					'message' => urlencode( 'There is already an active site generation process running.' ),
+					'message' => 'There is already an active site generation process running.',
 				),
 				admin_url( 'admin.php' )
 			)
@@ -92,7 +92,7 @@ function contai_handle_ai_site_generator_submission() {
 				'activity' => sanitize_text_field( wp_unslash( $_POST['contai_legal_activity'] ?? '' ) ),
 			),
 			'keyword_extraction' => array(
-				'source_url' => esc_url_raw( wp_unslash( $_POST['contai_source_url'] ?? '' ) ),
+				'source_topic' => sanitize_text_field( wp_unslash( $_POST['contai_source_topic'] ?? '' ) ),
 				'target_country' => sanitize_text_field( wp_unslash( $_POST['contai_target_country'] ?? 'us' ) ),
 				'target_language' => sanitize_text_field( wp_unslash( $_POST['contai_target_language'] ?? 'en' ) ),
 			),
@@ -128,7 +128,7 @@ function contai_handle_ai_site_generator_submission() {
 				array(
 					'page' => 'contai-ai-site-generator',
 					'error' => 1,
-					'message' => urlencode( 'Failed to start site generation process.' ),
+					'message' => 'Failed to start site generation process.',
 				),
 				admin_url( 'admin.php' )
 			)
@@ -140,6 +140,16 @@ function contai_handle_ai_site_generator_submission() {
 	update_option( 'contai_site_language', sanitize_text_field( wp_unslash( $_POST['contai_site_language'] ?? 'english' ) ) );
 	if ( ! empty( $_POST['contai_site_category'] ) ) {
 		update_option( 'contai_site_category', sanitize_text_field( wp_unslash( $_POST['contai_site_category'] ) ) );
+	}
+
+	// Save AdSense publisher ID immediately so it appears in Ads Manager
+	// before the background job completes (fixes #12)
+	$adsense_publisher = sanitize_text_field( wp_unslash( $_POST['contai_adsense_publisher'] ?? '' ) );
+	if ( ! empty( $adsense_publisher ) && preg_match( '/^pub-\d+$/', $adsense_publisher ) ) {
+		update_option( 'contai_adsense_publishers', $adsense_publisher );
+		if ( function_exists( 'contai_generate_adsense_ads' ) ) {
+			contai_generate_adsense_ads();
+		}
 	}
 
 	wp_safe_redirect(
@@ -169,14 +179,14 @@ function contai_ai_site_generator_page() {
 	if ( isset( $_GET['success'] ) ) {
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$msg = isset( $_GET['message'] ) ? sanitize_text_field( wp_unslash( $_GET['message'] ) ) : 'Success';
-		echo '<div class="notice notice-success is-dismissible"><p>' . esc_html( urldecode( $msg ) ) . '</p></div>';
+		echo '<div class="notice notice-success is-dismissible"><p>' . esc_html( $msg ) . '</p></div>';
 	}
 
     // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Display-only read of GET params after redirect.
 	if ( isset( $_GET['error'] ) ) {
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$msg = isset( $_GET['message'] ) ? sanitize_text_field( wp_unslash( $_GET['message'] ) ) : 'Error';
-		echo '<div class="notice notice-error is-dismissible"><p>' . esc_html( urldecode( $msg ) ) . '</p></div>';
+		echo '<div class="notice notice-error is-dismissible"><p>' . esc_html( $msg ) . '</p></div>';
 	}
 
 	?>

--- a/includes/admin/ai-site-generator/site-generator-form.php
+++ b/includes/admin/ai-site-generator/site-generator-form.php
@@ -11,33 +11,41 @@ function contai_render_full_site_generator_form() {
 	$category_service = new ContaiCategoryAPIService();
 	$categories = $category_service->getActiveCategories();
 	$saved_category = get_option( 'contai_site_category', '' );
+	$site_domain    = wp_parse_url( home_url(), PHP_URL_HOST );
+	$default_email  = 'info@' . preg_replace( '/^www\./', '', $site_domain );
 
 	?>
 	<form method="post" class="contai-site-generator-form">
 		<?php wp_nonce_field( 'contai_site_generator_nonce', 'contai_site_generator_nonce' ); ?>
 		<input type="hidden" name="contai_start_site_generation" value="1">
-
 		<input type="hidden" id="contai_wordpress_theme" name="contai_wordpress_theme" value="astra">
 
 		<!-- Step 1: Website Identity -->
-		<div class="contai-wizard-section">
+		<div class="contai-wizard-section" data-step="1">
 			<div class="contai-section-header">
 				<div class="contai-step-indicator">
 					<span class="contai-step-number">1</span>
+					<span class="contai-step-line"></span>
 				</div>
 				<div class="contai-section-title-group">
-					<h2 class="contai-section-title"><?php esc_html_e( 'Website Identity', '1platform-content-ai' ); ?></h2>
+					<h2 class="contai-section-title">
+						<span class="dashicons dashicons-admin-site-alt3 contai-section-icon"></span>
+						<?php esc_html_e( 'Website Identity', '1platform-content-ai' ); ?>
+					</h2>
 					<p class="contai-section-description"><?php esc_html_e( 'Define what your website is about and who it targets.', '1platform-content-ai' ); ?></p>
 				</div>
 			</div>
 			<div class="contai-section-body">
-				<div class="contai-form-grid contai-grid-3">
-					<div class="contai-form-group">
+				<div class="contai-form-grid contai-grid-2">
+					<div class="contai-form-group contai-span-full">
 						<label for="contai_site_topic" class="contai-label">
 							<?php esc_html_e( 'Site Topic', '1platform-content-ai' ); ?>
 							<span class="contai-required">*</span>
 						</label>
-						<input type="text" id="contai_site_topic" name="contai_site_topic" class="contai-input" placeholder="e.g., Technology News" autocomplete="off" required>
+						<div class="contai-input-wrap contai-input-icon">
+							<span class="dashicons dashicons-edit"></span>
+							<input type="text" id="contai_site_topic" name="contai_site_topic" class="contai-input" placeholder="<?php esc_attr_e( 'e.g., Indoor gardening, Personal finance, Pet care...', '1platform-content-ai' ); ?>" autocomplete="off" required>
+						</div>
 						<span class="contai-help-text"><?php esc_html_e( 'The main subject of your website', '1platform-content-ai' ); ?></span>
 					</div>
 
@@ -90,37 +98,47 @@ function contai_render_full_site_generator_form() {
 						</select>
 					</div>
 
-					<div class="contai-form-group contai-span-2">
+					<div class="contai-form-group">
 						<label for="contai_adsense_publisher" class="contai-label">
 							<?php esc_html_e( 'AdSense Publisher ID', '1platform-content-ai' ); ?>
 							<span class="contai-required">*</span>
 						</label>
-						<input type="text" id="contai_adsense_publisher" name="contai_adsense_publisher" class="contai-input" placeholder="pub-1234567890123456" autocomplete="off" spellcheck="false" required>
-						<span class="contai-help-text"><?php esc_html_e( 'Find it in your Google AdSense account under Account > Account information', '1platform-content-ai' ); ?></span>
+						<div class="contai-input-wrap contai-input-icon">
+							<span class="dashicons dashicons-money-alt"></span>
+							<input type="text" id="contai_adsense_publisher" name="contai_adsense_publisher" class="contai-input" placeholder="pub-1234567890123456" autocomplete="off" spellcheck="false" required>
+						</div>
+						<span class="contai-help-text"><?php esc_html_e( 'Account > Account information in AdSense', '1platform-content-ai' ); ?></span>
 					</div>
 				</div>
 			</div>
 		</div>
 
 		<!-- Step 2: Legal Information -->
-		<div class="contai-wizard-section">
+		<div class="contai-wizard-section" data-step="2">
 			<div class="contai-section-header">
 				<div class="contai-step-indicator">
 					<span class="contai-step-number">2</span>
+					<span class="contai-step-line"></span>
 				</div>
 				<div class="contai-section-title-group">
-					<h2 class="contai-section-title"><?php esc_html_e( 'Legal Information', '1platform-content-ai' ); ?></h2>
+					<h2 class="contai-section-title">
+						<span class="dashicons dashicons-shield contai-section-icon"></span>
+						<?php esc_html_e( 'Legal Information', '1platform-content-ai' ); ?>
+					</h2>
 					<p class="contai-section-description"><?php esc_html_e( 'Used to generate privacy policy, terms of service, and cookie consent.', '1platform-content-ai' ); ?></p>
 				</div>
 			</div>
 			<div class="contai-section-body">
-				<div class="contai-form-grid contai-grid-3">
+				<div class="contai-form-grid contai-grid-2">
 					<div class="contai-form-group">
 						<label for="contai_legal_owner" class="contai-label">
 							<?php esc_html_e( 'Business Owner', '1platform-content-ai' ); ?>
 							<span class="contai-required">*</span>
 						</label>
-						<input type="text" id="contai_legal_owner" name="contai_legal_owner" class="contai-input" placeholder="<?php esc_attr_e( 'John Doe', '1platform-content-ai' ); ?>" autocomplete="name" required>
+						<div class="contai-input-wrap contai-input-icon">
+							<span class="dashicons dashicons-businessperson"></span>
+							<input type="text" id="contai_legal_owner" name="contai_legal_owner" class="contai-input" placeholder="<?php esc_attr_e( 'John Doe', '1platform-content-ai' ); ?>" autocomplete="name" required>
+						</div>
 					</div>
 
 					<div class="contai-form-group">
@@ -128,7 +146,10 @@ function contai_render_full_site_generator_form() {
 							<?php esc_html_e( 'Contact Email', '1platform-content-ai' ); ?>
 							<span class="contai-required">*</span>
 						</label>
-						<input type="email" id="contai_legal_email" name="contai_legal_email" class="contai-input" placeholder="<?php esc_attr_e( 'contact@example.com', '1platform-content-ai' ); ?>" autocomplete="email" spellcheck="false" required>
+						<div class="contai-input-wrap contai-input-icon">
+							<span class="dashicons dashicons-email"></span>
+							<input type="email" id="contai_legal_email" name="contai_legal_email" class="contai-input" value="<?php echo esc_attr( $default_email ); ?>" placeholder="<?php esc_attr_e( 'info@domain.com', '1platform-content-ai' ); ?>" autocomplete="email" spellcheck="false" required>
+						</div>
 					</div>
 
 					<div class="contai-form-group">
@@ -136,40 +157,52 @@ function contai_render_full_site_generator_form() {
 							<?php esc_html_e( 'Business Activity', '1platform-content-ai' ); ?>
 							<span class="contai-required">*</span>
 						</label>
-						<input type="text" id="contai_legal_activity" name="contai_legal_activity" class="contai-input" placeholder="<?php esc_attr_e( 'e.g., Digital publishing', '1platform-content-ai' ); ?>" autocomplete="organization-title" required>
+						<div class="contai-input-wrap contai-input-icon">
+							<span class="dashicons dashicons-building"></span>
+							<input type="text" id="contai_legal_activity" name="contai_legal_activity" class="contai-input" placeholder="<?php esc_attr_e( 'e.g., Digital publishing', '1platform-content-ai' ); ?>" autocomplete="organization-title" required>
+						</div>
 					</div>
 
-					<div class="contai-form-group contai-span-full">
+					<div class="contai-form-group">
 						<label for="contai_legal_address" class="contai-label">
 							<?php esc_html_e( 'Business Address', '1platform-content-ai' ); ?>
 							<span class="contai-required">*</span>
 						</label>
-						<input type="text" id="contai_legal_address" name="contai_legal_address" class="contai-input" placeholder="<?php esc_attr_e( '123 Main St, City, Country', '1platform-content-ai' ); ?>" autocomplete="street-address" required>
+						<div class="contai-input-wrap contai-input-icon">
+							<span class="dashicons dashicons-location"></span>
+							<input type="text" id="contai_legal_address" name="contai_legal_address" class="contai-input" placeholder="<?php esc_attr_e( '123 Main St, City, Country', '1platform-content-ai' ); ?>" autocomplete="street-address" required>
+						</div>
 					</div>
 				</div>
 			</div>
 		</div>
 
 		<!-- Step 3: Content Generation Settings -->
-		<div class="contai-wizard-section">
+		<div class="contai-wizard-section" data-step="3">
 			<div class="contai-section-header">
 				<div class="contai-step-indicator">
 					<span class="contai-step-number">3</span>
 				</div>
 				<div class="contai-section-title-group">
-					<h2 class="contai-section-title"><?php esc_html_e( 'Content Generation', '1platform-content-ai' ); ?></h2>
+					<h2 class="contai-section-title">
+						<span class="dashicons dashicons-admin-post contai-section-icon"></span>
+						<?php esc_html_e( 'Content Generation', '1platform-content-ai' ); ?>
+					</h2>
 					<p class="contai-section-description"><?php esc_html_e( 'Configure how AI generates your website content, keywords, and images.', '1platform-content-ai' ); ?></p>
 				</div>
 			</div>
 			<div class="contai-section-body">
-				<div class="contai-form-grid contai-grid-3">
+				<div class="contai-form-grid contai-grid-2">
 					<div class="contai-form-group contai-span-full">
-						<label for="contai_source_url" class="contai-label">
-							<?php esc_html_e( 'Competitor Website (for keyword extraction)', '1platform-content-ai' ); ?>
+						<label for="contai_source_topic" class="contai-label">
+							<?php esc_html_e( 'Keyword Topic', '1platform-content-ai' ); ?>
 							<span class="contai-required">*</span>
 						</label>
-						<input type="url" id="contai_source_url" name="contai_source_url" class="contai-input" placeholder="https://example.com" autocomplete="url" spellcheck="false" required>
-						<span class="contai-help-text"><?php esc_html_e( 'We\'ll analyze this site to extract relevant keywords for your content.', '1platform-content-ai' ); ?></span>
+						<div class="contai-input-wrap contai-input-icon">
+							<span class="dashicons dashicons-search"></span>
+							<input type="text" id="contai_source_topic" name="contai_source_topic" class="contai-input" placeholder="<?php esc_attr_e( 'e.g., indoor plants care, home workout routines...', '1platform-content-ai' ); ?>" autocomplete="off" spellcheck="false" required>
+						</div>
+						<span class="contai-help-text"><?php esc_html_e( 'We\'ll research this topic to extract relevant keywords for your content.', '1platform-content-ai' ); ?></span>
 					</div>
 
 					<div class="contai-form-group">
@@ -190,7 +223,7 @@ function contai_render_full_site_generator_form() {
 
 					<div class="contai-form-group">
 						<label for="contai_image_provider" class="contai-label">
-							<?php esc_html_e( 'Image Provider', '1platform-content-ai' ); ?>
+							<?php esc_html_e( 'Image Source', '1platform-content-ai' ); ?>
 							<span class="contai-required">*</span>
 						</label>
 						<select id="contai_image_provider" name="contai_image_provider" class="contai-select" autocomplete="off" required>
@@ -205,19 +238,22 @@ function contai_render_full_site_generator_form() {
 		<!-- Submit Section -->
 		<div class="contai-wizard-section contai-wizard-submit">
 			<div class="contai-section-body">
-				<div class="contai-notice contai-notice-info">
-					<span class="dashicons dashicons-clock"></span>
-					<div>
-						<strong><?php esc_html_e( 'Background Process', '1platform-content-ai' ); ?></strong>
-						<p><?php esc_html_e( 'This process runs in the background and may take several hours depending on the number of posts. You can safely close this page and check back later.', '1platform-content-ai' ); ?></p>
+				<div class="contai-launch-card">
+					<div class="contai-launch-info">
+						<div class="contai-launch-icon">
+							<span class="dashicons dashicons-clock"></span>
+						</div>
+						<div class="contai-launch-text">
+							<strong><?php esc_html_e( 'Background Process', '1platform-content-ai' ); ?></strong>
+							<p><?php esc_html_e( 'Generation runs in the background. You can safely close this page and check progress later.', '1platform-content-ai' ); ?></p>
+						</div>
 					</div>
-				</div>
-
-				<div class="contai-submit-area">
-					<button type="submit" id="contai_submit_btn" class="contai-btn contai-btn-primary contai-btn-lg">
-						<span class="dashicons dashicons-controls-play"></span>
-						<?php esc_html_e( 'Start Site Generation', '1platform-content-ai' ); ?>
-					</button>
+					<div class="contai-submit-area">
+						<button type="submit" id="contai_submit_btn" class="contai-btn contai-btn-primary contai-btn-lg">
+							<span class="dashicons dashicons-controls-play"></span>
+							<?php esc_html_e( 'Launch Site Generation', '1platform-content-ai' ); ?>
+						</button>
+					</div>
 				</div>
 			</div>
 		</div>

--- a/includes/admin/assets/css/admin-ai-site-generator.css
+++ b/includes/admin/assets/css/admin-ai-site-generator.css
@@ -1,11 +1,12 @@
 /* ========================================================
-   Site Wizard - Modern Admin UI
+   Site Wizard — Refined Admin UI
+   Design: Precision minimalism with connected timeline
    ======================================================== */
 
 /* -- Wizard Wrapper -- */
 .contai-wizard-wrap {
-    max-width: 960px;
-    margin: 20px auto 40px;
+    max-width: 860px;
+    margin: 24px auto 48px;
     padding: 0;
     background: transparent;
     border: none;
@@ -15,9 +16,9 @@
 
 /* -- Hero Header -- */
 .contai-wizard-header {
-    background: linear-gradient(135deg, #1e3a5f 0%, var(--contai-primary) 50%, var(--contai-primary-light) 100%);
+    background: linear-gradient(135deg, #0f172a 0%, #1e3a5f 40%, var(--contai-primary) 100%);
     border-radius: var(--contai-radius-lg) var(--contai-radius-lg) 0 0;
-    padding: 32px 36px;
+    padding: 36px 40px;
     margin-bottom: 0;
     position: relative;
     overflow: hidden;
@@ -26,24 +27,18 @@
 .contai-wizard-header::before {
     content: '';
     position: absolute;
-    top: -40%;
-    right: -10%;
-    width: 300px;
-    height: 300px;
-    background: radial-gradient(circle, rgba(255,255,255,0.08) 0%, transparent 70%);
-    border-radius: 50%;
+    inset: 0;
+    background:
+        radial-gradient(ellipse 600px 400px at 80% 20%, rgba(59, 130, 246, 0.2) 0%, transparent 70%),
+        radial-gradient(ellipse 300px 300px at 20% 80%, rgba(37, 99, 235, 0.1) 0%, transparent 70%);
     pointer-events: none;
 }
 
 .contai-wizard-header::after {
     content: '';
     position: absolute;
-    bottom: -60%;
-    left: 20%;
-    width: 200px;
-    height: 200px;
-    background: radial-gradient(circle, rgba(255,255,255,0.05) 0%, transparent 70%);
-    border-radius: 50%;
+    inset: 0;
+    background: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.03'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
     pointer-events: none;
 }
 
@@ -56,124 +51,168 @@
 }
 
 .contai-wizard-icon {
-    width: 56px;
-    height: 56px;
-    background: rgba(255, 255, 255, 0.15);
-    border-radius: 14px;
+    width: 52px;
+    height: 52px;
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: var(--contai-radius-lg);
     display: flex;
     align-items: center;
     justify-content: center;
     flex-shrink: 0;
-    backdrop-filter: blur(10px);
-    border: 1px solid rgba(255, 255, 255, 0.2);
+    backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.15);
 }
 
 .contai-wizard-icon .dashicons {
-    font-size: 28px;
-    width: 28px;
-    height: 28px;
+    font-size: 26px;
+    width: 26px;
+    height: 26px;
     color: #fff;
 }
 
 .contai-wizard-header-text h1 {
-    margin: 0 0 6px 0;
-    font-size: 26px;
+    margin: 0 0 4px 0;
+    font-size: 22px;
     font-weight: 700;
     color: #fff;
-    letter-spacing: -0.3px;
+    letter-spacing: -0.4px;
     line-height: 1.2;
     padding: 0;
 }
 
 .contai-wizard-header-text p {
     margin: 0;
-    color: rgba(255, 255, 255, 0.85);
-    font-size: 14px;
+    color: rgba(255, 255, 255, 0.7);
+    font-size: 13.5px;
     line-height: 1.5;
-    max-width: 520px;
+    max-width: 480px;
 }
 
 /* -- Form Container -- */
 .contai-site-generator-form {
-    background: var(--contai-neutral-100);
+    background: var(--contai-neutral-50);
     border-radius: 0 0 var(--contai-radius-lg) var(--contai-radius-lg);
-    padding: 28px;
+    padding: 32px;
     display: flex;
     flex-direction: column;
-    gap: 24px;
+    gap: 0;
 }
 
 /* -- Wizard Section Cards -- */
 .contai-wizard-section {
     background: #fff;
-    border-radius: var(--contai-radius-md);
+    border-radius: var(--contai-radius-lg);
     border: 1px solid var(--contai-neutral-200);
     overflow: hidden;
-    transition: box-shadow var(--contai-duration-fast) ease;
+    transition: border-color var(--contai-duration-fast) ease,
+                box-shadow var(--contai-duration-fast) ease;
+    margin-bottom: 0;
+    position: relative;
+}
+
+.contai-wizard-section:not(.contai-wizard-submit) {
+    margin-bottom: 24px;
 }
 
 .contai-wizard-section:hover {
+    border-color: var(--contai-neutral-300);
     box-shadow: var(--contai-shadow-sm);
 }
 
-/* -- Section Header with Step Indicator -- */
+.contai-wizard-section:focus-within {
+    border-color: var(--contai-primary-border);
+    box-shadow: 0 0 0 3px var(--contai-primary-glow), var(--contai-shadow-sm);
+}
+
+/* -- Section Header with Timeline -- */
 .contai-section-header {
     display: flex;
     align-items: flex-start;
     gap: 16px;
-    padding: 20px 24px;
-    border-bottom: 1px solid var(--contai-neutral-200);
-    background: var(--contai-neutral-50);
+    padding: 20px 24px 16px;
+    background: #fff;
+    border-bottom: none;
 }
 
 .contai-step-indicator {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
     flex-shrink: 0;
+    gap: 0;
 }
 
 .contai-step-number {
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 36px;
-    height: 36px;
-    background: linear-gradient(135deg, var(--contai-primary), var(--contai-primary-dark));
+    width: 32px;
+    height: 32px;
+    background: var(--contai-primary);
     color: #fff;
-    border-radius: var(--contai-radius-md);
-    font-size: 15px;
+    border-radius: 50%;
+    font-size: 13px;
     font-weight: 700;
     line-height: 1;
+    position: relative;
+    z-index: 1;
+    box-shadow: 0 0 0 4px var(--contai-primary-glow);
+}
+
+.contai-step-line {
+    display: block;
+    width: 2px;
+    height: 16px;
+    background: var(--contai-neutral-200);
+    margin-top: 4px;
 }
 
 .contai-section-title-group {
     flex: 1;
     min-width: 0;
-    padding-top: 2px;
+    padding-top: 4px;
 }
 
 .contai-section-title {
-    margin: 0 0 4px 0;
-    font-size: 17px;
-    font-weight: 600;
+    margin: 0 0 2px 0;
+    font-size: 15px;
+    font-weight: 650;
     color: var(--contai-neutral-700);
     line-height: 1.3;
+    letter-spacing: -0.2px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.contai-section-icon {
+    font-size: 17px;
+    width: 17px;
+    height: 17px;
+    color: var(--contai-primary);
+    opacity: 0.85;
 }
 
 .contai-section-description {
     margin: 0;
-    color: var(--contai-neutral-500);
-    font-size: 13px;
+    color: var(--contai-neutral-400);
+    font-size: 12.5px;
     line-height: 1.5;
 }
 
 /* -- Section Body -- */
 .contai-section-body {
-    padding: 24px;
+    padding: 4px 24px 24px;
 }
 
 /* -- Form Grid -- */
 .contai-form-grid {
     display: grid;
-    gap: 20px;
+    gap: 18px;
+}
+
+.contai-grid-2 {
+    grid-template-columns: repeat(2, 1fr);
 }
 
 .contai-grid-3 {
@@ -188,13 +227,6 @@
     grid-column: span 2;
 }
 
-/* -- Form Divider -- */
-.contai-form-divider {
-    height: 1px;
-    background: var(--contai-neutral-200);
-    margin: 8px 0;
-}
-
 /* -- Form Group -- */
 .contai-form-group {
     display: flex;
@@ -205,71 +237,117 @@
     display: flex;
     align-items: center;
     gap: 4px;
-    font-weight: 600;
-    font-size: 13px;
+    font-weight: 550;
+    font-size: 12.5px;
     margin-bottom: 6px;
-    color: var(--contai-neutral-700);
+    color: var(--contai-neutral-600);
     line-height: 1.4;
+    letter-spacing: 0.01em;
+    text-transform: uppercase;
 }
 
 .contai-required {
     color: var(--contai-error);
     font-weight: 700;
-    font-size: 14px;
+    font-size: 13px;
+}
+
+/* -- Input Wrapper with Icon -- */
+.contai-input-wrap {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.contai-input-icon > .dashicons {
+    position: absolute;
+    left: 12px;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+    color: var(--contai-neutral-400);
+    pointer-events: none;
+    transition: color var(--contai-duration-fast) ease;
+    z-index: 1;
+}
+
+.contai-input-icon > .contai-input {
+    padding-left: 38px;
+}
+
+.contai-input-icon:focus-within > .dashicons {
+    color: var(--contai-primary);
 }
 
 /* -- Inputs & Selects -- */
 .contai-input,
 .contai-select {
     width: 100%;
-    padding: 10px 14px;
-    border: 1.5px solid var(--contai-neutral-300);
-    border-radius: var(--contai-radius-lg);
-    font-size: 14px;
+    padding: 9px 13px;
+    border: 1.5px solid var(--contai-neutral-200);
+    border-radius: var(--contai-radius-md);
+    font-size: 13.5px;
     font-family: inherit;
     color: var(--contai-neutral-700);
-    background: #fff;
-    transition: border-color var(--contai-duration-fast) ease, box-shadow var(--contai-duration-fast) ease;
+    background: var(--contai-neutral-50);
+    transition: border-color var(--contai-duration-fast) ease,
+                box-shadow var(--contai-duration-fast) ease,
+                background-color var(--contai-duration-fast) ease;
     -webkit-appearance: none;
     appearance: none;
     box-sizing: border-box;
+    line-height: 1.5;
 }
 
 .contai-select {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23646970' d='M6 8.825L1.175 4 2.238 2.938 6 6.7l3.763-3.763L10.825 4z'/%3E%3C/svg%3E");
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%2394a3b8' d='M6 8.825L1.175 4 2.238 2.938 6 6.7l3.763-3.763L10.825 4z'/%3E%3C/svg%3E");
     background-repeat: no-repeat;
-    background-position: right 14px center;
+    background-position: right 12px center;
     background-size: 12px;
-    padding-right: 36px;
+    background-color: var(--contai-neutral-50);
+    padding-right: 34px;
     cursor: pointer;
 }
 
 .contai-input::placeholder {
     color: var(--contai-neutral-400);
+    font-weight: 400;
 }
 
 .contai-input:hover,
 .contai-select:hover {
-    border-color: var(--contai-neutral-400);
+    border-color: var(--contai-neutral-300);
+    background: #fff;
 }
 
 .contai-input:focus,
 .contai-select:focus {
     outline: none;
     border-color: var(--contai-primary);
+    background: #fff;
     box-shadow: 0 0 0 3px var(--contai-primary-glow);
+}
+
+/* Number input refinement */
+.contai-input[type="number"] {
+    font-variant-numeric: tabular-nums;
+    font-family: var(--contai-font-mono);
+    font-size: 13px;
+    letter-spacing: -0.01em;
 }
 
 /* -- Input Error State -- */
 .contai-input-error {
     border-color: var(--contai-error) !important;
-    box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.1) !important;
+    box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.08) !important;
 }
 
 .contai-field-error {
     display: block;
     color: var(--contai-error);
-    font-size: 12px;
+    font-size: 11.5px;
     margin-top: 5px;
     font-weight: 500;
     line-height: 1.4;
@@ -278,13 +356,177 @@
 /* -- Help Text -- */
 .contai-help-text {
     display: block;
-    color: var(--contai-neutral-500);
-    font-size: 12px;
-    margin-top: 6px;
+    color: var(--contai-neutral-400);
+    font-size: 11.5px;
+    margin-top: 5px;
     line-height: 1.5;
 }
 
-/* -- Info Notice -- */
+/* -- Launch Card (Submit Section) -- */
+.contai-wizard-submit {
+    border: none;
+    background: transparent;
+    box-shadow: none !important;
+    margin-top: 4px;
+}
+
+.contai-wizard-submit:hover {
+    box-shadow: none !important;
+    border-color: transparent !important;
+}
+
+.contai-wizard-submit:focus-within {
+    box-shadow: none !important;
+    border-color: transparent !important;
+}
+
+.contai-wizard-submit .contai-section-body {
+    padding: 0;
+}
+
+.contai-launch-card {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 24px;
+    padding: 20px 24px;
+    background: linear-gradient(135deg, var(--contai-neutral-700) 0%, #1e3a5f 100%);
+    border-radius: var(--contai-radius-lg);
+    position: relative;
+    overflow: hidden;
+}
+
+.contai-launch-card::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background:
+        radial-gradient(ellipse 300px 200px at 90% 50%, rgba(37, 99, 235, 0.15) 0%, transparent 70%);
+    pointer-events: none;
+}
+
+.contai-launch-info {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    position: relative;
+    z-index: 1;
+    flex: 1;
+    min-width: 0;
+}
+
+.contai-launch-icon {
+    width: 40px;
+    height: 40px;
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.contai-launch-icon .dashicons {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.contai-launch-text {
+    flex: 1;
+    min-width: 0;
+}
+
+.contai-launch-text strong {
+    display: block;
+    color: #fff;
+    font-size: 13px;
+    font-weight: 600;
+    margin-bottom: 1px;
+}
+
+.contai-launch-text p {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.55);
+    font-size: 12px;
+    line-height: 1.5;
+}
+
+.contai-launch-card .contai-submit-area {
+    position: relative;
+    z-index: 1;
+    flex-shrink: 0;
+}
+
+/* -- Buttons -- */
+.contai-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 10px 24px;
+    font-size: 13px;
+    font-weight: 600;
+    font-family: inherit;
+    border: none;
+    border-radius: var(--contai-radius-md);
+    cursor: pointer;
+    transition: all var(--contai-duration-fast) var(--contai-ease);
+    line-height: 1;
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.contai-btn .dashicons {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+}
+
+.contai-btn-primary {
+    background: #fff;
+    color: var(--contai-neutral-700);
+    box-shadow: var(--contai-shadow-sm);
+}
+
+.contai-btn-primary:hover {
+    background: #fff;
+    color: var(--contai-primary);
+    box-shadow: var(--contai-shadow-md), 0 0 0 1px rgba(255, 255, 255, 0.1);
+    transform: translateY(-1px);
+}
+
+.contai-btn-primary:active {
+    transform: translateY(0);
+    box-shadow: var(--contai-shadow-xs);
+}
+
+.contai-btn-lg {
+    padding: 12px 28px;
+    font-size: 13.5px;
+    border-radius: var(--contai-radius-md);
+}
+
+.contai-btn:disabled,
+.contai-btn-loading {
+    opacity: 0.7;
+    cursor: not-allowed;
+    transform: none !important;
+}
+
+/* -- Spinner -- */
+.contai-spinning {
+    animation: contai-spin 1s linear infinite;
+}
+
+@keyframes contai-spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+/* -- Legacy Notice (keep for backward compat) -- */
 .contai-notice {
     display: flex;
     align-items: flex-start;
@@ -320,91 +562,6 @@
     color: var(--contai-neutral-600);
     font-size: 13px;
     line-height: 1.5;
-}
-
-/* -- Submit Area -- */
-.contai-submit-area {
-    display: flex;
-    justify-content: flex-end;
-}
-
-/* -- Buttons -- */
-.contai-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-    padding: 12px 28px;
-    font-size: 14px;
-    font-weight: 600;
-    font-family: inherit;
-    border: none;
-    border-radius: var(--contai-radius-lg);
-    cursor: pointer;
-    transition: all var(--contai-duration-fast) ease;
-    line-height: 1;
-    text-decoration: none;
-}
-
-.contai-btn .dashicons {
-    font-size: 18px;
-    width: 18px;
-    height: 18px;
-}
-
-.contai-btn-primary {
-    background: linear-gradient(135deg, var(--contai-primary), var(--contai-primary-dark));
-    color: #fff;
-    box-shadow: var(--contai-shadow-md);
-}
-
-.contai-btn-primary:hover {
-    background: linear-gradient(135deg, var(--contai-primary-dark), var(--contai-primary-darker));
-    box-shadow: var(--contai-shadow-lg);
-    color: #fff;
-    transform: translateY(-1px);
-}
-
-.contai-btn-primary:active {
-    transform: translateY(0);
-    box-shadow: var(--contai-shadow-sm);
-}
-
-.contai-btn-lg {
-    padding: 14px 36px;
-    font-size: 15px;
-}
-
-.contai-btn:disabled,
-.contai-btn-loading {
-    opacity: 0.75;
-    cursor: not-allowed;
-    transform: none !important;
-}
-
-/* -- Spinner -- */
-.contai-spinning {
-    animation: contai-spin 1s linear infinite;
-}
-
-@keyframes contai-spin {
-    from { transform: rotate(0deg); }
-    to { transform: rotate(360deg); }
-}
-
-/* -- Submit Section Override -- */
-.contai-wizard-submit {
-    border: none;
-    background: transparent;
-    box-shadow: none;
-}
-
-.contai-wizard-submit:hover {
-    box-shadow: none;
-}
-
-.contai-wizard-submit .contai-section-body {
-    padding: 0;
 }
 
 /* -- Progress Section (Active Job) -- */
@@ -449,9 +606,9 @@
 
 .contai-progress-bar {
     width: 100%;
-    height: 12px;
+    height: 10px;
     background-color: var(--contai-neutral-200);
-    border-radius: var(--contai-radius-md);
+    border-radius: var(--contai-radius-pill);
     overflow: hidden;
     margin-bottom: 10px;
 }
@@ -459,15 +616,16 @@
 .contai-progress-fill {
     height: 100%;
     background: linear-gradient(90deg, var(--contai-primary), var(--contai-primary-light));
-    border-radius: var(--contai-radius-md);
-    transition: width 0.3s ease;
+    border-radius: var(--contai-radius-pill);
+    transition: width 0.4s var(--contai-ease);
 }
 
 .contai-progress-text {
     text-align: center;
     font-weight: 600;
-    font-size: 14px;
+    font-size: 13px;
     color: var(--contai-neutral-700);
+    font-variant-numeric: tabular-nums;
 }
 
 .contai-current-step,
@@ -483,11 +641,11 @@
 .contai-status-badge {
     display: inline-block;
     padding: 3px 10px;
-    border-radius: 20px;
+    border-radius: var(--contai-radius-pill);
     font-weight: 600;
     text-transform: uppercase;
-    font-size: 11px;
-    letter-spacing: 0.3px;
+    font-size: 10.5px;
+    letter-spacing: 0.4px;
 }
 
 .contai-status-pending {
@@ -516,9 +674,11 @@
 
 .contai-completed-steps h3 {
     margin: 0 0 12px;
-    font-size: 14px;
+    font-size: 13px;
     font-weight: 600;
     color: var(--contai-neutral-700);
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
 }
 
 .contai-completed-steps ul {
@@ -542,7 +702,7 @@
 }
 
 .contai-completed-steps li .dashicons {
-    color: #00a32a;
+    color: var(--contai-success);
     font-size: 18px;
     width: 18px;
     height: 18px;
@@ -561,7 +721,7 @@
     padding: 10px 20px;
     background: linear-gradient(135deg, var(--contai-primary), var(--contai-primary-dark));
     border: none;
-    border-radius: var(--contai-radius-lg);
+    border-radius: var(--contai-radius-md);
     color: #fff;
     font-size: 13px;
     font-weight: 600;
@@ -659,6 +819,7 @@
         margin: 10px 0 30px;
     }
 
+    .contai-grid-2,
     .contai-grid-3 {
         grid-template-columns: repeat(2, 1fr);
     }
@@ -669,6 +830,21 @@
 
     .contai-span-2 {
         grid-column: 1 / -1;
+    }
+
+    .contai-launch-card {
+        flex-direction: column;
+        align-items: stretch;
+        text-align: center;
+    }
+
+    .contai-launch-info {
+        flex-direction: column;
+    }
+
+    .contai-submit-area {
+        display: flex;
+        justify-content: center;
     }
 }
 
@@ -689,7 +865,7 @@
     }
 
     .contai-wizard-header-text h1 {
-        font-size: 22px;
+        font-size: 20px;
     }
 
     .contai-wizard-header-text p {
@@ -699,21 +875,21 @@
     .contai-site-generator-form {
         border-radius: 0;
         padding: 16px;
-        gap: 16px;
     }
 
-    .contai-wizard-section {
-        border-radius: var(--contai-radius-lg);
+    .contai-wizard-section:not(.contai-wizard-submit) {
+        margin-bottom: 16px;
     }
 
     .contai-section-header {
-        padding: 16px;
+        padding: 16px 16px 12px;
     }
 
     .contai-section-body {
-        padding: 16px;
+        padding: 4px 16px 16px;
     }
 
+    .contai-grid-2,
     .contai-grid-3 {
         grid-template-columns: 1fr;
     }
@@ -725,14 +901,34 @@
     .contai-input,
     .contai-select {
         font-size: 16px;
-        padding: 12px 14px;
+        padding: 11px 13px;
     }
 
-    .contai-submit-area {
-        justify-content: stretch;
+    .contai-input-icon > .contai-input {
+        padding-left: 38px;
     }
 
     .contai-btn-lg {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .contai-launch-card {
+        padding: 16px;
+        flex-direction: column;
+        gap: 16px;
+    }
+
+    .contai-launch-info {
+        flex-direction: column;
+        text-align: center;
+    }
+
+    .contai-submit-area {
+        display: flex;
+    }
+
+    .contai-submit-area .contai-btn {
         width: 100%;
     }
 }

--- a/includes/admin/content-generator/handlers/KeywordExtractionHandler.php
+++ b/includes/admin/content-generator/handlers/KeywordExtractionHandler.php
@@ -99,9 +99,9 @@ class ContaiKeywordExtractionHandler {
         }
 
         $payload = [
-            'domain' => $validation['domain'],
+            'topic' => $validation['topic'],
             'country' => $validation['country'],
-            'lang' => $validation['lang']
+            'lang' => $validation['lang'],
         ];
 
         $job = ContaiJob::create(
@@ -122,55 +122,42 @@ class ContaiKeywordExtractionHandler {
         return [
             'success' => true,
             'message' => sprintf(
-                /* translators: %s: domain name for keyword extraction */
-                __('Keyword extraction job has been queued. Domain: %s. You can check the Keywords List page for results.', '1platform-content-ai'),
-                $validation['domain']
+                /* translators: %s: topic name for keyword extraction */
+                __('Keyword extraction job has been queued for: %s. You can check the Keywords List page for results.', '1platform-content-ai'),
+                $validation['topic']
             )
         ];
     }
 
     private function validateExtractionRequest(): array {
         // phpcs:disable WordPress.Security.NonceVerification.Missing -- Nonce verified in handleRequest() via verifyNonce().
-        $domain = esc_url_raw(wp_unslash($_POST['contai_source_url'] ?? ''));
+        $topic = sanitize_text_field(wp_unslash($_POST['contai_topic'] ?? ''));
         $country = sanitize_text_field(wp_unslash($_POST['contai_country'] ?? ''));
         $lang = sanitize_text_field(wp_unslash($_POST['contai_target_language'] ?? ''));
         // phpcs:enable WordPress.Security.NonceVerification.Missing
 
-        if (empty($domain) || empty($country) || empty($lang)) {
-            return [
-                'valid' => false,
-                'message' => __('Please fill in all required fields.', '1platform-content-ai')
-            ];
+        if (empty($topic)) {
+            return ['valid' => false, 'message' => __('Please enter a topic for keyword discovery.', '1platform-content-ai')];
         }
-
-        if (!filter_var($domain, FILTER_VALIDATE_URL)) {
-            return [
-                'valid' => false,
-                'message' => __('Please enter a valid URL.', '1platform-content-ai')
-            ];
+        if (mb_strlen($topic) < 3 || mb_strlen($topic) > 200) {
+            return ['valid' => false, 'message' => __('Topic must be between 3 and 200 characters.', '1platform-content-ai')];
         }
 
         $validLanguages = ['en', 'es'];
         if (!in_array($lang, $validLanguages, true)) {
-            return [
-                'valid' => false,
-                'message' => __('Invalid language selected.', '1platform-content-ai')
-            ];
+            return ['valid' => false, 'message' => __('Invalid language selected.', '1platform-content-ai')];
         }
 
         $validCountries = ['us', 'es'];
         if (!in_array($country, $validCountries, true)) {
-            return [
-                'valid' => false,
-                'message' => __('Invalid country selected.', '1platform-content-ai')
-            ];
+            return ['valid' => false, 'message' => __('Invalid country selected.', '1platform-content-ai')];
         }
 
         return [
             'valid' => true,
-            'domain' => $domain,
+            'topic' => $topic,
             'country' => $country,
-            'lang' => $lang
+            'lang' => $lang,
         ];
     }
 

--- a/includes/admin/content-generator/panels/keyword-extractor.php
+++ b/includes/admin/content-generator/panels/keyword-extractor.php
@@ -23,19 +23,20 @@ class ContaiKeywordExtractorPanel {
                 <form method="post" action="<?php echo esc_url( admin_url( 'admin.php?page=contai-content-generator&section=keyword-extractor' ) ); ?>" class="contai-keyword-form">
                     <div class="contai-form-grid contai-grid-2">
                         <div class="contai-form-group">
-                            <label for="contai_source_url" class="contai-label">
-                                <span class="dashicons dashicons-admin-site-alt3"></span>
-                                <?php esc_html_e('Source Website', '1platform-content-ai'); ?>
+                            <label for="contai_topic" class="contai-label">
+                                <span class="dashicons dashicons-lightbulb"></span>
+                                <?php esc_html_e('Topic / Theme', '1platform-content-ai'); ?>
                             </label>
-                            <input type="url" id="contai_source_url" name="contai_source_url" required
-                                   class="contai-input"
-                                   placeholder="https://example.com"
+                            <input type="text" id="contai_topic" name="contai_topic"
+                                   class="contai-input" required
+                                   placeholder="<?php esc_attr_e('e.g. plantas de interior, salud medioambiental', '1platform-content-ai'); ?>"
+                                   minlength="3" maxlength="200"
                                    value="<?php
                                    // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Repopulating form field after submission; value is sanitized and escaped.
-                                   echo isset($_POST['contai_source_url']) ? esc_attr( sanitize_text_field( wp_unslash( $_POST['contai_source_url'] ) ) ) : ''; ?>">
+                                   echo isset($_POST['contai_topic']) ? esc_attr( sanitize_text_field( wp_unslash( $_POST['contai_topic'] ) ) ) : ''; ?>">
                             <p class="contai-help-text">
                                 <span class="dashicons dashicons-info"></span>
-                                <?php esc_html_e('Enter the competitor website URL to analyze', '1platform-content-ai'); ?>
+                                <?php esc_html_e('Enter a topic or theme to discover keywords from Google (2-4 words work best)', '1platform-content-ai'); ?>
                             </p>
                         </div>
 
@@ -198,7 +199,7 @@ class ContaiKeywordExtractorPanel {
         <table class="contai-table contai-processing-table">
             <thead>
                 <tr>
-                    <th><?php esc_html_e('Domain', '1platform-content-ai'); ?></th>
+                    <th><?php esc_html_e('Topic', '1platform-content-ai'); ?></th>
                     <th><?php esc_html_e('Country', '1platform-content-ai'); ?></th>
                     <th><?php esc_html_e('Language', '1platform-content-ai'); ?></th>
                     <th><?php esc_html_e('Processing Time', '1platform-content-ai'); ?></th>
@@ -214,14 +215,14 @@ class ContaiKeywordExtractorPanel {
     }
 
     private function renderJobRow(array $job): void {
-        $payload = json_decode($job['payload'], true);
-        $domain = $payload['domain'] ?? __('Unknown', '1platform-content-ai');
+        $payload = json_decode($job['payload'], true) ?? [];
+        $topic = $payload['topic'] ?? $payload['domain'] ?? __('Unknown', '1platform-content-ai');
         $country = strtoupper($payload['country'] ?? 'N/A');
         $lang = strtoupper($payload['lang'] ?? 'N/A');
         $elapsed = $this->calculateElapsedTime($job['processed_at']);
         ?>
         <tr>
-            <td><strong><?php echo esc_html($domain); ?></strong></td>
+            <td><strong><?php echo esc_html($topic); ?></strong></td>
             <td><?php echo esc_html($country); ?></td>
             <td><?php echo esc_html($lang); ?></td>
             <td>
@@ -233,10 +234,16 @@ class ContaiKeywordExtractorPanel {
         <?php
     }
 
-    private function calculateElapsedTime(string $processedAt): string {
-        $now = current_time('timestamp');
+    private function calculateElapsedTime(?string $processedAt): string {
+        if (empty($processedAt)) {
+            return __('Just started', '1platform-content-ai');
+        }
         $processed = strtotime($processedAt);
-        $diff = $now - $processed;
+        if ($processed === false) {
+            return __('Unknown', '1platform-content-ai');
+        }
+        $now = time();
+        $diff = max(0, $now - $processed);
 
         $minutes = floor($diff / 60);
         $seconds = $diff % 60;

--- a/includes/services/api/OnePlatformEndpoints.php
+++ b/includes/services/api/OnePlatformEndpoints.php
@@ -52,6 +52,7 @@ class ContaiOnePlatformEndpoints {
 
     // ── Content Generation ──────────────────────────────────────
     const POSTS_KEYWORDS = '/posts/keywords/';
+    const POSTS_KEYWORDS_TOPIC = '/posts/keywords/topic/';
     const POSTS_CONTENT = '/posts/content/';
     const POSTS_CONTENT_JOBS = '/posts/content/jobs/';
     const POSTS_INDEXING = '/posts/indexing/';

--- a/includes/services/jobs/KeywordExtractionJob.php
+++ b/includes/services/jobs/KeywordExtractionJob.php
@@ -18,18 +18,24 @@ class ContaiKeywordExtractionJob implements ContaiJobInterface
 
     public function handle(array $payload)
     {
+        $topic = $payload['topic'] ?? '';
         $domain = $payload['domain'] ?? '';
         $country = $payload['country'] ?? '';
         $lang = $payload['lang'] ?? '';
 
-        if (empty($domain) || empty($country) || empty($lang)) {
+        // Support both topic-based (new) and domain-based (legacy) payloads
+        $source = !empty($topic) ? $topic : $domain;
+
+        if (empty($source) || empty($country) || empty($lang)) {
             return [
                 'success' => false,
-                'error' => 'Missing required parameters: domain, country, or lang'
+                'error' => 'Missing required parameters: topic/domain, country, or lang'
             ];
         }
 
-        $result = $this->extractor_service->extractAndSaveKeywords($domain, $country, $lang);
+        $result = !empty($topic)
+            ? $this->extractor_service->extractByTopicAndSave($topic, $country, $lang)
+            : $this->extractor_service->extractAndSaveKeywords($domain, $country, $lang);
 
         if ($result->isSuccess()) {
             return [
@@ -37,14 +43,14 @@ class ContaiKeywordExtractionJob implements ContaiJobInterface
                 'saved_count' => $result->getSavedCount(),
                 'skipped_count' => $result->getSkippedCount(),
                 'total_count' => $result->getTotalCount(),
-                'domain' => $domain
+                'source' => $source,
             ];
         }
 
         return [
             'success' => false,
             'error' => $result->getErrorMessage(),
-            'domain' => $domain
+            'source' => $source,
         ];
     }
 

--- a/includes/services/jobs/SiteGenerationJob.php
+++ b/includes/services/jobs/SiteGenerationJob.php
@@ -202,11 +202,11 @@ class ContaiSiteGenerationJob implements ContaiJobInterface
     {
         $service = ContaiKeywordExtractorService::create();
 
-        $domain = $extractionConfig['source_url'] ?? '';
+        $topic = $extractionConfig['source_topic'] ?? '';
         $country = $extractionConfig['target_country'] ?? 'us';
         $lang = $extractionConfig['target_language'] ?? 'en';
 
-        $result = $service->extractAndSaveKeywords($domain, $country, $lang);
+        $result = $service->extractByTopicAndSave($topic, $country, $lang);
 
         if (!$result->isSuccess()) {
             // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped

--- a/includes/services/keyword/KeywordExtractorService.php
+++ b/includes/services/keyword/KeywordExtractorService.php
@@ -56,6 +56,22 @@ class ContaiKeywordExtractorService {
         return $this->processAndSaveKeywords($response);
     }
 
+    public function extractByTopicAndSave(
+        string $topic,
+        string $country,
+        string $lang
+    ): ContaiKeywordExtractionResult {
+        $response = $this->requestKeywordExtractionByTopic($topic, $country, $lang);
+
+        if (!$response->isSuccess()) {
+            return ContaiKeywordExtractionResult::failure(
+                $response->getMessage() ?? self::ERROR_API_REQUEST_FAILED
+            );
+        }
+
+        return $this->processAndSaveKeywords($response);
+    }
+
     private function requestKeywordExtraction(
         string $domain,
         string $country,
@@ -68,6 +84,20 @@ class ContaiKeywordExtractorService {
         ];
 
         return $this->client->post(ContaiOnePlatformEndpoints::POSTS_KEYWORDS, $request_data);
+    }
+
+    private function requestKeywordExtractionByTopic(
+        string $topic,
+        string $country,
+        string $lang
+    ): ContaiOnePlatformResponse {
+        $request_data = [
+            'topic' => $topic,
+            'country' => $country,
+            'lang' => $lang,
+        ];
+
+        return $this->client->post(ContaiOnePlatformEndpoints::POSTS_KEYWORDS_TOPIC, $request_data);
     }
 
     private function processAndSaveKeywords(ContaiOnePlatformResponse $response): ContaiKeywordExtractionResult {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai content, seo, content generation, internal links, table of contents
 Requires at least: 5.9
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.7.0
+Stable tag: 2.8.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Summary

- **Topic-based keyword extraction** replacing domain URL input — uses new API endpoint `POST /posts/keywords/topic/`
- **Site Generator redesign**: source URL field replaced with topic/theme field, CSS overhaul
- **AdSense publisher ID fix**: saved immediately on form submit (#12)
- **Version bump** to `2.8.0`

### Changed files (11)

| File | Change |
|---|---|
| `KeywordExtractorService.php` | New `extractByTopicAndSave()` + `requestKeywordExtractionByTopic()` |
| `OnePlatformEndpoints.php` | Added `POSTS_KEYWORDS_TOPIC` constant |
| `KeywordExtractionHandler.php` | Validates topic (3-200 chars) instead of URL |
| `KeywordExtractionJob.php` | Uses topic-based extraction |
| `SiteGenerationJob.php` | `source_url` → `source_topic` |
| `keyword-extractor.php` | Topic input replaces URL input |
| `admin-ai-site-generator.php` | Topic field, AdSense early save, remove urlencode |
| `site-generator-form.php` | Redesigned form layout |
| `admin-ai-site-generator.css` | Full CSS overhaul |

### Depends on
- API PR merged: `1platform-api` PR #38 (`POST /posts/keywords/topic/` endpoint)

## Test plan
- [ ] Keyword Extractor: enter a topic → verify keywords are returned
- [ ] Site Generator: enter topic + select category → verify full pipeline runs
- [ ] AdSense publisher ID appears in Ads Manager immediately after form submit
- [ ] Verify error messages display correctly (no double encoding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)