### PR TITLE
fix(auth): clear stale token errors when connection is healthy

### DIFF
--- a/1platform-content-ai.php
+++ b/1platform-content-ai.php
@@ -277,6 +277,15 @@ function contai_display_auth_error_notices(): void {
     }
 
     require_once plugin_dir_path(__FILE__) . 'includes/services/api/OnePlatformAuthService.php';
+    require_once plugin_dir_path(__FILE__) . 'includes/services/config/Config.php';
+
+    // If tokens are currently valid, clear any stale error notices
+    // left over from a previous transient failure.
+    $authService = ContaiOnePlatformAuthService::create();
+    if ($authService->validateToken()) {
+        $authService->clearErrors();
+        return;
+    }
 
     $app_error = ContaiOnePlatformAuthService::getAppTokenError();
     if ($app_error !== null) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to Content AI are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.10.1] - 2026-03-25
+
+### Fixed
+
+- **Stale auth error banner persisting after connection recovery**: The "Failed to obtain user authentication token" admin notice now auto-clears when tokens are valid, preventing stale errors from a previous transient API failure (#20)
+- **`validateConnectionStatus()` leaving stale errors**: Successful connection validation (first attempt or retry) now clears any leftover token error options from `wp_options`
+- **`forceRefreshAllTokens()` not clearing errors early enough**: Errors are now cleared at the start of a force-refresh, not just at the end — prevents stale errors from persisting if the refresh partially fails
+- **`WPContentAILicensePanel` testability**: Constructor now accepts optional `UserProfileService` and `AuthService` dependencies for unit testing
+
+### Added
+
+- **`OnePlatformAuthService::clearErrors()`**: Public method to clear both app and user token error options
+- **`WPContentAILicensePanel::getAuthService()`**: Centralized auth service accessor supporting dependency injection
+- **`OnePlatformAuthServiceTest`**: 7 unit tests covering error clearing, token validation, and auth header generation
+- **`WPContentAILicensePanelTest`**: 3 unit tests covering stale error clearing on connection success, retry success, and error persistence on failure
+
 ## [2.9.1] - 2026-03-25
 
 ### Fixed

--- a/includes/admin/licenses/WPContentAILicensePanel.php
+++ b/includes/admin/licenses/WPContentAILicensePanel.php
@@ -15,12 +15,14 @@ class WPContentAILicensePanel
     private const NONCE_FIELD = 'contai_license_nonce';
 
     private ContaiUserProfileService $service;
+    private ?ContaiOnePlatformAuthService $authService;
     private ?string $message = null;
     private string $messageType = 'success';
 
-    public function __construct()
+    public function __construct(?ContaiUserProfileService $service = null, ?ContaiOnePlatformAuthService $authService = null)
     {
-        $this->service = new ContaiUserProfileService();
+        $this->service = $service ?? new ContaiUserProfileService();
+        $this->authService = $authService;
     }
 
     public function handleFormSubmissionEarly(): void
@@ -270,8 +272,7 @@ class WPContentAILicensePanel
      */
     private function handleRefreshTokens(): void
     {
-        $authService = ContaiOnePlatformAuthService::create();
-        $result = $authService->forceRefreshAllTokens();
+        $result = $this->getAuthService()->forceRefreshAllTokens();
 
         if (!$result['success']) {
             $this->message = $result['message'] ?? __('Failed to refresh tokens', '1platform-content-ai');
@@ -306,6 +307,7 @@ class WPContentAILicensePanel
             if ($data) {
                 $this->service->saveUserProfile($data);
             }
+            $this->clearStaleTokenErrors();
             return true;
         }
 
@@ -313,8 +315,7 @@ class WPContentAILicensePanel
         // This covers cases where token generation failed transiently
         // and the OnePlatformClient retry was also exhausted.
         contai_log('Content AI: Profile fetch failed on first attempt, force-refreshing tokens and retrying');
-        $authService = ContaiOnePlatformAuthService::create();
-        $refreshResult = $authService->forceRefreshAllTokens();
+        $refreshResult = $this->getAuthService()->forceRefreshAllTokens();
 
         if (!$refreshResult['success']) {
             return false;
@@ -327,10 +328,21 @@ class WPContentAILicensePanel
             if ($data) {
                 $this->service->saveUserProfile($data);
             }
+            $this->clearStaleTokenErrors();
             return true;
         }
 
         return false;
+    }
+
+    private function clearStaleTokenErrors(): void
+    {
+        $this->getAuthService()->clearErrors();
+    }
+
+    private function getAuthService(): ContaiOnePlatformAuthService
+    {
+        return $this->authService ?? ContaiOnePlatformAuthService::create();
     }
 
     private function renderMessage(): void

--- a/includes/services/api/OnePlatformAuthService.php
+++ b/includes/services/api/OnePlatformAuthService.php
@@ -272,6 +272,7 @@ class ContaiOnePlatformAuthService {
      */
     public function forceRefreshAllTokens(): array {
         $this->clearToken();
+        $this->clearErrors();
 
         $app_token = $this->generateNewAppToken();
 
@@ -363,6 +364,11 @@ class ContaiOnePlatformAuthService {
         $user_expires = (int) get_option(self::OPTION_USER_TOKEN_EXPIRES, 0);
 
         return $now < ($app_expires - $buffer) && $now < ($user_expires - $buffer);
+    }
+
+    public function clearErrors(): void {
+        $this->clearError(self::OPTION_APP_TOKEN_ERROR);
+        $this->clearError(self::OPTION_USER_TOKEN_ERROR);
     }
 
     private function storeError(string $option_key, string $message): void {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -80,3 +80,7 @@ require_once __DIR__ . '/../includes/providers/WebsiteProvider.php';
 require_once __DIR__ . '/../includes/services/search-console/SearchConsoleService.php';
 require_once __DIR__ . '/../includes/services/setup/SearchConsoleSetupService.php';
 require_once __DIR__ . '/../includes/admin/apps/handlers/SearchConsoleFormHandler.php';
+
+// ── User Profile & License ─────────────────────────────────────
+require_once __DIR__ . '/../includes/services/user-profile/UserProfileService.php';
+require_once __DIR__ . '/../includes/admin/licenses/WPContentAILicensePanel.php';

--- a/tests/unit/admin/licenses/WPContentAILicensePanelTest.php
+++ b/tests/unit/admin/licenses/WPContentAILicensePanelTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace ContAI\Tests\Unit\Admin\Licenses;
+
+use WP_Mock;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use WPContentAILicensePanel;
+use ContaiUserProfileService;
+use ContaiOnePlatformAuthService;
+use ContaiOnePlatformResponse;
+use ContaiWebsiteProvider;
+
+class WPContentAILicensePanelTest extends TestCase
+{
+    private WPContentAILicensePanel $panel;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        WP_Mock::setUp();
+    }
+
+    public function tearDown(): void
+    {
+        WP_Mock::tearDown();
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_validateConnectionStatus_clears_stale_errors_on_success(): void
+    {
+        $service = Mockery::mock(ContaiUserProfileService::class);
+        $authService = Mockery::mock(ContaiOnePlatformAuthService::class);
+
+        $service->shouldReceive('fetchUserProfile')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(true, ['id' => '123', 'username' => 'test', 'is_active' => true], 'OK', 200));
+
+        $service->shouldReceive('saveUserProfile')
+            ->once()
+            ->with(Mockery::type('array'));
+
+        $authService->shouldReceive('clearErrors')->once();
+
+        $panel = new WPContentAILicensePanel($service, $authService);
+
+        $method = new \ReflectionMethod($panel, 'validateConnectionStatus');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($panel);
+
+        $this->assertTrue($result);
+    }
+
+    public function test_validateConnectionStatus_clears_errors_after_successful_retry(): void
+    {
+        $service = Mockery::mock(ContaiUserProfileService::class);
+        $authService = Mockery::mock(ContaiOnePlatformAuthService::class);
+
+        // First attempt fails
+        $service->shouldReceive('fetchUserProfile')
+            ->twice()
+            ->andReturn(
+                new ContaiOnePlatformResponse(false, null, 'Auth failed', 401),
+                new ContaiOnePlatformResponse(true, ['id' => '123', 'username' => 'test', 'is_active' => true], 'OK', 200)
+            );
+
+        $service->shouldReceive('saveUserProfile')->once();
+
+        WP_Mock::userFunction('contai_log');
+
+        // Force refresh succeeds
+        $authService->shouldReceive('forceRefreshAllTokens')
+            ->once()
+            ->andReturn(['success' => true, 'message' => 'Tokens refreshed']);
+
+        // Errors cleared after retry success
+        $authService->shouldReceive('clearErrors')->once();
+
+        $panel = new WPContentAILicensePanel($service, $authService);
+
+        $method = new \ReflectionMethod($panel, 'validateConnectionStatus');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($panel);
+
+        $this->assertTrue($result);
+    }
+
+    public function test_validateConnectionStatus_does_not_clear_errors_on_failure(): void
+    {
+        $service = Mockery::mock(ContaiUserProfileService::class);
+        $authService = Mockery::mock(ContaiOnePlatformAuthService::class);
+
+        // Both attempts fail
+        $service->shouldReceive('fetchUserProfile')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(false, null, 'Auth failed', 401));
+
+        WP_Mock::userFunction('contai_log');
+
+        $authService->shouldReceive('forceRefreshAllTokens')
+            ->once()
+            ->andReturn(['success' => false, 'message' => 'Failed']);
+
+        // clearErrors should NOT be called
+        $authService->shouldNotReceive('clearErrors');
+
+        $panel = new WPContentAILicensePanel($service, $authService);
+
+        $method = new \ReflectionMethod($panel, 'validateConnectionStatus');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($panel);
+
+        $this->assertFalse($result);
+    }
+}

--- a/tests/unit/services/api/OnePlatformAuthServiceTest.php
+++ b/tests/unit/services/api/OnePlatformAuthServiceTest.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace ContAI\Tests\Unit\Services\Api;
+
+use WP_Mock;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use ContaiOnePlatformAuthService;
+use ContaiHTTPClientService;
+use ContaiHTTPResponse;
+use ContaiConfig;
+
+class OnePlatformAuthServiceTest extends TestCase
+{
+    private ContaiHTTPClientService $httpClient;
+    private ContaiConfig $config;
+    private ContaiOnePlatformAuthService $authService;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        WP_Mock::setUp();
+
+        $this->httpClient = Mockery::mock(ContaiHTTPClientService::class);
+        $this->config = Mockery::mock(ContaiConfig::class);
+
+        $this->config->shouldReceive('getApiBaseUrl')->andReturn('https://api.example.com/api/v1');
+        $this->config->shouldReceive('getAuthEndpoint')->andReturn('/auth/token');
+        $this->config->shouldReceive('getUserTokenEndpoint')->andReturn('/users/token');
+        $this->config->shouldReceive('getTokenBufferTime')->andReturn(60);
+
+        $this->authService = new ContaiOnePlatformAuthService($this->httpClient, $this->config);
+    }
+
+    public function tearDown(): void
+    {
+        WP_Mock::tearDown();
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_clearErrors_deletes_both_error_options(): void
+    {
+        WP_Mock::userFunction('delete_option')
+            ->with('contai_app_token_error')
+            ->once();
+
+        WP_Mock::userFunction('delete_option')
+            ->with('contai_user_token_error')
+            ->once();
+
+        $this->authService->clearErrors();
+
+        $this->assertTrue(true);
+    }
+
+    public function test_forceRefreshAllTokens_clears_errors_before_generating_tokens(): void
+    {
+        // clearToken() calls
+        WP_Mock::userFunction('delete_transient')->andReturn(true);
+        WP_Mock::userFunction('delete_option')->andReturn(true);
+
+        // App token generation
+        $this->config->shouldReceive('getApiKey')->andReturn('test-app-key');
+
+        $appResponse = Mockery::mock(ContaiHTTPResponse::class);
+        $appResponse->shouldReceive('isSuccess')->andReturn(true);
+        $appResponse->shouldReceive('getJson')->andReturn([
+            'success' => true,
+            'data' => [
+                'access_token' => 'fresh-app-token',
+                'expires_in' => 1800,
+            ],
+        ]);
+
+        $this->httpClient->shouldReceive('post')
+            ->with('https://api.example.com/api/v1/auth/token', Mockery::any())
+            ->once()
+            ->andReturn($appResponse);
+
+        WP_Mock::userFunction('update_option')->andReturn(true);
+
+        // User token generation
+        $this->config->shouldReceive('getUserApiKey')->andReturn('test-user-key');
+
+        $userResponse = Mockery::mock(ContaiHTTPResponse::class);
+        $userResponse->shouldReceive('isSuccess')->andReturn(true);
+        $userResponse->shouldReceive('getJson')->andReturn([
+            'success' => true,
+            'data' => [
+                'access_token' => 'fresh-user-token',
+                'expires_in' => 1800,
+            ],
+        ]);
+
+        $this->httpClient->shouldReceive('post')
+            ->with('https://api.example.com/api/v1/users/token', Mockery::any(), Mockery::any())
+            ->once()
+            ->andReturn($userResponse);
+
+        WP_Mock::userFunction('contai_log');
+
+        $result = $this->authService->forceRefreshAllTokens();
+
+        $this->assertTrue($result['success']);
+        $this->assertTrue(true);
+    }
+
+    public function test_forceRefreshAllTokens_clears_errors_even_when_app_token_fails(): void
+    {
+        // clearToken() + clearErrors() call delete_option for multiple keys
+        WP_Mock::userFunction('delete_transient')->andReturn(true);
+        WP_Mock::userFunction('delete_option')->andReturn(true);
+
+        $this->config->shouldReceive('getApiKey')->andReturn('bad-key');
+
+        $failResponse = Mockery::mock(ContaiHTTPResponse::class);
+        $failResponse->shouldReceive('isSuccess')->andReturn(false);
+        $failResponse->shouldReceive('getError')->andReturn('Unauthorized');
+        $failResponse->shouldReceive('getStatusCode')->andReturn(401);
+
+        $this->httpClient->shouldReceive('post')
+            ->with('https://api.example.com/api/v1/auth/token', Mockery::any())
+            ->once()
+            ->andReturn($failResponse);
+
+        WP_Mock::userFunction('contai_log');
+        WP_Mock::userFunction('get_option')->andReturn('');
+
+        $result = $this->authService->forceRefreshAllTokens();
+
+        $this->assertFalse($result['success']);
+        $this->assertTrue(true);
+    }
+
+    public function test_getAuthHeaders_stores_error_when_user_token_fails(): void
+    {
+        // App token cached and valid
+        WP_Mock::userFunction('get_option')
+            ->with('contai_app_access_token', '')
+            ->andReturn('cached-app-token');
+
+        WP_Mock::userFunction('get_option')
+            ->with('contai_app_token_expires_at', 0)
+            ->andReturn(time() + 3600);
+
+        // Clear app error
+        WP_Mock::userFunction('delete_option')
+            ->with('contai_app_token_error')
+            ->once();
+
+        // User token not cached
+        WP_Mock::userFunction('get_option')
+            ->with('contai_user_access_token', '')
+            ->andReturn('');
+
+        // User API key empty → returns null
+        $this->config->shouldReceive('getUserApiKey')->andReturn('');
+
+        WP_Mock::userFunction('contai_log');
+
+        // Error stored
+        WP_Mock::userFunction('update_option')
+            ->with('contai_user_token_error', Mockery::type('string'), false)
+            ->once();
+
+        $result = $this->authService->getAuthHeaders();
+
+        $this->assertNull($result);
+        $this->assertTrue(true);
+    }
+
+    public function test_getAuthHeaders_clears_errors_on_success(): void
+    {
+        $now = time();
+
+        // App token cached and valid
+        WP_Mock::userFunction('get_option')
+            ->with('contai_app_access_token', '')
+            ->andReturn('valid-app-token');
+
+        WP_Mock::userFunction('get_option')
+            ->with('contai_app_token_expires_at', 0)
+            ->andReturn($now + 3600);
+
+        // User token cached and valid
+        WP_Mock::userFunction('get_option')
+            ->with('contai_user_access_token', '')
+            ->andReturn('valid-user-token');
+
+        WP_Mock::userFunction('get_option')
+            ->with('contai_user_token_expires_at', 0)
+            ->andReturn($now + 3600);
+
+        // Both errors cleared on success
+        WP_Mock::userFunction('delete_option')
+            ->with('contai_app_token_error')
+            ->once();
+
+        WP_Mock::userFunction('delete_option')
+            ->with('contai_user_token_error')
+            ->once();
+
+        $result = $this->authService->getAuthHeaders();
+
+        $this->assertNotNull($result);
+        $this->assertEquals('Bearer valid-app-token', $result['Authorization']);
+        $this->assertEquals('valid-user-token', $result['x-user-token']);
+        $this->assertTrue(true);
+    }
+
+    public function test_validateToken_returns_false_when_tokens_expired(): void
+    {
+        WP_Mock::userFunction('get_option')
+            ->with('contai_app_access_token', '')
+            ->andReturn('some-token');
+
+        WP_Mock::userFunction('get_option')
+            ->with('contai_user_access_token', '')
+            ->andReturn('some-user-token');
+
+        WP_Mock::userFunction('get_option')
+            ->with('contai_app_token_expires_at', 0)
+            ->andReturn(time() - 100);
+
+        WP_Mock::userFunction('get_option')
+            ->with('contai_user_token_expires_at', 0)
+            ->andReturn(time() - 100);
+
+        $result = $this->authService->validateToken();
+
+        $this->assertFalse($result);
+    }
+
+    public function test_validateToken_returns_true_when_tokens_valid(): void
+    {
+        $future = time() + 3600;
+
+        WP_Mock::userFunction('get_option')
+            ->with('contai_app_access_token', '')
+            ->andReturn('valid-app-token');
+
+        WP_Mock::userFunction('get_option')
+            ->with('contai_user_access_token', '')
+            ->andReturn('valid-user-token');
+
+        WP_Mock::userFunction('get_option')
+            ->with('contai_app_token_expires_at', 0)
+            ->andReturn($future);
+
+        WP_Mock::userFunction('get_option')
+            ->with('contai_user_token_expires_at', 0)
+            ->andReturn($future);
+
+        $result = $this->authService->validateToken();
+
+        $this->assertTrue($result);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #20 — "API Connection Disconnected despite Active License"

The root cause was a **stale error state** in `wp_options` that persisted indefinitely after transient API failures. Three independent mechanisms were missing:

- **`validateConnectionStatus()`** never cleared token errors on successful reconnection — fixed by calling `clearErrors()` after a successful profile fetch (first attempt or retry)
- **`forceRefreshAllTokens()`** only cleared errors at the end of a full success — fixed by clearing errors at the start, so stale state from a previous failure doesn't persist if only part of the refresh succeeds
- **Admin notice (`contai_display_auth_error_notices`)** displayed errors from `wp_options` without checking current token validity — fixed by checking `validateToken()` first and auto-clearing stale errors

### Additional improvements

- `WPContentAILicensePanel` constructor now accepts optional `UserProfileService` and `AuthService` for dependency injection and testability
- Added `OnePlatformAuthService::clearErrors()` public method
- Centralized auth service access via `getAuthService()` helper

## Files changed

| File | Change |
|---|---|
| `OnePlatformAuthService.php` | Added `clearErrors()`, errors cleared early in `forceRefreshAllTokens()` |
| `WPContentAILicensePanel.php` | DI constructor, `clearStaleTokenErrors()` on success, `getAuthService()` helper |
| `1platform-content-ai.php` | Admin notice checks `validateToken()` before showing errors |
| `OnePlatformAuthServiceTest.php` | 7 new unit tests |
| `WPContentAILicensePanelTest.php` | 3 new unit tests |
| `bootstrap.php` | Registered new test dependencies |
| `CHANGELOG.md` | v2.10.1 entry |

## Test plan

- [x] All 349 tests pass (543 assertions)
- [ ] Simulate transient API failure → verify error banner appears
- [ ] Restore API → refresh page → verify banner auto-clears
- [ ] Click "Refresh Tokens" with valid credentials → verify "Connected" status and no error banner
- [ ] Click "Refresh Tokens" with invalid credentials → verify error banner persists correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)