### PR TITLE
fix(site-wizard): wrap setupAdsManager in try/catch to prevent job crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Content AI are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.9.1] - 2026-03-25
+
+### Fixed
+
+- **`SiteGenerationJob::setupAdsManager`**: Wrapped in try/catch to prevent AdSense setup failures from crashing the entire site generation job — now logs the error and continues, consistent with other optional steps (#13)
+- **Null coalescing fallback**: Added `$config['adsense']['publisher_id'] ?? ''` to prevent `TypeError` when the `adsense` key is missing from the payload
+
 ## [2.9.0] - 2026-03-25
 
 ### Changed

--- a/includes/services/jobs/SiteGenerationJob.php
+++ b/includes/services/jobs/SiteGenerationJob.php
@@ -142,7 +142,11 @@ class ContaiSiteGenerationJob implements ContaiJobInterface
                 break;
 
             case 'setupAdsManager':
-                $this->setupAdsManager($config['adsense']['publisher_id']);
+                try {
+                    $this->setupAdsManager($config['adsense']['publisher_id'] ?? '');
+                } catch (Exception $e) {
+                    contai_log("Optional step 'setupAdsManager' failed: " . $e->getMessage()); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+                }
                 break;
         }
         return $payload;


### PR DESCRIPTION
## Summary

- Wrapped `setupAdsManager` case in try/catch with `contai_log()`, consistent with `generateComments` and `setupSearchConsole` optional steps
- Added null coalescing fallback `$config['adsense']['publisher_id'] ?? ''` to prevent `TypeError` when the `adsense` key is missing

Closes #13

## Test plan

- [ ] Trigger site generation with a valid AdSense publisher ID — verify ads setup completes normally
- [ ] Trigger site generation with an empty/invalid publisher ID — verify job completes and error is logged
- [ ] Trigger site generation without the `adsense` key in config — verify no `TypeError` and job continues

🤖 Generated with [Claude Code](https://claude.com/claude-code)