### PR TITLE
test: add unit tests for admin form handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to Content AI are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.10.6] - 2026-03-25
+
+### Added
+
+- **Admin form handler unit tests**: 38 new tests covering the 4 most critical admin form handlers (#22)
+  - `TopUpHandlerTest` (9 tests): nonce/capability checks, amount validation ($5–$200), currency validation, payment URL redirect, API failure handling
+  - `PublisuitesFormHandlerTest` (10 tests): nonce/capability checks, connect, verify, disconnect, verification file creation
+  - `KeywordExtractionHandlerTest` (10 tests): nonce/capability checks, topic/language/country validation, job creation success and failure
+  - `PostGenerationQueueHandlerTest` (9 tests): nonce/capability checks, post count/language/image provider validation, enqueue and clear queue
+
+### Changed
+
+- **`KeywordExtractionHandler`**: Constructor now accepts optional `ContaiJobRepository` for dependency injection
+- **`PostGenerationQueueHandler`**: Constructor now accepts optional `ContaiQueueManager` for dependency injection
+- **`phpunit.xml.dist`**: Admin handler directories now included in code coverage (previously all of `includes/admin` was excluded)
+
 ## [2.10.5] - 2026-03-25
 
 ### Fixed

--- a/includes/admin/content-generator/handlers/KeywordExtractionHandler.php
+++ b/includes/admin/content-generator/handlers/KeywordExtractionHandler.php
@@ -15,8 +15,8 @@ class ContaiKeywordExtractionHandler {
 
     private $jobRepository;
 
-    public function __construct() {
-        $this->jobRepository = new ContaiJobRepository();
+    public function __construct(?ContaiJobRepository $jobRepository = null) {
+        $this->jobRepository = $jobRepository ?? new ContaiJobRepository();
     }
 
     public function handleRequest(): void {

--- a/includes/admin/content-generator/handlers/PostGenerationQueueHandler.php
+++ b/includes/admin/content-generator/handlers/PostGenerationQueueHandler.php
@@ -14,8 +14,8 @@ class ContaiPostGenerationQueueHandler {
 
     private $queueManager;
 
-    public function __construct() {
-        $this->queueManager = new ContaiQueueManager();
+    public function __construct(?ContaiQueueManager $queueManager = null) {
+        $this->queueManager = $queueManager ?? new ContaiQueueManager();
     }
 
     public function handleRequest(): void {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,8 +21,24 @@
             <directory suffix=".php">includes</directory>
         </include>
         <exclude>
-            <directory>includes/admin</directory>
+            <directory>includes/admin/pages</directory>
+            <directory>includes/admin/views</directory>
+            <directory>includes/admin/panels</directory>
+            <directory>includes/admin/assets</directory>
+            <directory>includes/admin/agents</directory>
+            <directory>includes/admin/licenses</directory>
+            <directory>includes/admin/logs</directory>
+            <directory>includes/admin/init-configuration</directory>
+            <directory>includes/admin/ai-site-generator</directory>
             <directory>includes/database/migrations</directory>
+            <file>includes/admin/admin-adsense-injector.php</file>
+            <file>includes/admin/admin-ai-site-generator.php</file>
+            <file>includes/admin/admin-apps.php</file>
+            <file>includes/admin/admin-billing.php</file>
+            <file>includes/admin/admin-content-generator.php</file>
+            <file>includes/admin/admin-init-configuration.php</file>
+            <file>includes/admin/admin-job-monitor.php</file>
+            <file>includes/admin/admin-licenses.php</file>
             <file>includes/header.php</file>
             <file>includes/cron/job-processor-cron.php</file>
         </exclude>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -81,6 +81,16 @@ require_once __DIR__ . '/../includes/services/search-console/SearchConsoleServic
 require_once __DIR__ . '/../includes/services/setup/SearchConsoleSetupService.php';
 require_once __DIR__ . '/../includes/admin/apps/handlers/SearchConsoleFormHandler.php';
 
+// ── Admin Handlers (Billing, Publisuites, Content Generator) ───
+require_once __DIR__ . '/../includes/services/billing/BillingService.php';
+require_once __DIR__ . '/../includes/admin/billing/handlers/TopUpHandler.php';
+require_once __DIR__ . '/../includes/services/publisuites/PublisuitesService.php';
+require_once __DIR__ . '/../includes/admin/apps/handlers/PublisuitesFormHandler.php';
+require_once __DIR__ . '/../includes/services/jobs/KeywordExtractionJob.php';
+require_once __DIR__ . '/../includes/admin/content-generator/handlers/KeywordExtractionHandler.php';
+require_once __DIR__ . '/../includes/services/jobs/QueueManager.php';
+require_once __DIR__ . '/../includes/admin/content-generator/handlers/PostGenerationQueueHandler.php';
+
 // ── User Profile & License ─────────────────────────────────────
 require_once __DIR__ . '/../includes/services/user-profile/UserProfileService.php';
 require_once __DIR__ . '/../includes/admin/licenses/WPContentAILicensePanel.php';

--- a/tests/unit/admin/apps/handlers/PublisuitesFormHandlerTest.php
+++ b/tests/unit/admin/apps/handlers/PublisuitesFormHandlerTest.php
@@ -1,0 +1,326 @@
+<?php
+
+namespace ContAI\Tests\Unit\Admin\Apps\Handlers;
+
+use WP_Mock;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use ContaiPublisuitesFormHandler;
+use ContaiPublisuitesService;
+use ContaiOnePlatformResponse;
+
+class PublisuitesRedirectException extends \RuntimeException {}
+
+class PublisuitesFormHandlerTest extends TestCase
+{
+    private ContaiPublisuitesService $service;
+    private ContaiPublisuitesFormHandler $handler;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        WP_Mock::setUp();
+
+        $this->service = Mockery::mock(ContaiPublisuitesService::class);
+        $this->handler = new ContaiPublisuitesFormHandler($this->service);
+    }
+
+    public function tearDown(): void
+    {
+        unset(
+            $_POST['contai_publisuites_nonce'],
+            $_POST['contai_connect_publisuites'],
+            $_POST['contai_verify_publisuites'],
+            $_POST['contai_disconnect_publisuites'],
+            $_POST['contai_create_verification_file']
+        );
+        WP_Mock::tearDown();
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    // ── Security Tests ─────────────────────────────────────────────
+
+    public function test_returns_early_when_nonce_field_not_present(): void
+    {
+        $this->service->shouldNotReceive('connectWebsite');
+        $this->service->shouldNotReceive('verifyWebsite');
+        $this->service->shouldNotReceive('deletePublisuitesConfig');
+
+        $this->handler->handleRequest();
+
+        $this->assertTrue(true);
+    }
+
+    public function test_returns_early_when_nonce_is_invalid(): void
+    {
+        $_POST['contai_publisuites_nonce'] = 'invalid-nonce';
+        $_POST['contai_connect_publisuites'] = '1';
+
+        WP_Mock::userFunction('sanitize_text_field')
+            ->andReturnUsing(function ($val) { return $val; });
+
+        WP_Mock::userFunction('wp_unslash')
+            ->andReturnUsing(function ($val) { return $val; });
+
+        WP_Mock::userFunction('wp_verify_nonce')
+            ->with('invalid-nonce', 'contai_publisuites_action')
+            ->andReturn(false);
+
+        $this->service->shouldNotReceive('connectWebsite');
+
+        $this->handler->handleRequest();
+
+        $this->assertTrue(true);
+    }
+
+    public function test_returns_early_when_user_lacks_capability(): void
+    {
+        $_POST['contai_publisuites_nonce'] = 'valid-nonce';
+        $_POST['contai_connect_publisuites'] = '1';
+
+        WP_Mock::userFunction('sanitize_text_field')
+            ->andReturnUsing(function ($val) { return $val; });
+
+        WP_Mock::userFunction('wp_unslash')
+            ->andReturnUsing(function ($val) { return $val; });
+
+        WP_Mock::userFunction('wp_verify_nonce')
+            ->with('valid-nonce', 'contai_publisuites_action')
+            ->andReturn(1);
+
+        WP_Mock::userFunction('current_user_can')
+            ->with('manage_options')
+            ->andReturn(false);
+
+        $this->service->shouldNotReceive('connectWebsite');
+
+        $this->handler->handleRequest();
+
+        $this->assertTrue(true);
+    }
+
+    // ── Connect Tests ──────────────────────────────────────────────
+
+    public function test_connect_success_saves_config_and_redirects(): void
+    {
+        $this->mockValidRequest('contai_connect_publisuites');
+
+        $responseData = [
+            'publisuites_id' => 'ps-123',
+            'verification_file_name' => 'verify.html',
+            'verification_file_content' => 'verification-content',
+            'message' => 'Connected',
+        ];
+
+        $this->service
+            ->shouldReceive('connectWebsite')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(true, $responseData, 'Connected', 200));
+
+        $this->service
+            ->shouldReceive('savePublisuitesConfig')
+            ->once()
+            ->with(Mockery::on(function ($config) {
+                return $config['publisuites_id'] === 'ps-123'
+                    && $config['status'] === 'pending_verification'
+                    && $config['verified'] === false;
+            }));
+
+        WP_Mock::userFunction('__')->andReturnUsing(function ($text) { return $text; });
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected redirect');
+        } catch (PublisuitesRedirectException $e) {
+            $this->assertStringContainsString('contai_ps_type=success', $redirectUrl->url);
+        }
+    }
+
+    public function test_connect_api_failure_redirects_with_error(): void
+    {
+        $this->mockValidRequest('contai_connect_publisuites');
+
+        $this->service
+            ->shouldReceive('connectWebsite')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(false, null, 'API error', 500, 'trace-456'));
+
+        $this->service->shouldNotReceive('savePublisuitesConfig');
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected redirect');
+        } catch (PublisuitesRedirectException $e) {
+            $this->assertStringContainsString('contai_ps_type=error', $redirectUrl->url);
+            $this->assertStringContainsString('trace-456', $redirectUrl->url);
+        }
+    }
+
+    // ── Verify Tests ───────────────────────────────────────────────
+
+    public function test_verify_success_updates_config_to_active(): void
+    {
+        $this->mockValidRequest('contai_verify_publisuites');
+
+        $this->service
+            ->shouldReceive('verifyWebsite')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(true, ['verified' => true, 'verified_at' => '2026-01-01'], 'Verified', 200));
+
+        $this->service
+            ->shouldReceive('getPublisuitesConfig')
+            ->once()
+            ->andReturn(['publisuites_id' => 'ps-123', 'status' => 'pending_verification']);
+
+        $this->service
+            ->shouldReceive('savePublisuitesConfig')
+            ->once()
+            ->with(Mockery::on(function ($config) {
+                return $config['verified'] === true && $config['status'] === 'active';
+            }));
+
+        WP_Mock::userFunction('__')->andReturnUsing(function ($text) { return $text; });
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected redirect');
+        } catch (PublisuitesRedirectException $e) {
+            $this->assertStringContainsString('contai_ps_type=success', $redirectUrl->url);
+        }
+    }
+
+    public function test_verify_api_failure_redirects_with_error(): void
+    {
+        $this->mockValidRequest('contai_verify_publisuites');
+
+        $this->service
+            ->shouldReceive('verifyWebsite')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(false, null, 'Verification failed', 400, 'trace-789'));
+
+        $this->service->shouldNotReceive('getPublisuitesConfig');
+        $this->service->shouldNotReceive('savePublisuitesConfig');
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected redirect');
+        } catch (PublisuitesRedirectException $e) {
+            $this->assertStringContainsString('contai_ps_type=error', $redirectUrl->url);
+        }
+    }
+
+    // ── Disconnect Tests ───────────────────────────────────────────
+
+    public function test_disconnect_deletes_local_config_and_redirects(): void
+    {
+        $this->mockValidRequest('contai_disconnect_publisuites');
+
+        $this->service
+            ->shouldReceive('deletePublisuitesConfig')
+            ->once();
+
+        WP_Mock::userFunction('__')->andReturnUsing(function ($text) { return $text; });
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected redirect');
+        } catch (PublisuitesRedirectException $e) {
+            $this->assertStringContainsString('contai_ps_type=success', $redirectUrl->url);
+        }
+    }
+
+    // ── Verification File Tests ────────────────────────────────────
+
+    public function test_create_verification_file_success(): void
+    {
+        $this->mockValidRequest('contai_create_verification_file');
+
+        $this->service
+            ->shouldReceive('createVerificationFile')
+            ->once()
+            ->andReturn(['success' => true, 'message' => 'File created successfully']);
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected redirect');
+        } catch (PublisuitesRedirectException $e) {
+            $this->assertStringContainsString('contai_ps_type=success', $redirectUrl->url);
+        }
+    }
+
+    public function test_create_verification_file_failure(): void
+    {
+        $this->mockValidRequest('contai_create_verification_file');
+
+        $this->service
+            ->shouldReceive('createVerificationFile')
+            ->once()
+            ->andReturn(['success' => false, 'message' => 'Cannot write file']);
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected redirect');
+        } catch (PublisuitesRedirectException $e) {
+            $this->assertStringContainsString('contai_ps_type=error', $redirectUrl->url);
+        }
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────
+
+    private function mockValidRequest(string $action): void
+    {
+        $_POST['contai_publisuites_nonce'] = 'valid-nonce';
+        $_POST[$action] = '1';
+
+        WP_Mock::userFunction('sanitize_text_field')
+            ->andReturnUsing(function ($val) { return $val; });
+
+        WP_Mock::userFunction('wp_unslash')
+            ->andReturnUsing(function ($val) { return $val; });
+
+        WP_Mock::userFunction('wp_verify_nonce')
+            ->with('valid-nonce', 'contai_publisuites_action')
+            ->andReturn(1);
+
+        WP_Mock::userFunction('current_user_can')
+            ->with('manage_options')
+            ->andReturn(true);
+    }
+
+    private function expectRedirect(): object
+    {
+        $capture = new class { public string $url = ''; };
+
+        WP_Mock::userFunction('admin_url')
+            ->andReturn('http://example.com/wp-admin/admin.php?page=contai-apps&section=publisuites');
+
+        WP_Mock::userFunction('add_query_arg')
+            ->andReturnUsing(function ($args, $url) {
+                return $url . '&' . http_build_query($args);
+            });
+
+        WP_Mock::userFunction('wp_safe_redirect')
+            ->once()
+            ->andReturnUsing(function ($url) use ($capture) {
+                $capture->url = $url;
+                throw new PublisuitesRedirectException('redirect');
+            });
+
+        return $capture;
+    }
+}

--- a/tests/unit/admin/billing/handlers/TopUpHandlerTest.php
+++ b/tests/unit/admin/billing/handlers/TopUpHandlerTest.php
@@ -1,0 +1,286 @@
+<?php
+
+namespace ContAI\Tests\Unit\Admin\Billing\Handlers;
+
+use WP_Mock;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use ContaiTopUpHandler;
+use ContaiBillingService;
+use ContaiOnePlatformResponse;
+
+class RedirectException extends \RuntimeException {}
+
+class TopUpHandlerTest extends TestCase
+{
+    private ContaiBillingService $service;
+    private ContaiTopUpHandler $handler;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        WP_Mock::setUp();
+
+        $this->service = Mockery::mock(ContaiBillingService::class);
+        $this->handler = new ContaiTopUpHandler($this->service);
+    }
+
+    public function tearDown(): void
+    {
+        unset(
+            $_POST['contai_billing_topup_nonce'],
+            $_POST['contai_billing_topup'],
+            $_POST['contai_topup_amount'],
+            $_POST['contai_topup_currency']
+        );
+        WP_Mock::tearDown();
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    // ── Security Tests ─────────────────────────────────────────────
+
+    public function test_returns_early_when_nonce_field_not_present(): void
+    {
+        $this->service->shouldNotReceive('createTransaction');
+
+        $this->handler->handleRequest();
+
+        $this->assertTrue(true);
+    }
+
+    public function test_returns_early_when_nonce_is_invalid(): void
+    {
+        $_POST['contai_billing_topup_nonce'] = 'invalid-nonce';
+
+        WP_Mock::userFunction('sanitize_text_field')
+            ->andReturnUsing(function ($val) { return $val; });
+
+        WP_Mock::userFunction('wp_unslash')
+            ->andReturnUsing(function ($val) { return $val; });
+
+        WP_Mock::userFunction('wp_verify_nonce')
+            ->with('invalid-nonce', 'contai_billing_topup_action')
+            ->andReturn(false);
+
+        $this->service->shouldNotReceive('createTransaction');
+
+        $this->handler->handleRequest();
+
+        $this->assertTrue(true);
+    }
+
+    public function test_returns_early_when_user_lacks_capability(): void
+    {
+        $_POST['contai_billing_topup_nonce'] = 'valid-nonce';
+
+        WP_Mock::userFunction('sanitize_text_field')
+            ->andReturnUsing(function ($val) { return $val; });
+
+        WP_Mock::userFunction('wp_unslash')
+            ->andReturnUsing(function ($val) { return $val; });
+
+        WP_Mock::userFunction('wp_verify_nonce')
+            ->with('valid-nonce', 'contai_billing_topup_action')
+            ->andReturn(1);
+
+        WP_Mock::userFunction('current_user_can')
+            ->with('manage_options')
+            ->andReturn(false);
+
+        $this->service->shouldNotReceive('createTransaction');
+
+        $this->handler->handleRequest();
+
+        $this->assertTrue(true);
+    }
+
+    // ── Validation Tests ───────────────────────────────────────────
+
+    public function test_topup_rejects_amount_below_minimum(): void
+    {
+        $this->mockValidRequest();
+        $_POST['contai_topup_amount'] = '3';
+        $_POST['contai_topup_currency'] = 'USD';
+
+        WP_Mock::userFunction('__')->andReturnUsing(function ($text) { return $text; });
+
+        $this->service->shouldNotReceive('createTransaction');
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected RedirectException');
+        } catch (RedirectException $e) {
+            $this->assertStringContainsString('contai_bl_type=error', $redirectUrl->url);
+        }
+    }
+
+    public function test_topup_rejects_amount_above_maximum(): void
+    {
+        $this->mockValidRequest();
+        $_POST['contai_topup_amount'] = '300';
+        $_POST['contai_topup_currency'] = 'USD';
+
+        WP_Mock::userFunction('__')->andReturnUsing(function ($text) { return $text; });
+
+        $this->service->shouldNotReceive('createTransaction');
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected RedirectException');
+        } catch (RedirectException $e) {
+            $this->assertStringContainsString('contai_bl_type=error', $redirectUrl->url);
+        }
+    }
+
+    public function test_topup_rejects_empty_currency(): void
+    {
+        $this->mockValidRequest();
+        $_POST['contai_topup_amount'] = '10';
+        $_POST['contai_topup_currency'] = '';
+
+        WP_Mock::userFunction('__')->andReturnUsing(function ($text) { return $text; });
+
+        $this->service->shouldNotReceive('createTransaction');
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected RedirectException');
+        } catch (RedirectException $e) {
+            $this->assertStringContainsString('contai_bl_type=error', $redirectUrl->url);
+        }
+    }
+
+    // ── Success Flow Tests ─────────────────────────────────────────
+
+    public function test_topup_success_redirects_to_payment_url(): void
+    {
+        $this->mockValidRequest();
+        $_POST['contai_topup_amount'] = '25';
+        $_POST['contai_topup_currency'] = 'USD';
+
+        $paymentUrl = 'https://payment.example.com/checkout/abc123';
+
+        $this->service
+            ->shouldReceive('createTransaction')
+            ->with(25.0, 'USD', 'Account top-up')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(true, ['payment_url' => $paymentUrl], 'Created', 200));
+
+        WP_Mock::userFunction('esc_url_raw')
+            ->andReturnUsing(function ($url) { return $url; });
+
+        $capturedUrl = new class { public string $url = ''; };
+
+        WP_Mock::userFunction('wp_redirect')
+            ->once()
+            ->andReturnUsing(function ($url) use ($capturedUrl) {
+                $capturedUrl->url = $url;
+                throw new RedirectException('redirect');
+            });
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected RedirectException');
+        } catch (RedirectException $e) {
+            $this->assertEquals($paymentUrl, $capturedUrl->url);
+        }
+    }
+
+    // ── Failure Flow Tests ─────────────────────────────────────────
+
+    public function test_topup_api_failure_redirects_with_error(): void
+    {
+        $this->mockValidRequest();
+        $_POST['contai_topup_amount'] = '25';
+        $_POST['contai_topup_currency'] = 'USD';
+
+        $this->service
+            ->shouldReceive('createTransaction')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(false, null, 'Service unavailable', 503, 'trace-123'));
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected RedirectException');
+        } catch (RedirectException $e) {
+            $this->assertStringContainsString('contai_bl_type=error', $redirectUrl->url);
+            $this->assertStringContainsString('contai_bl_trace_id', $redirectUrl->url);
+        }
+    }
+
+    public function test_topup_missing_payment_url_redirects_with_error(): void
+    {
+        $this->mockValidRequest();
+        $_POST['contai_topup_amount'] = '25';
+        $_POST['contai_topup_currency'] = 'USD';
+
+        $this->service
+            ->shouldReceive('createTransaction')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(true, [], 'Created', 200));
+
+        WP_Mock::userFunction('__')->andReturnUsing(function ($text) { return $text; });
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected RedirectException');
+        } catch (RedirectException $e) {
+            $this->assertStringContainsString('contai_bl_type=error', $redirectUrl->url);
+        }
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────
+
+    private function mockValidRequest(): void
+    {
+        $_POST['contai_billing_topup_nonce'] = 'valid-nonce';
+        $_POST['contai_billing_topup'] = '1';
+
+        WP_Mock::userFunction('sanitize_text_field')
+            ->andReturnUsing(function ($val) { return $val; });
+
+        WP_Mock::userFunction('wp_unslash')
+            ->andReturnUsing(function ($val) { return $val; });
+
+        WP_Mock::userFunction('wp_verify_nonce')
+            ->with('valid-nonce', 'contai_billing_topup_action')
+            ->andReturn(1);
+
+        WP_Mock::userFunction('current_user_can')
+            ->with('manage_options')
+            ->andReturn(true);
+    }
+
+    private function expectRedirect(): object
+    {
+        $capture = new class { public string $url = ''; };
+
+        WP_Mock::userFunction('admin_url')
+            ->andReturn('http://example.com/wp-admin/admin.php?page=contai-billing&section=overview');
+
+        WP_Mock::userFunction('add_query_arg')
+            ->andReturnUsing(function ($args, $url) {
+                return $url . '&' . http_build_query($args);
+            });
+
+        WP_Mock::userFunction('wp_safe_redirect')
+            ->once()
+            ->andReturnUsing(function ($url) use ($capture) {
+                $capture->url = $url;
+                throw new RedirectException('redirect');
+            });
+
+        return $capture;
+    }
+}

--- a/tests/unit/admin/content-generator/handlers/KeywordExtractionHandlerTest.php
+++ b/tests/unit/admin/content-generator/handlers/KeywordExtractionHandlerTest.php
@@ -1,0 +1,321 @@
+<?php
+
+namespace ContAI\Tests\Unit\Admin\ContentGenerator\Handlers;
+
+use WP_Mock;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use ContaiKeywordExtractionHandler;
+use ContaiJobRepository;
+use ContaiJob;
+use ContaiKeywordExtractionJob;
+
+class KeywordRedirectException extends \Error {}
+
+class KeywordExtractionHandlerTest extends TestCase
+{
+    private ContaiJobRepository $jobRepository;
+    private ContaiKeywordExtractionHandler $handler;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        WP_Mock::setUp();
+
+        $this->jobRepository = Mockery::mock(ContaiJobRepository::class);
+        $this->handler = new ContaiKeywordExtractionHandler($this->jobRepository);
+    }
+
+    public function tearDown(): void
+    {
+        unset(
+            $_POST['contai_keyword_extractor_nonce'],
+            $_POST['contai_extract_keywords'],
+            $_POST['contai_topic'],
+            $_POST['contai_country'],
+            $_POST['contai_target_language'],
+            $_SERVER['REQUEST_METHOD']
+        );
+        WP_Mock::tearDown();
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    // ── Security Tests ─────────────────────────────────────────────
+
+    public function test_returns_early_when_not_post_request(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+
+        $this->jobRepository->shouldNotReceive('create');
+
+        $this->handler->handleRequest();
+
+        $this->assertTrue(true);
+    }
+
+    public function test_returns_early_when_no_request_method(): void
+    {
+        unset($_SERVER['REQUEST_METHOD']);
+
+        $this->jobRepository->shouldNotReceive('create');
+
+        $this->handler->handleRequest();
+
+        $this->assertTrue(true);
+    }
+
+    public function test_invalid_nonce_redirects_with_error(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST['contai_keyword_extractor_nonce'] = 'invalid';
+
+        WP_Mock::userFunction('sanitize_text_field')
+            ->andReturnUsing(function ($val) { return $val; });
+
+        WP_Mock::userFunction('wp_unslash')
+            ->andReturnUsing(function ($val) { return $val; });
+
+        WP_Mock::userFunction('wp_verify_nonce')
+            ->with('invalid', 'contai_keyword_extractor_nonce')
+            ->andReturn(false);
+
+        WP_Mock::userFunction('__')->andReturnUsing(function ($text) { return $text; });
+
+        $this->jobRepository->shouldNotReceive('create');
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected redirect');
+        } catch (KeywordRedirectException $e) {
+            $this->assertStringContainsString('error=1', $redirectUrl->url);
+        }
+    }
+
+    public function test_insufficient_capability_redirects_with_error(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST['contai_keyword_extractor_nonce'] = 'valid-nonce';
+
+        WP_Mock::userFunction('sanitize_text_field')
+            ->andReturnUsing(function ($val) { return $val; });
+
+        WP_Mock::userFunction('wp_unslash')
+            ->andReturnUsing(function ($val) { return $val; });
+
+        WP_Mock::userFunction('wp_verify_nonce')
+            ->with('valid-nonce', 'contai_keyword_extractor_nonce')
+            ->andReturn(1);
+
+        WP_Mock::userFunction('current_user_can')
+            ->with('manage_options')
+            ->andReturn(false);
+
+        WP_Mock::userFunction('__')->andReturnUsing(function ($text) { return $text; });
+
+        $this->jobRepository->shouldNotReceive('create');
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected redirect');
+        } catch (KeywordRedirectException $e) {
+            $this->assertStringContainsString('error=1', $redirectUrl->url);
+        }
+    }
+
+    // ── Validation Tests ───────────────────────────────────────────
+
+    public function test_empty_topic_redirects_with_error(): void
+    {
+        $this->mockValidRequest();
+        $_POST['contai_topic'] = '';
+        $_POST['contai_country'] = 'us';
+        $_POST['contai_target_language'] = 'en';
+
+        WP_Mock::userFunction('__')->andReturnUsing(function ($text) { return $text; });
+
+        $this->jobRepository->shouldNotReceive('create');
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected redirect');
+        } catch (KeywordRedirectException $e) {
+            $this->assertStringContainsString('error=1', $redirectUrl->url);
+        }
+    }
+
+    public function test_topic_too_short_redirects_with_error(): void
+    {
+        $this->mockValidRequest();
+        $_POST['contai_topic'] = 'ab';
+        $_POST['contai_country'] = 'us';
+        $_POST['contai_target_language'] = 'en';
+
+        WP_Mock::userFunction('__')->andReturnUsing(function ($text) { return $text; });
+
+        $this->jobRepository->shouldNotReceive('create');
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected redirect');
+        } catch (KeywordRedirectException $e) {
+            $this->assertStringContainsString('error=1', $redirectUrl->url);
+        }
+    }
+
+    public function test_invalid_language_redirects_with_error(): void
+    {
+        $this->mockValidRequest();
+        $_POST['contai_topic'] = 'machine learning';
+        $_POST['contai_country'] = 'us';
+        $_POST['contai_target_language'] = 'fr';
+
+        WP_Mock::userFunction('__')->andReturnUsing(function ($text) { return $text; });
+
+        $this->jobRepository->shouldNotReceive('create');
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected redirect');
+        } catch (KeywordRedirectException $e) {
+            $this->assertStringContainsString('error=1', $redirectUrl->url);
+        }
+    }
+
+    public function test_invalid_country_redirects_with_error(): void
+    {
+        $this->mockValidRequest();
+        $_POST['contai_topic'] = 'machine learning';
+        $_POST['contai_country'] = 'fr';
+        $_POST['contai_target_language'] = 'en';
+
+        WP_Mock::userFunction('__')->andReturnUsing(function ($text) { return $text; });
+
+        $this->jobRepository->shouldNotReceive('create');
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected redirect');
+        } catch (KeywordRedirectException $e) {
+            $this->assertStringContainsString('error=1', $redirectUrl->url);
+        }
+    }
+
+    // ── Success Flow ───────────────────────────────────────────────
+
+    public function test_extract_keywords_success_creates_job_and_redirects(): void
+    {
+        $this->mockValidRequest();
+        $_POST['contai_topic'] = 'machine learning';
+        $_POST['contai_country'] = 'us';
+        $_POST['contai_target_language'] = 'en';
+
+        WP_Mock::userFunction('current_time')
+            ->andReturn('2026-01-01 00:00:00');
+
+        WP_Mock::userFunction('__')->andReturnUsing(function ($text) { return $text; });
+
+        $this->jobRepository
+            ->shouldReceive('create')
+            ->once()
+            ->with(Mockery::on(function ($job) {
+                return $job instanceof ContaiJob;
+            }))
+            ->andReturn(true);
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected redirect');
+        } catch (KeywordRedirectException $e) {
+            $this->assertStringContainsString('success=1', $redirectUrl->url);
+        }
+    }
+
+    // ── Failure Flow ───────────────────────────────────────────────
+
+    public function test_extract_keywords_job_creation_failure_redirects_with_error(): void
+    {
+        $this->mockValidRequest();
+        $_POST['contai_topic'] = 'machine learning';
+        $_POST['contai_country'] = 'us';
+        $_POST['contai_target_language'] = 'en';
+
+        WP_Mock::userFunction('current_time')
+            ->andReturn('2026-01-01 00:00:00');
+
+        WP_Mock::userFunction('__')->andReturnUsing(function ($text) { return $text; });
+
+        $this->jobRepository
+            ->shouldReceive('create')
+            ->once()
+            ->andReturn(false);
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected redirect');
+        } catch (KeywordRedirectException $e) {
+            $this->assertStringContainsString('error=1', $redirectUrl->url);
+        }
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────
+
+    private function mockValidRequest(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST['contai_keyword_extractor_nonce'] = 'valid-nonce';
+        $_POST['contai_extract_keywords'] = '1';
+
+        WP_Mock::userFunction('sanitize_text_field')
+            ->andReturnUsing(function ($val) { return $val; });
+
+        WP_Mock::userFunction('wp_unslash')
+            ->andReturnUsing(function ($val) { return $val; });
+
+        WP_Mock::userFunction('wp_verify_nonce')
+            ->with('valid-nonce', 'contai_keyword_extractor_nonce')
+            ->andReturn(1);
+
+        WP_Mock::userFunction('current_user_can')
+            ->with('manage_options')
+            ->andReturn(true);
+    }
+
+    private function expectRedirect(): object
+    {
+        $capture = new class { public string $url = ''; };
+
+        WP_Mock::userFunction('admin_url')
+            ->andReturn('http://example.com/wp-admin/admin.php');
+
+        WP_Mock::userFunction('add_query_arg')
+            ->andReturnUsing(function ($args, $url) {
+                return $url . '?' . http_build_query($args);
+            });
+
+        WP_Mock::userFunction('wp_safe_redirect')
+            ->once()
+            ->andReturnUsing(function ($url) use ($capture) {
+                $capture->url = $url;
+                throw new KeywordRedirectException('redirect');
+            });
+
+        return $capture;
+    }
+}

--- a/tests/unit/admin/content-generator/handlers/PostGenerationQueueHandlerTest.php
+++ b/tests/unit/admin/content-generator/handlers/PostGenerationQueueHandlerTest.php
@@ -1,0 +1,319 @@
+<?php
+
+namespace ContAI\Tests\Unit\Admin\ContentGenerator\Handlers;
+
+use WP_Mock;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use ContaiPostGenerationQueueHandler;
+use ContaiQueueManager;
+
+class PostGenRedirectException extends \Error {}
+
+class PostGenerationQueueHandlerTest extends TestCase
+{
+    private ContaiQueueManager $queueManager;
+    private ContaiPostGenerationQueueHandler $handler;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        WP_Mock::setUp();
+
+        $this->queueManager = Mockery::mock(ContaiQueueManager::class);
+        $this->handler = new ContaiPostGenerationQueueHandler($this->queueManager);
+    }
+
+    public function tearDown(): void
+    {
+        unset(
+            $_POST['contai_post_generator_nonce'],
+            $_POST['contai_enqueue_posts'],
+            $_POST['contai_clear_queue'],
+            $_POST['post_count'],
+            $_POST['content_lang'],
+            $_POST['content_country'],
+            $_POST['image_provider'],
+            $_SERVER['REQUEST_METHOD']
+        );
+        WP_Mock::tearDown();
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    // ── Security Tests ─────────────────────────────────────────────
+
+    public function test_returns_early_when_not_post_request(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+
+        $this->queueManager->shouldNotReceive('enqueuePostGeneration');
+        $this->queueManager->shouldNotReceive('clearAllJobs');
+
+        $this->handler->handleRequest();
+
+        $this->assertTrue(true);
+    }
+
+    public function test_invalid_nonce_redirects_with_error(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST['contai_post_generator_nonce'] = 'invalid';
+
+        WP_Mock::userFunction('sanitize_text_field')
+            ->andReturnUsing(function ($val) { return $val; });
+
+        WP_Mock::userFunction('wp_unslash')
+            ->andReturnUsing(function ($val) { return $val; });
+
+        WP_Mock::userFunction('wp_verify_nonce')
+            ->with('invalid', 'contai_post_generator_nonce')
+            ->andReturn(false);
+
+        WP_Mock::userFunction('__')->andReturnUsing(function ($text) { return $text; });
+
+        $this->queueManager->shouldNotReceive('enqueuePostGeneration');
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected redirect');
+        } catch (PostGenRedirectException $e) {
+            $this->assertStringContainsString('error=1', $redirectUrl->url);
+        }
+    }
+
+    public function test_insufficient_capability_redirects_with_error(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST['contai_post_generator_nonce'] = 'valid-nonce';
+
+        WP_Mock::userFunction('sanitize_text_field')
+            ->andReturnUsing(function ($val) { return $val; });
+
+        WP_Mock::userFunction('wp_unslash')
+            ->andReturnUsing(function ($val) { return $val; });
+
+        WP_Mock::userFunction('wp_verify_nonce')
+            ->with('valid-nonce', 'contai_post_generator_nonce')
+            ->andReturn(1);
+
+        WP_Mock::userFunction('current_user_can')
+            ->with('manage_options')
+            ->andReturn(false);
+
+        WP_Mock::userFunction('__')->andReturnUsing(function ($text) { return $text; });
+
+        $this->queueManager->shouldNotReceive('enqueuePostGeneration');
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected redirect');
+        } catch (PostGenRedirectException $e) {
+            $this->assertStringContainsString('error=1', $redirectUrl->url);
+        }
+    }
+
+    // ── Enqueue Validation Tests ───────────────────────────────────
+
+    public function test_enqueue_rejects_zero_post_count(): void
+    {
+        $this->mockValidRequest('contai_enqueue_posts');
+        $_POST['post_count'] = '0';
+        $_POST['content_lang'] = 'en';
+        $_POST['content_country'] = 'us';
+        $_POST['image_provider'] = 'pexels';
+
+        WP_Mock::userFunction('__')->andReturnUsing(function ($text) { return $text; });
+        WP_Mock::userFunction('absint')->andReturnUsing(function ($val) { return abs(intval($val)); });
+
+        $this->queueManager->shouldNotReceive('enqueuePostGeneration');
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected redirect');
+        } catch (PostGenRedirectException $e) {
+            $this->assertStringContainsString('error=1', $redirectUrl->url);
+        }
+    }
+
+    public function test_enqueue_rejects_count_above_100(): void
+    {
+        $this->mockValidRequest('contai_enqueue_posts');
+        $_POST['post_count'] = '150';
+        $_POST['content_lang'] = 'en';
+        $_POST['content_country'] = 'us';
+        $_POST['image_provider'] = 'pexels';
+
+        WP_Mock::userFunction('__')->andReturnUsing(function ($text) { return $text; });
+        WP_Mock::userFunction('absint')->andReturnUsing(function ($val) { return abs(intval($val)); });
+
+        $this->queueManager->shouldNotReceive('enqueuePostGeneration');
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected redirect');
+        } catch (PostGenRedirectException $e) {
+            $this->assertStringContainsString('error=1', $redirectUrl->url);
+        }
+    }
+
+    public function test_enqueue_rejects_empty_language(): void
+    {
+        $this->mockValidRequest('contai_enqueue_posts');
+        $_POST['post_count'] = '5';
+        $_POST['content_lang'] = '';
+        $_POST['content_country'] = 'us';
+        $_POST['image_provider'] = 'pexels';
+
+        WP_Mock::userFunction('__')->andReturnUsing(function ($text) { return $text; });
+        WP_Mock::userFunction('absint')->andReturnUsing(function ($val) { return abs(intval($val)); });
+
+        $this->queueManager->shouldNotReceive('enqueuePostGeneration');
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected redirect');
+        } catch (PostGenRedirectException $e) {
+            $this->assertStringContainsString('error=1', $redirectUrl->url);
+        }
+    }
+
+    public function test_enqueue_rejects_invalid_image_provider(): void
+    {
+        $this->mockValidRequest('contai_enqueue_posts');
+        $_POST['post_count'] = '5';
+        $_POST['content_lang'] = 'en';
+        $_POST['content_country'] = 'us';
+        $_POST['image_provider'] = 'unsplash';
+
+        WP_Mock::userFunction('__')->andReturnUsing(function ($text) { return $text; });
+        WP_Mock::userFunction('absint')->andReturnUsing(function ($val) { return abs(intval($val)); });
+
+        $this->queueManager->shouldNotReceive('enqueuePostGeneration');
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected redirect');
+        } catch (PostGenRedirectException $e) {
+            $this->assertStringContainsString('error=1', $redirectUrl->url);
+        }
+    }
+
+    // ── Enqueue Success ────────────────────────────────────────────
+
+    public function test_enqueue_posts_success(): void
+    {
+        $this->mockValidRequest('contai_enqueue_posts');
+        $_POST['post_count'] = '10';
+        $_POST['content_lang'] = 'en';
+        $_POST['content_country'] = 'us';
+        $_POST['image_provider'] = 'pexels';
+
+        WP_Mock::userFunction('absint')->andReturnUsing(function ($val) { return abs(intval($val)); });
+
+        $this->queueManager
+            ->shouldReceive('enqueuePostGeneration')
+            ->once()
+            ->with(10, Mockery::on(function ($config) {
+                return $config['lang'] === 'en'
+                    && $config['country'] === 'us'
+                    && $config['image_provider'] === 'pexels';
+            }))
+            ->andReturn(10);
+
+        WP_Mock::userFunction('_n')->andReturnUsing(function ($single, $plural, $count) {
+            return $count === 1 ? $single : $plural;
+        });
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected redirect');
+        } catch (PostGenRedirectException $e) {
+            $this->assertStringContainsString('success=1', $redirectUrl->url);
+        }
+    }
+
+    // ── Clear Queue Tests ──────────────────────────────────────────
+
+    public function test_clear_queue_success(): void
+    {
+        $this->mockValidRequest('contai_clear_queue');
+
+        $this->queueManager
+            ->shouldReceive('clearAllJobs')
+            ->once()
+            ->andReturn(5);
+
+        WP_Mock::userFunction('_n')->andReturnUsing(function ($single, $plural, $count) {
+            return $count === 1 ? $single : $plural;
+        });
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected redirect');
+        } catch (PostGenRedirectException $e) {
+            $this->assertStringContainsString('success=1', $redirectUrl->url);
+        }
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────
+
+    private function mockValidRequest(string $action): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $_POST['contai_post_generator_nonce'] = 'valid-nonce';
+        $_POST[$action] = '1';
+
+        WP_Mock::userFunction('sanitize_text_field')
+            ->andReturnUsing(function ($val) { return $val; });
+
+        WP_Mock::userFunction('wp_unslash')
+            ->andReturnUsing(function ($val) { return $val; });
+
+        WP_Mock::userFunction('wp_verify_nonce')
+            ->with('valid-nonce', 'contai_post_generator_nonce')
+            ->andReturn(1);
+
+        WP_Mock::userFunction('current_user_can')
+            ->with('manage_options')
+            ->andReturn(true);
+    }
+
+    private function expectRedirect(): object
+    {
+        $capture = new class { public string $url = ''; };
+
+        WP_Mock::userFunction('admin_url')
+            ->andReturn('http://example.com/wp-admin/admin.php');
+
+        WP_Mock::userFunction('add_query_arg')
+            ->andReturnUsing(function ($args, $url) {
+                return $url . '?' . http_build_query($args);
+            });
+
+        WP_Mock::userFunction('wp_safe_redirect')
+            ->once()
+            ->andReturnUsing(function ($url) use ($capture) {
+                $capture->url = $url;
+                throw new PostGenRedirectException('redirect');
+            });
+
+        return $capture;
+    }
+}


### PR DESCRIPTION
## Summary

- Add **38 unit tests** covering the 4 most critical admin form handlers, resolving the lack of test coverage for `includes/admin/` (#22)
- Refactor `KeywordExtractionHandler` and `PostGenerationQueueHandler` constructors for dependency injection
- Update `phpunit.xml.dist` to include admin handler directories in code coverage

### Test breakdown

| Handler | Tests | Coverage |
|---|---|---|
| `TopUpHandler` (billing) | 9 | Nonce, capability, amount validation ($5–$200), currency, payment URL redirect, API failure |
| `PublisuitesFormHandler` | 10 | Nonce, capability, connect, verify, disconnect, verification file |
| `KeywordExtractionHandler` | 10 | Nonce, capability, topic/language/country validation, job creation |
| `PostGenerationQueueHandler` | 9 | Nonce, capability, count/language/provider validation, enqueue, clear queue |

## Test plan

- [x] All 425 tests pass (645 assertions)
- [x] No regressions in existing test suites
- [x] New tests follow established `SearchConsoleFormHandlerTest` pattern
- [x] Handlers using DI remain backward-compatible (optional constructor params)

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)