### PR TITLE
feat(db): implement MigrationRunner with version tracking and rollback (#24)

### DIFF
--- a/1platform-content-ai.php
+++ b/1platform-content-ai.php
@@ -61,46 +61,37 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/services/agents/ContaiAgent
 require_once plugin_dir_path( __FILE__ ) . 'includes/admin/agents/ContaiAgentsAdminPage.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/cron/agent-actions-cron.php';
 
+require_once plugin_dir_path(__FILE__) . 'includes/database/MigrationRunner.php';
 require_once plugin_dir_path(__FILE__) . 'includes/database/migrations/CreateKeywordsTable.php';
 require_once plugin_dir_path(__FILE__) . 'includes/database/migrations/CreateAPILogsTable.php';
 require_once plugin_dir_path(__FILE__) . 'includes/database/migrations/CreateJobsTable.php';
 require_once plugin_dir_path(__FILE__) . 'includes/database/migrations/UpdateKeywordsTableStatus.php';
 require_once plugin_dir_path(__FILE__) . 'includes/database/migrations/CreateInternalLinksTable.php';
 
+/**
+ * Build the migration runner with all registered migrations.
+ *
+ * Each migration is assigned a sequential version number.
+ * New migrations MUST be appended at the end with the next version number.
+ */
+function contai_build_migration_runner(): ContaiMigrationRunner {
+    $runner = new ContaiMigrationRunner();
+
+    $runner->register(1, new ContaiCreateKeywordsTable());
+    $runner->register(2, new ContaiCreateAPILogsTable());
+    $runner->register(3, new ContaiCreateJobsTable());
+    $runner->register(4, new ContaiUpdateKeywordsTableStatus());
+    $runner->register(5, new ContaiCreateInternalLinksTable());
+
+    return $runner;
+}
+
 function contai_activate_plugin() {
-    try {
-        $keywords_migration = new ContaiCreateKeywordsTable();
-        $keywords_migration->up();
-    } catch (Exception $e) {
-        contai_log("ContaiCreateKeywordsTable migration error: " . $e->getMessage());
-    }
+    $runner = contai_build_migration_runner();
+    $result = $runner->run();
 
-    try {
-        $api_logs_migration = new ContaiCreateAPILogsTable();
-        $api_logs_migration->up();
-    } catch (Exception $e) {
-        contai_log("ContaiCreateAPILogsTable migration error: " . $e->getMessage());
-    }
-
-    try {
-        $jobs_migration = new ContaiCreateJobsTable();
-        $jobs_migration->up();
-    } catch (Exception $e) {
-        contai_log("ContaiCreateJobsTable migration error: " . $e->getMessage());
-    }
-
-    try {
-        $update_keywords_status = new ContaiUpdateKeywordsTableStatus();
-        $update_keywords_status->up();
-    } catch (Exception $e) {
-        contai_log("ContaiUpdateKeywordsTableStatus migration error: " . $e->getMessage());
-    }
-
-    try {
-        $internal_links_migration = new ContaiCreateInternalLinksTable();
-        $internal_links_migration->up();
-    } catch (Exception $e) {
-        contai_log("ContaiCreateInternalLinksTable migration error: " . $e->getMessage());
+    if (!$result['success']) {
+        contai_log('Migration batch failed: ' . $result['message']);
     }
 
     try {
@@ -308,3 +299,31 @@ function contai_display_auth_error_notices(): void {
     }
 }
 add_action('admin_notices', 'contai_display_auth_error_notices');
+
+/**
+ * Display admin notice when database migrations have failed.
+ */
+function contai_display_migration_error_notice(): void {
+    if (!current_user_can('manage_options')) {
+        return;
+    }
+
+    $screen = get_current_screen();
+    if (!$screen || strpos($screen->id, 'contai') === false) {
+        return;
+    }
+
+    require_once plugin_dir_path(__FILE__) . 'includes/database/MigrationRunner.php';
+
+    $error = ContaiMigrationRunner::getError();
+    if ($error === null) {
+        return;
+    }
+
+    printf(
+        '<div class="notice notice-error"><p><strong>%s</strong> %s</p></div>',
+        esc_html__('Content AI Database Error:', '1platform-content-ai'),
+        esc_html($error)
+    );
+}
+add_action('admin_notices', 'contai_display_migration_error_notice');

--- a/includes/database/MigrationRunner.php
+++ b/includes/database/MigrationRunner.php
@@ -1,0 +1,139 @@
+<?php
+
+if (!defined('ABSPATH')) exit;
+
+class ContaiMigrationRunner {
+
+    private const OPTION_DB_VERSION = 'contai_db_version';
+    private const OPTION_MIGRATION_ERROR = 'contai_migration_error';
+
+    /** @var array<int, object> Version => migration instance */
+    private array $migrations = [];
+
+    public function register(int $version, object $migration): void {
+        $this->migrations[$version] = $migration;
+    }
+
+    public function run(): array {
+        $current_version = $this->getCurrentVersion();
+        $pending = $this->getPendingMigrations($current_version);
+
+        if (empty($pending)) {
+            return [
+                'success' => true,
+                'message' => 'No pending migrations',
+                'version' => $current_version,
+                'applied' => [],
+            ];
+        }
+
+        $applied = [];
+
+        foreach ($pending as $version => $migration) {
+            $class_name = get_class($migration);
+
+            try {
+                $result = $migration->up();
+            } catch (\Exception $e) {
+                $result = false;
+                contai_log(sprintf('%s migration exception: %s', $class_name, $e->getMessage()));
+            }
+
+            if ($result === false) {
+                contai_log(sprintf('%s migration failed at version %d', $class_name, $version));
+
+                $this->rollback($applied);
+                $error_message = sprintf(
+                    'Migration %s (v%d) failed. All changes from this batch have been rolled back.',
+                    $class_name,
+                    $version
+                );
+                $this->storeError($error_message);
+
+                return [
+                    'success' => false,
+                    'message' => $error_message,
+                    'version' => $current_version,
+                    'applied' => [],
+                    'failed_at' => $version,
+                ];
+            }
+
+            $applied[$version] = $migration;
+            $this->setCurrentVersion($version);
+
+            contai_log(sprintf('%s migration applied (v%d)', $class_name, $version));
+        }
+
+        $this->clearError();
+
+        return [
+            'success' => true,
+            'message' => sprintf('%d migration(s) applied successfully', count($applied)),
+            'version' => $this->getCurrentVersion(),
+            'applied' => array_keys($applied),
+        ];
+    }
+
+    private function rollback(array $applied): void {
+        $reversed = array_reverse($applied, true);
+
+        foreach ($reversed as $version => $migration) {
+            $class_name = get_class($migration);
+
+            if (!method_exists($migration, 'down')) {
+                contai_log(sprintf('%s has no down() method, skipping rollback for v%d', $class_name, $version));
+                continue;
+            }
+
+            try {
+                $migration->down();
+                contai_log(sprintf('%s rolled back (v%d)', $class_name, $version));
+            } catch (\Exception $e) {
+                contai_log(sprintf('%s rollback failed (v%d): %s', $class_name, $version, $e->getMessage()));
+            }
+        }
+    }
+
+    public function getCurrentVersion(): int {
+        return (int) get_option(self::OPTION_DB_VERSION, 0);
+    }
+
+    private function setCurrentVersion(int $version): void {
+        update_option(self::OPTION_DB_VERSION, $version, false);
+    }
+
+    private function getPendingMigrations(int $current_version): array {
+        ksort($this->migrations);
+
+        return array_filter($this->migrations, function (int $version) use ($current_version) {
+            return $version > $current_version;
+        }, ARRAY_FILTER_USE_KEY);
+    }
+
+    private function storeError(string $message): void {
+        update_option(self::OPTION_MIGRATION_ERROR, $message, false);
+    }
+
+    private function clearError(): void {
+        delete_option(self::OPTION_MIGRATION_ERROR);
+    }
+
+    public static function getError(): ?string {
+        $error = get_option(self::OPTION_MIGRATION_ERROR, '');
+        return !empty($error) ? $error : null;
+    }
+
+    public static function hasError(): bool {
+        return self::getError() !== null;
+    }
+
+    public static function clearStoredError(): void {
+        delete_option(self::OPTION_MIGRATION_ERROR);
+    }
+
+    public function getMigrations(): array {
+        ksort($this->migrations);
+        return $this->migrations;
+    }
+}

--- a/includes/database/migrations/UpdateKeywordsTableStatus.php
+++ b/includes/database/migrations/UpdateKeywordsTableStatus.php
@@ -26,4 +26,22 @@ class ContaiUpdateKeywordsTableStatus {
 
         return $this->db->query($sql);
     }
+
+    public function down(): bool {
+        if (!$this->db->tableExists($this->tableName)) {
+            return true;
+        }
+
+        $table = $this->db->getTableName($this->tableName);
+
+        $sql = "ALTER TABLE {$table}
+                MODIFY COLUMN status ENUM('active', 'inactive', 'pending', 'processing', 'done')
+                NOT NULL DEFAULT 'pending'";
+
+        return $this->db->query($sql);
+    }
+
+    public function getTableName(): string {
+        return $this->tableName;
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -23,6 +23,7 @@ class_alias(WPContentAI\ContaiDatabase\Models\ContaiInternalLink::class, 'WPCont
 
 // ── Database ────────────────────────────────────────────────────
 require_once __DIR__ . '/../includes/database/Database.php';
+require_once __DIR__ . '/../includes/database/MigrationRunner.php';
 require_once __DIR__ . '/../includes/database/repositories/JobRepository.php';
 require_once __DIR__ . '/../includes/database/repositories/KeywordRepository.php';
 

--- a/tests/unit/database/MigrationRunnerTest.php
+++ b/tests/unit/database/MigrationRunnerTest.php
@@ -1,0 +1,466 @@
+<?php
+
+namespace ContAI\Tests\Unit\Database;
+
+use WP_Mock;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use ContaiMigrationRunner;
+
+class MigrationRunnerTest extends TestCase {
+
+    public function setUp(): void {
+        parent::setUp();
+        WP_Mock::setUp();
+    }
+
+    public function tearDown(): void {
+        WP_Mock::tearDown();
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    private function createMigration(bool $up_result = true, bool $has_down = true, bool $down_result = true): object {
+        $migration = Mockery::mock();
+        $migration->shouldReceive('up')->andReturn($up_result)->byDefault();
+
+        if ($has_down) {
+            $migration->shouldReceive('down')->andReturn($down_result)->byDefault();
+        }
+
+        return $migration;
+    }
+
+    // ── No pending migrations ────────────────────────────────────
+
+    public function test_run_returns_success_when_no_migrations_registered(): void {
+        WP_Mock::userFunction('get_option')
+            ->with('contai_db_version', 0)
+            ->andReturn(0);
+
+        $runner = new ContaiMigrationRunner();
+        $result = $runner->run();
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('No pending migrations', $result['message']);
+        $this->assertSame(0, $result['version']);
+        $this->assertEmpty($result['applied']);
+    }
+
+    public function test_run_skips_already_applied_migrations(): void {
+        WP_Mock::userFunction('get_option')
+            ->with('contai_db_version', 0)
+            ->andReturn(3);
+
+        $migration1 = $this->createMigration();
+        $migration1->shouldNotReceive('up');
+        $migration2 = $this->createMigration();
+        $migration2->shouldNotReceive('up');
+
+        $runner = new ContaiMigrationRunner();
+        $runner->register(1, $migration1);
+        $runner->register(2, $migration2);
+
+        $result = $runner->run();
+
+        $this->assertTrue($result['success']);
+        $this->assertSame('No pending migrations', $result['message']);
+    }
+
+    // ── Successful migrations ────────────────────────────────────
+
+    public function test_run_applies_all_pending_migrations_in_order(): void {
+        $call_order = [];
+
+        WP_Mock::userFunction('get_option')
+            ->with('contai_db_version', 0)
+            ->andReturn(0);
+
+        $migration1 = Mockery::mock();
+        $migration1->shouldReceive('up')->once()->andReturnUsing(function () use (&$call_order) {
+            $call_order[] = 1;
+            return true;
+        });
+
+        $migration2 = Mockery::mock();
+        $migration2->shouldReceive('up')->once()->andReturnUsing(function () use (&$call_order) {
+            $call_order[] = 2;
+            return true;
+        });
+
+        $migration3 = Mockery::mock();
+        $migration3->shouldReceive('up')->once()->andReturnUsing(function () use (&$call_order) {
+            $call_order[] = 3;
+            return true;
+        });
+
+        WP_Mock::userFunction('update_option')->times(3);
+        WP_Mock::userFunction('delete_option')
+            ->with('contai_migration_error')
+            ->once();
+
+        $runner = new ContaiMigrationRunner();
+        $runner->register(1, $migration1);
+        $runner->register(2, $migration2);
+        $runner->register(3, $migration3);
+
+        $result = $runner->run();
+
+        $this->assertTrue($result['success']);
+        $this->assertSame([1, 2, 3], $result['applied']);
+        $this->assertSame([1, 2, 3], $call_order);
+    }
+
+    public function test_run_updates_version_after_each_migration(): void {
+        WP_Mock::userFunction('get_option')
+            ->with('contai_db_version', 0)
+            ->andReturn(0);
+
+        $versions_set = [];
+
+        WP_Mock::userFunction('update_option')
+            ->withArgs(function ($key, $value) use (&$versions_set) {
+                if ($key === 'contai_db_version') {
+                    $versions_set[] = $value;
+                }
+                return true;
+            });
+
+        WP_Mock::userFunction('delete_option')
+            ->with('contai_migration_error');
+
+        $runner = new ContaiMigrationRunner();
+        $runner->register(1, $this->createMigration());
+        $runner->register(2, $this->createMigration());
+
+        $runner->run();
+
+        $this->assertSame([1, 2], $versions_set);
+    }
+
+    public function test_run_only_applies_migrations_after_current_version(): void {
+        WP_Mock::userFunction('get_option')
+            ->with('contai_db_version', 0)
+            ->andReturn(2);
+
+        $migration1 = $this->createMigration();
+        $migration1->shouldNotReceive('up');
+
+        $migration2 = $this->createMigration();
+        $migration2->shouldNotReceive('up');
+
+        $migration3 = Mockery::mock();
+        $migration3->shouldReceive('up')->once()->andReturn(true);
+
+        WP_Mock::userFunction('update_option')->times(1);
+        WP_Mock::userFunction('delete_option')
+            ->with('contai_migration_error')
+            ->once();
+
+        $runner = new ContaiMigrationRunner();
+        $runner->register(1, $migration1);
+        $runner->register(2, $migration2);
+        $runner->register(3, $migration3);
+
+        $result = $runner->run();
+
+        $this->assertTrue($result['success']);
+        $this->assertSame([3], $result['applied']);
+    }
+
+    // ── Failed migrations with rollback ──────────────────────────
+
+    public function test_run_rolls_back_applied_migrations_on_failure(): void {
+        WP_Mock::userFunction('get_option')
+            ->with('contai_db_version', 0)
+            ->andReturn(0);
+
+        $tracker = new \stdClass();
+        $tracker->down_called = [];
+
+        $migration1 = new class($tracker) {
+            private object $tracker;
+            public function __construct(object $t) { $this->tracker = $t; }
+            public function up(): bool { return true; }
+            public function down(): bool { $this->tracker->down_called[] = 1; return true; }
+        };
+
+        $migration2 = new class($tracker) {
+            private object $tracker;
+            public function __construct(object $t) { $this->tracker = $t; }
+            public function up(): bool { return true; }
+            public function down(): bool { $this->tracker->down_called[] = 2; return true; }
+        };
+
+        $migration3 = new class {
+            public function up(): bool { return false; }
+            public function down(): bool { return true; }
+        };
+
+        WP_Mock::userFunction('update_option');
+
+        $runner = new ContaiMigrationRunner();
+        $runner->register(1, $migration1);
+        $runner->register(2, $migration2);
+        $runner->register(3, $migration3);
+
+        $result = $runner->run();
+
+        $this->assertFalse($result['success']);
+        $this->assertSame(3, $result['failed_at']);
+        $this->assertEmpty($result['applied']);
+        $this->assertSame([2, 1], $tracker->down_called);
+    }
+
+    public function test_run_rolls_back_in_reverse_order(): void {
+        $tracker = new \stdClass();
+        $tracker->order = [];
+
+        WP_Mock::userFunction('get_option')
+            ->with('contai_db_version', 0)
+            ->andReturn(0);
+
+        $migration1 = new class($tracker) {
+            private object $tracker;
+            public function __construct(object $t) { $this->tracker = $t; }
+            public function up(): bool { return true; }
+            public function down(): bool { $this->tracker->order[] = 1; return true; }
+        };
+
+        $migration2 = new class($tracker) {
+            private object $tracker;
+            public function __construct(object $t) { $this->tracker = $t; }
+            public function up(): bool { return true; }
+            public function down(): bool { $this->tracker->order[] = 2; return true; }
+        };
+
+        $migration3 = new class {
+            public function up(): bool { return false; }
+        };
+
+        WP_Mock::userFunction('update_option');
+
+        $runner = new ContaiMigrationRunner();
+        $runner->register(1, $migration1);
+        $runner->register(2, $migration2);
+        $runner->register(3, $migration3);
+
+        $runner->run();
+
+        $this->assertSame([2, 1], $tracker->order);
+    }
+
+    public function test_run_stores_error_on_failure(): void {
+        WP_Mock::userFunction('get_option')
+            ->with('contai_db_version', 0)
+            ->andReturn(0);
+
+        $migration1 = Mockery::mock();
+        $migration1->shouldReceive('up')->once()->andReturn(false);
+
+        $stored_error = null;
+        WP_Mock::userFunction('update_option')
+            ->withArgs(function ($key, $value) use (&$stored_error) {
+                if ($key === 'contai_migration_error') {
+                    $stored_error = $value;
+                }
+                return true;
+            });
+
+        $runner = new ContaiMigrationRunner();
+        $runner->register(1, $migration1);
+
+        $runner->run();
+
+        $this->assertNotNull($stored_error);
+        $this->assertStringContainsString('v1', $stored_error);
+        $this->assertStringContainsString('failed', $stored_error);
+    }
+
+    public function test_run_handles_exception_in_up_as_failure(): void {
+        WP_Mock::userFunction('get_option')
+            ->with('contai_db_version', 0)
+            ->andReturn(0);
+
+        $migration1 = Mockery::mock();
+        $migration1->shouldReceive('up')->once()->andThrow(new \RuntimeException('DB connection lost'));
+
+        WP_Mock::userFunction('update_option');
+
+        $runner = new ContaiMigrationRunner();
+        $runner->register(1, $migration1);
+
+        $result = $runner->run();
+
+        $this->assertFalse($result['success']);
+        $this->assertSame(1, $result['failed_at']);
+    }
+
+    public function test_run_continues_rollback_if_down_throws_exception(): void {
+        WP_Mock::userFunction('get_option')
+            ->with('contai_db_version', 0)
+            ->andReturn(0);
+
+        $tracker = new \stdClass();
+        $tracker->order = [];
+
+        $migration1 = new class($tracker) {
+            private object $tracker;
+            public function __construct(object $t) { $this->tracker = $t; }
+            public function up(): bool { return true; }
+            public function down(): bool { $this->tracker->order[] = 1; return true; }
+        };
+
+        $migration2 = new class {
+            public function up(): bool { return true; }
+            public function down(): bool { throw new \RuntimeException('Cannot drop'); }
+        };
+
+        $migration3 = new class {
+            public function up(): bool { return false; }
+        };
+
+        WP_Mock::userFunction('update_option');
+
+        $runner = new ContaiMigrationRunner();
+        $runner->register(1, $migration1);
+        $runner->register(2, $migration2);
+        $runner->register(3, $migration3);
+
+        $result = $runner->run();
+
+        $this->assertFalse($result['success']);
+        // migration1's down() should still be called even though migration2's down() threw
+        $this->assertSame([1], $tracker->order);
+    }
+
+    public function test_run_skips_rollback_for_migration_without_down_method(): void {
+        WP_Mock::userFunction('get_option')
+            ->with('contai_db_version', 0)
+            ->andReturn(0);
+
+        // Migration without down() method
+        $migration1 = new class {
+            public function up(): bool { return true; }
+        };
+
+        $migration2 = new class {
+            public function up(): bool { return false; }
+        };
+
+        WP_Mock::userFunction('update_option');
+
+        $runner = new ContaiMigrationRunner();
+        $runner->register(1, $migration1);
+        $runner->register(2, $migration2);
+
+        $result = $runner->run();
+
+        $this->assertFalse($result['success']);
+    }
+
+    // ── Version tracking ─────────────────────────────────────────
+
+    public function test_get_current_version_returns_stored_value(): void {
+        WP_Mock::userFunction('get_option')
+            ->with('contai_db_version', 0)
+            ->andReturn(5);
+
+        $runner = new ContaiMigrationRunner();
+
+        $this->assertSame(5, $runner->getCurrentVersion());
+    }
+
+    public function test_get_current_version_returns_zero_when_not_set(): void {
+        WP_Mock::userFunction('get_option')
+            ->with('contai_db_version', 0)
+            ->andReturn(0);
+
+        $runner = new ContaiMigrationRunner();
+
+        $this->assertSame(0, $runner->getCurrentVersion());
+    }
+
+    // ── Error state methods ──────────────────────────────────────
+
+    public function test_get_error_returns_stored_error(): void {
+        WP_Mock::userFunction('get_option')
+            ->with('contai_migration_error', '')
+            ->andReturn('Migration failed at v3');
+
+        $this->assertSame('Migration failed at v3', ContaiMigrationRunner::getError());
+    }
+
+    public function test_get_error_returns_null_when_no_error(): void {
+        WP_Mock::userFunction('get_option')
+            ->with('contai_migration_error', '')
+            ->andReturn('');
+
+        $this->assertNull(ContaiMigrationRunner::getError());
+    }
+
+    public function test_has_error_returns_true_when_error_exists(): void {
+        WP_Mock::userFunction('get_option')
+            ->with('contai_migration_error', '')
+            ->andReturn('Something failed');
+
+        $this->assertTrue(ContaiMigrationRunner::hasError());
+    }
+
+    public function test_has_error_returns_false_when_no_error(): void {
+        WP_Mock::userFunction('get_option')
+            ->with('contai_migration_error', '')
+            ->andReturn('');
+
+        $this->assertFalse(ContaiMigrationRunner::hasError());
+    }
+
+    public function test_clear_stored_error_deletes_option(): void {
+        WP_Mock::userFunction('delete_option')
+            ->with('contai_migration_error')
+            ->once();
+
+        ContaiMigrationRunner::clearStoredError();
+
+        // If we get here without exception, the assertion passed via WP_Mock expectation
+        $this->assertTrue(true);
+    }
+
+    // ── Successful run clears previous error ─────────────────────
+
+    public function test_successful_run_clears_previous_error(): void {
+        WP_Mock::userFunction('get_option')
+            ->with('contai_db_version', 0)
+            ->andReturn(0);
+
+        WP_Mock::userFunction('update_option');
+
+        WP_Mock::userFunction('delete_option')
+            ->with('contai_migration_error')
+            ->once();
+
+        $runner = new ContaiMigrationRunner();
+        $runner->register(1, $this->createMigration());
+
+        $result = $runner->run();
+
+        $this->assertTrue($result['success']);
+    }
+
+    // ── Registration ─────────────────────────────────────────────
+
+    public function test_get_migrations_returns_sorted_by_version(): void {
+        $m1 = $this->createMigration();
+        $m3 = $this->createMigration();
+        $m2 = $this->createMigration();
+
+        $runner = new ContaiMigrationRunner();
+        $runner->register(3, $m3);
+        $runner->register(1, $m1);
+        $runner->register(2, $m2);
+
+        $migrations = $runner->getMigrations();
+
+        $this->assertSame([1, 2, 3], array_keys($migrations));
+    }
+}


### PR DESCRIPTION
## Summary

Closes #24

- **MigrationRunner** — New service that runs migrations sequentially, tracks schema version in `contai_db_version` (wp_options), and automatically rolls back applied migrations (in reverse order) if any migration fails
- **Admin notice** — Displays error on plugin pages when migrations have failed, following existing auth error notice pattern
- **Activation hook refactored** — Replaced 5 individual try/catch blocks with a single `$runner->run()` call
- **UpdateKeywordsTableStatus** — Added missing `down()` and `getTableName()` methods for rollback support

## Files changed

| File | Change |
|---|---|
| `includes/database/MigrationRunner.php` | New: version-tracked migration runner with rollback |
| `1platform-content-ai.php` | Refactored activation hook + migration error admin notice |
| `includes/database/migrations/UpdateKeywordsTableStatus.php` | Added `down()` and `getTableName()` |
| `tests/unit/database/MigrationRunnerTest.php` | 20 new unit tests |
| `tests/bootstrap.php` | Registered MigrationRunner for test autoloading |

## Test plan

- [x] All 445 tests pass (679 assertions)
- [x] 20 new MigrationRunner tests cover: sequential execution, version tracking, rollback in reverse order, exception handling, skip without `down()`, error storage/retrieval, error cleared on success
- [ ] Activate plugin on fresh install → verify all tables created and `contai_db_version` = 5
- [ ] Deactivate/reactivate on existing install → verify no duplicate table errors
- [ ] Simulate migration failure → verify rollback executes and admin notice appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)