### PR TITLE
fix(cron): clean up all cron hooks on deactivation and uninstall (#23)

### DIFF
--- a/1platform-content-ai.php
+++ b/1platform-content-ai.php
@@ -4,7 +4,7 @@
  * Plugin Name: 1Platform Content AI
  * Plugin URI: https://1platform.pro/
  * Description: SaaS client for AI-powered content generation, SEO optimization, and site management. All AI processing happens on 1Platform external servers. Includes free local tools: Table of Contents and Internal Links.
- * Version: 2.10.4
+ * Version: 2.10.5
  * Author: 1Platform
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Content AI are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.10.5] - 2026-03-25
+
+### Fixed
+
+- **Orphan agent cron on plugin uninstall**: `uninstall.php` only cleared `contai_process_job_queue` but not `contai_agent_actions_poll`, leaving an orphan cron event after plugin deletion (#23)
+- **Job processor deactivation not clearing all instances**: `contai_unregister_job_processor_cron` used `wp_unschedule_event` (removes one instance) instead of `wp_clear_scheduled_hook` (removes all), which could leave orphan entries if a race condition caused double-scheduling. Now both cron hooks use `wp_clear_scheduled_hook` consistently
+
+### Added
+
+- **`CronDeactivationTest`**: 6 unit tests covering registration and unregistration of both cron hooks (`contai_process_job_queue` and `contai_agent_actions_poll`)
+
 ## [2.10.3] - 2026-03-25
 
 ### Fixed

--- a/includes/cron/job-processor-cron.php
+++ b/includes/cron/job-processor-cron.php
@@ -15,10 +15,7 @@ function contai_register_job_processor_cron()
 
 function contai_unregister_job_processor_cron()
 {
-    $timestamp = wp_next_scheduled('contai_process_job_queue');
-    if ($timestamp) {
-        wp_unschedule_event($timestamp, 'contai_process_job_queue');
-    }
+    wp_clear_scheduled_hook('contai_process_job_queue');
 }
 
 function contai_process_job_queue_callback()

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai content, seo, content generation, internal links, table of contents
 Requires at least: 5.9
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.10.4
+Stable tag: 2.10.5
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -87,3 +87,7 @@ require_once __DIR__ . '/../includes/admin/licenses/WPContentAILicensePanel.php'
 
 // ── Category API ────────────────────────────────────────────────
 require_once __DIR__ . '/../includes/services/category-api/CategoryAPIService.php';
+
+// ── Cron ────────────────────────────────────────────────────────
+require_once __DIR__ . '/../includes/cron/job-processor-cron.php';
+require_once __DIR__ . '/../includes/cron/agent-actions-cron.php';

--- a/tests/unit/cron/CronDeactivationTest.php
+++ b/tests/unit/cron/CronDeactivationTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace ContAI\Tests\Unit\Cron;
+
+use WP_Mock;
+use PHPUnit\Framework\TestCase;
+
+class CronDeactivationTest extends TestCase {
+
+    public function setUp(): void {
+        parent::setUp();
+        WP_Mock::setUp();
+    }
+
+    public function tearDown(): void {
+        WP_Mock::tearDown();
+        parent::tearDown();
+    }
+
+    // ── Job Processor Cron ───────────────────────────────────────
+
+    public function test_unregister_job_processor_clears_scheduled_hook(): void {
+        WP_Mock::userFunction( 'wp_clear_scheduled_hook' )
+            ->once()
+            ->with( 'contai_process_job_queue' );
+
+        contai_unregister_job_processor_cron();
+
+        $this->assertTrue( true );
+    }
+
+    // ── Agent Actions Cron ───────────────────────────────────────
+
+    public function test_unregister_agent_actions_clears_scheduled_hook(): void {
+        WP_Mock::userFunction( 'wp_clear_scheduled_hook' )
+            ->once()
+            ->with( 'contai_agent_actions_poll' );
+
+        contai_unregister_agent_actions_cron();
+
+        $this->assertTrue( true );
+    }
+
+    // ── Registration ─────────────────────────────────────────────
+
+    public function test_register_job_processor_schedules_when_not_existing(): void {
+        WP_Mock::userFunction( 'wp_next_scheduled' )
+            ->with( 'contai_process_job_queue' )
+            ->andReturn( false );
+
+        WP_Mock::userFunction( 'wp_schedule_event' )
+            ->once()
+            ->with( \Mockery::type( 'int' ), 'contai_every_minute', 'contai_process_job_queue' );
+
+        contai_register_job_processor_cron();
+
+        $this->assertTrue( true );
+    }
+
+    public function test_register_job_processor_skips_when_already_scheduled(): void {
+        WP_Mock::userFunction( 'wp_next_scheduled' )
+            ->with( 'contai_process_job_queue' )
+            ->andReturn( 1234567890 );
+
+        WP_Mock::userFunction( 'wp_schedule_event' )->never();
+
+        contai_register_job_processor_cron();
+
+        $this->assertTrue( true );
+    }
+
+    public function test_register_agent_actions_schedules_when_not_existing(): void {
+        WP_Mock::userFunction( 'wp_next_scheduled' )
+            ->with( 'contai_agent_actions_poll' )
+            ->andReturn( false );
+
+        WP_Mock::userFunction( 'wp_schedule_event' )
+            ->once()
+            ->with( \Mockery::type( 'int' ), 'contai_every_minute', 'contai_agent_actions_poll' );
+
+        contai_register_agent_actions_cron();
+
+        $this->assertTrue( true );
+    }
+
+    public function test_register_agent_actions_skips_when_already_scheduled(): void {
+        WP_Mock::userFunction( 'wp_next_scheduled' )
+            ->with( 'contai_agent_actions_poll' )
+            ->andReturn( 1234567890 );
+
+        WP_Mock::userFunction( 'wp_schedule_event' )->never();
+
+        contai_register_agent_actions_cron();
+
+        $this->assertTrue( true );
+    }
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -105,3 +105,4 @@ $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->options} WHERE option_name LI
 
 // Clear scheduled cron events.
 wp_clear_scheduled_hook( 'contai_process_job_queue' );
+wp_clear_scheduled_hook( 'contai_agent_actions_poll' );


### PR DESCRIPTION
## Summary

- Add missing `wp_clear_scheduled_hook('contai_agent_actions_poll')` to `uninstall.php` — prevents orphan cron after plugin deletion
- Normalize `contai_unregister_job_processor_cron` to use `wp_clear_scheduled_hook` instead of `wp_next_scheduled` + `wp_unschedule_event` — consistent with agent cron and safer against double-scheduling race conditions
- Add `CronDeactivationTest` with 6 unit tests covering register/unregister of both cron hooks

## Changes

| File | Change |
|---|---|
| `uninstall.php` | Add `wp_clear_scheduled_hook('contai_agent_actions_poll')` |
| `includes/cron/job-processor-cron.php` | Simplify `contai_unregister_job_processor_cron` to use `wp_clear_scheduled_hook` |
| `tests/unit/cron/CronDeactivationTest.php` | New: 6 tests for cron registration and cleanup |
| `tests/bootstrap.php` | Add cron file requires |
| `CHANGELOG.md` | Add v2.10.5 entry |
| `1platform-content-ai.php`, `readme.txt` | Bump to 2.10.5 |

## Test plan

- [x] All 387 unit tests pass (`vendor/bin/phpunit`)
- [ ] Activate → deactivate plugin: verify no orphan cron entries in `wp_options` (`cron` option)
- [ ] Delete plugin: verify `contai_agent_actions_poll` and `contai_process_job_queue` are cleared

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)