### PR TITLE
feat: add credit validation guard across all content generation entry points

### DIFF
--- a/includes/admin/admin-ai-site-generator.php
+++ b/includes/admin/admin-ai-site-generator.php
@@ -60,6 +60,25 @@ function contai_handle_ai_site_generator_submission() {
 		exit;
 	}
 
+	// Validate credits before starting site generation
+	require_once __DIR__ . '/../services/billing/CreditGuard.php';
+	$creditGuard = new ContaiCreditGuard();
+	$creditCheck = $creditGuard->validateCredits();
+
+	if ( ! $creditCheck['has_credits'] ) {
+		wp_safe_redirect(
+			add_query_arg(
+				array(
+					'page'    => 'contai-ai-site-generator',
+					'error'   => 1,
+					'message' => $creditCheck['message'],
+				),
+				admin_url( 'admin.php' )
+			)
+		);
+		exit;
+	}
+
 	$jobRepository = new ContaiJobRepository();
 	$activeJob = $jobRepository->findActiveSiteGenerationJob();
 
@@ -117,7 +136,7 @@ function contai_handle_ai_site_generator_submission() {
 			'current_step' => 0,
 			'current_step_name' => '',
 			'completed_steps' => array(),
-			'total_steps' => 11,
+			'total_steps' => ( new ContaiSiteGenerationJob() )->getStepCount(),
 			'started_at' => current_time( 'mysql' ),
 		),
 	);
@@ -216,11 +235,12 @@ function contai_ai_site_generator_page() {
 }
 
 function contai_render_active_job_status( $job ) {
+	require_once __DIR__ . '/../services/billing/CreditGuard.php';
 	$payload = $job->getPayload();
 	$progress = $payload['progress'] ?? array();
 	$currentStep = $progress['current_step_name'] ?? 'Unknown';
 	$completedSteps = $progress['completed_steps'] ?? array();
-	$totalSteps = $progress['total_steps'] ?? 11;
+	$totalSteps = $progress['total_steps'] ?? ( new ContaiSiteGenerationJob() )->getStepCount();
 	$completedCount = count( $completedSteps );
 	$percentage = $totalSteps > 0 ? round( ( $completedCount / $totalSteps ) * 100 ) : 0;
 	$status = $job->getStatus();
@@ -290,16 +310,36 @@ function contai_render_active_job_status( $job ) {
 				</a>
 			</div>
 
-			<?php if ( $status === 'FAILED' ) : ?>
-				<div class="contai-info-box contai-info-box-error" style="margin-top: 20px;">
-					<div class="contai-info-box-icon">
-						<span class="dashicons dashicons-warning"></span>
+			<?php if ( $status === 'FAILED' ) :
+				$jobError = $job->getErrorMessage() ?? 'Unknown error';
+				$isBalanceError = ContaiCreditGuard::isInsufficientCreditsError( $jobError )
+					|| stripos( $jobError, 'Insufficient balance' ) !== false;
+			?>
+				<?php if ( $isBalanceError ) : ?>
+					<div class="contai-info-box contai-info-box-warning" style="margin-top: 20px;">
+						<div class="contai-info-box-icon">
+							<span class="dashicons dashicons-warning"></span>
+						</div>
+						<div class="contai-info-box-content">
+							<h4><?php esc_html_e( 'Insufficient Credits', '1platform-content-ai' ); ?></h4>
+							<p><?php esc_html_e( 'Content generation could not complete due to insufficient balance.', '1platform-content-ai' ); ?></p>
+							<a href="<?php echo esc_url( admin_url( 'admin.php?page=contai-billing' ) ); ?>" class="button button-primary" style="margin-top: 10px;">
+								<span class="dashicons dashicons-plus-alt2" style="margin-top: 3px;"></span>
+								<?php esc_html_e( 'Add Credits', '1platform-content-ai' ); ?>
+							</a>
+						</div>
 					</div>
-					<div class="contai-info-box-content">
-						<h4><?php esc_html_e( 'Error', '1platform-content-ai' ); ?></h4>
-						<p><?php echo esc_html( $job->getErrorMessage() ?? 'Unknown error' ); ?></p>
+				<?php else : ?>
+					<div class="contai-info-box contai-info-box-error" style="margin-top: 20px;">
+						<div class="contai-info-box-icon">
+							<span class="dashicons dashicons-warning"></span>
+						</div>
+						<div class="contai-info-box-content">
+							<h4><?php esc_html_e( 'Error', '1platform-content-ai' ); ?></h4>
+							<p><?php echo esc_html( $jobError ); ?></p>
+						</div>
 					</div>
-				</div>
+				<?php endif; ?>
 			<?php endif; ?>
 		</div>
 	</div>

--- a/includes/admin/ai-site-generator/site-generator-form.php
+++ b/includes/admin/ai-site-generator/site-generator-form.php
@@ -5,6 +5,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 require_once __DIR__ . '/../../services/category-api/CategoryAPIService.php';
+require_once __DIR__ . '/../../services/billing/CreditGuard.php';
 
 function contai_render_full_site_generator_form() {
 	// Fetch categories for the select field
@@ -14,7 +15,54 @@ function contai_render_full_site_generator_form() {
 	$site_domain    = wp_parse_url( home_url(), PHP_URL_HOST );
 	$default_email  = 'info@' . preg_replace( '/^www\./', '', $site_domain );
 
+	// Check credit balance for UI feedback
+	$creditGuard = new ContaiCreditGuard();
+	$creditCheck = $creditGuard->validateCredits();
+
 	?>
+	<?php if ( ! $creditCheck['has_credits'] ) : ?>
+		<div class="contai-info-box contai-info-box-warning" style="margin-bottom: 20px;">
+			<div class="contai-info-box-icon">
+				<span class="dashicons dashicons-warning"></span>
+			</div>
+			<div class="contai-info-box-content">
+				<p><strong><?php esc_html_e( 'Insufficient Balance', '1platform-content-ai' ); ?></strong></p>
+				<p>
+					<?php
+					printf(
+						/* translators: %1$s: balance amount, %2$s: currency code */
+						esc_html__( 'Your current balance is %1$s %2$s. You need credits to generate content.', '1platform-content-ai' ),
+						esc_html( number_format( $creditCheck['balance'], 2 ) ),
+						esc_html( $creditCheck['currency'] )
+					);
+					?>
+				</p>
+				<a href="<?php echo esc_url( admin_url( 'admin.php?page=contai-billing' ) ); ?>" class="button button-primary" style="margin-top: 8px;">
+					<span class="dashicons dashicons-plus-alt2" style="margin-top: 3px;"></span>
+					<?php esc_html_e( 'Add Credits', '1platform-content-ai' ); ?>
+				</a>
+			</div>
+		</div>
+	<?php else : ?>
+		<div class="contai-info-box contai-info-box-success" style="margin-bottom: 20px;">
+			<div class="contai-info-box-icon">
+				<span class="dashicons dashicons-money-alt"></span>
+			</div>
+			<div class="contai-info-box-content">
+				<p>
+					<?php
+					printf(
+						/* translators: %1$s: balance amount, %2$s: currency code */
+						esc_html__( 'Available balance: %1$s %2$s', '1platform-content-ai' ),
+						esc_html( number_format( $creditCheck['balance'], 2 ) ),
+						esc_html( $creditCheck['currency'] )
+					);
+					?>
+				</p>
+			</div>
+		</div>
+	<?php endif; ?>
+
 	<form method="post" class="contai-site-generator-form">
 		<?php wp_nonce_field( 'contai_site_generator_nonce', 'contai_site_generator_nonce' ); ?>
 		<input type="hidden" name="contai_start_site_generation" value="1">
@@ -249,7 +297,7 @@ function contai_render_full_site_generator_form() {
 						</div>
 					</div>
 					<div class="contai-submit-area">
-						<button type="submit" id="contai_submit_btn" class="contai-btn contai-btn-primary contai-btn-lg">
+						<button type="submit" id="contai_submit_btn" class="contai-btn contai-btn-primary contai-btn-lg" <?php echo ! $creditCheck['has_credits'] ? 'disabled' : ''; ?>>
 							<span class="dashicons dashicons-controls-play"></span>
 							<?php esc_html_e( 'Launch Site Generation', '1platform-content-ai' ); ?>
 						</button>

--- a/includes/admin/content-generator/handlers/KeywordExtractionHandler.php
+++ b/includes/admin/content-generator/handlers/KeywordExtractionHandler.php
@@ -89,6 +89,18 @@ class ContaiKeywordExtractionHandler {
     }
 
     private function extractKeywords(): array {
+        // Validate credits before enqueueing keyword extraction
+        require_once __DIR__ . '/../../../services/billing/CreditGuard.php';
+        $creditGuard = new ContaiCreditGuard();
+        $creditCheck = $creditGuard->validateCredits();
+
+        if (!$creditCheck['has_credits']) {
+            return [
+                'success' => false,
+                'message' => $creditCheck['message']
+            ];
+        }
+
         $validation = $this->validateExtractionRequest();
 
         if (!$validation['valid']) {

--- a/includes/admin/content-generator/handlers/PostGenerationQueueHandler.php
+++ b/includes/admin/content-generator/handlers/PostGenerationQueueHandler.php
@@ -97,6 +97,18 @@ class ContaiPostGenerationQueueHandler {
     }
 
     private function enqueuePosts(): array {
+        // Validate credits before enqueueing posts
+        require_once __DIR__ . '/../../../services/billing/CreditGuard.php';
+        $creditGuard = new ContaiCreditGuard();
+        $creditCheck = $creditGuard->validateCredits();
+
+        if (!$creditCheck['has_credits']) {
+            return [
+                'success' => false,
+                'message' => $creditCheck['message']
+            ];
+        }
+
         $validation = $this->validateEnqueueRequest();
 
         if (!$validation['valid']) {

--- a/includes/admin/content-generator/panels/generate-comments.php
+++ b/includes/admin/content-generator/panels/generate-comments.php
@@ -10,6 +10,7 @@ class ContaiGenerateCommentsPanel {
     private bool $comments_generated = false;
     private int $posts_processed = 0;
     private int $posts_failed = 0;
+    private array $creditCheck = ['has_credits' => true];
 
     public function __construct() {
         $this->handle_form_submissions();
@@ -35,6 +36,21 @@ class ContaiGenerateCommentsPanel {
     }
 
     private function handle_comment_generation(): void {
+        // Validate credits before generating comments
+        require_once __DIR__ . '/../../../services/billing/CreditGuard.php';
+        $creditGuard = new ContaiCreditGuard();
+        $creditCheck = $creditGuard->validateCredits();
+
+        if (!$creditCheck['has_credits']) {
+            add_settings_error(
+                'contai_comments',
+                'insufficient_credits',
+                $creditCheck['message'],
+                'error'
+            );
+            return;
+        }
+
         // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified in handle_form_submissions() via check_admin_referer().
         $num_posts = isset($_POST['contai_num_posts']) ? absint($_POST['contai_num_posts']) : 10;
         // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified in handle_form_submissions() via check_admin_referer().
@@ -138,6 +154,28 @@ class ContaiGenerateCommentsPanel {
         $this->render_notices();
         settings_errors('contai_comments');
 
+        $creditGuard = new ContaiCreditGuard();
+        $this->creditCheck = $creditGuard->validateCredits();
+
+        if ( ! $this->creditCheck['has_credits'] ) : ?>
+            <div class="notice notice-warning" style="margin-bottom: 15px;">
+                <p>
+                    <strong><?php esc_html_e( 'Insufficient Balance', '1platform-content-ai' ); ?></strong> —
+                    <?php
+                    printf(
+                        /* translators: %1$s: balance amount, %2$s: currency code */
+                        esc_html__( 'Your balance is %1$s %2$s. Add credits to generate comments.', '1platform-content-ai' ),
+                        esc_html( number_format( $this->creditCheck['balance'], 2 ) ),
+                        esc_html( $this->creditCheck['currency'] )
+                    );
+                    ?>
+                    <a href="<?php echo esc_url( admin_url( 'admin.php?page=contai-billing' ) ); ?>">
+                        <?php esc_html_e( 'Add Credits', '1platform-content-ai' ); ?>
+                    </a>
+                </p>
+            </div>
+        <?php endif;
+
         $this->render_generation_form();
 
         if ($this->comments_generated && !empty($this->generated_comments)) {
@@ -229,7 +267,7 @@ class ContaiGenerateCommentsPanel {
                     </div>
 
                     <div class="contai-button-group" style="padding: 20px; border-top: 1px solid #e5e5e5; background: #f8f9fa; margin: 0;">
-                        <button type="submit" name="contai_generate_now" class="button button-primary">
+                        <button type="submit" name="contai_generate_now" class="button button-primary" <?php echo ! $this->creditCheck['has_credits'] ? 'disabled' : ''; ?>>
                             <span class="dashicons dashicons-update" style="margin-top: 3px;"></span>
                             <?php esc_html_e('Generate Comments Now', '1platform-content-ai'); ?>
                         </button>

--- a/includes/admin/content-generator/panels/keyword-extractor.php
+++ b/includes/admin/content-generator/panels/keyword-extractor.php
@@ -5,6 +5,7 @@ if (!defined('ABSPATH')) exit;
 require_once __DIR__ . '/../../../database/repositories/JobRepository.php';
 require_once __DIR__ . '/../../../database/models/JobStatus.php';
 require_once __DIR__ . '/../../../services/jobs/KeywordExtractionJob.php';
+require_once __DIR__ . '/../../../services/billing/CreditGuard.php';
 
 class ContaiKeywordExtractorPanel {
 
@@ -16,6 +17,29 @@ class ContaiKeywordExtractorPanel {
 
     public function render(): void {
         $this->renderAdminNotices();
+
+        $creditGuard = new ContaiCreditGuard();
+        $creditCheck = $creditGuard->validateCredits();
+
+        if ( ! $creditCheck['has_credits'] ) : ?>
+            <div class="notice notice-warning" style="margin-bottom: 15px;">
+                <p>
+                    <strong><?php esc_html_e( 'Insufficient Balance', '1platform-content-ai' ); ?></strong> —
+                    <?php
+                    printf(
+                        /* translators: %1$s: balance amount, %2$s: currency code */
+                        esc_html__( 'Your balance is %1$s %2$s. Add credits to extract keywords.', '1platform-content-ai' ),
+                        esc_html( number_format( $creditCheck['balance'], 2 ) ),
+                        esc_html( $creditCheck['currency'] )
+                    );
+                    ?>
+                    <a href="<?php echo esc_url( admin_url( 'admin.php?page=contai-billing' ) ); ?>">
+                        <?php esc_html_e( 'Add Credits', '1platform-content-ai' ); ?>
+                    </a>
+                </p>
+            </div>
+        <?php endif;
+
         $status = $this->getQueueStatus();
         ?>
         <div class="contai-settings-panel contai-panel-keyword-extractor">
@@ -82,7 +106,7 @@ class ContaiKeywordExtractorPanel {
                     <?php wp_nonce_field('contai_keyword_extractor_nonce', 'contai_keyword_extractor_nonce'); ?>
 
                     <div class="contai-button-group">
-                        <button type="submit" name="contai_extract_keywords" class="button button-primary contai-button-action">
+                        <button type="submit" name="contai_extract_keywords" class="button button-primary contai-button-action" <?php echo ! $creditCheck['has_credits'] ? 'disabled' : ''; ?>>
                             <span class="dashicons dashicons-search"></span>
                             <span class="contai-button-text"><?php esc_html_e('Extract Keywords', '1platform-content-ai'); ?></span>
                         </button>

--- a/includes/admin/content-generator/panels/post-generator.php
+++ b/includes/admin/content-generator/panels/post-generator.php
@@ -3,6 +3,7 @@
 if (!defined('ABSPATH')) exit;
 
 require_once __DIR__ . '/../../../services/jobs/QueueManager.php';
+require_once __DIR__ . '/../../../services/billing/CreditGuard.php';
 
 class ContaiPostGeneratorPanel {
 
@@ -14,6 +15,29 @@ class ContaiPostGeneratorPanel {
 
     public function render(): void {
         $this->renderAdminNotices();
+
+        $creditGuard = new ContaiCreditGuard();
+        $creditCheck = $creditGuard->validateCredits();
+
+        if ( ! $creditCheck['has_credits'] ) : ?>
+            <div class="notice notice-warning" style="margin-bottom: 15px;">
+                <p>
+                    <strong><?php esc_html_e( 'Insufficient Balance', '1platform-content-ai' ); ?></strong> —
+                    <?php
+                    printf(
+                        /* translators: %1$s: balance amount, %2$s: currency code */
+                        esc_html__( 'Your balance is %1$s %2$s. Add credits to generate content.', '1platform-content-ai' ),
+                        esc_html( number_format( $creditCheck['balance'], 2 ) ),
+                        esc_html( $creditCheck['currency'] )
+                    );
+                    ?>
+                    <a href="<?php echo esc_url( admin_url( 'admin.php?page=contai-billing' ) ); ?>">
+                        <?php esc_html_e( 'Add Credits', '1platform-content-ai' ); ?>
+                    </a>
+                </p>
+            </div>
+        <?php endif;
+
         $status = $this->queueManager->getQueueStatus();
         ?>
         <div class="contai-post-generator-container">
@@ -82,7 +106,7 @@ class ContaiPostGeneratorPanel {
                         <?php wp_nonce_field('contai_post_generator_nonce', 'contai_post_generator_nonce'); ?>
 
                         <div class="contai-button-group">
-                            <button type="submit" name="contai_enqueue_posts" class="button button-primary contai-button-action">
+                            <button type="submit" name="contai_enqueue_posts" class="button button-primary contai-button-action" <?php echo ! $creditCheck['has_credits'] ? 'disabled' : ''; ?>>
                                 <span class="dashicons dashicons-edit"></span>
                                 <span class="contai-button-text"><?php esc_html_e('Add to Queue', '1platform-content-ai'); ?></span>
                             </button>

--- a/includes/services/agents/ContaiAgentRestController.php
+++ b/includes/services/agents/ContaiAgentRestController.php
@@ -525,6 +525,15 @@ class ContaiAgentRestController {
      * @return WP_REST_Response|WP_Error
      */
     public function run_agent( $request ) {
+        // Validate credits before running agent
+        require_once __DIR__ . '/../billing/CreditGuard.php';
+        $creditGuard = new ContaiCreditGuard();
+        $creditCheck = $creditGuard->validateCredits();
+
+        if ( ! $creditCheck['has_credits'] ) {
+            return $this->error( 'insufficient_credits', $creditCheck['message'], 402 );
+        }
+
         $id   = sanitize_text_field( $request->get_param( 'id' ) );
         $body = $request->get_json_params();
 
@@ -682,6 +691,15 @@ class ContaiAgentRestController {
      * @return WP_REST_Response|WP_Error
      */
     public function consume_action( $request ) {
+        // Validate credits before consuming action
+        require_once __DIR__ . '/../billing/CreditGuard.php';
+        $creditGuard = new ContaiCreditGuard();
+        $creditCheck = $creditGuard->validateCredits();
+
+        if ( ! $creditCheck['has_credits'] ) {
+            return $this->error( 'insufficient_credits', $creditCheck['message'], 402 );
+        }
+
         $action_id = sanitize_text_field( $request->get_param( 'action_id' ) );
         $sync      = ContaiAgentSyncService::create();
         $result    = $sync->consumeActionManually( $action_id );

--- a/includes/services/api/OnePlatformClient.php
+++ b/includes/services/api/OnePlatformClient.php
@@ -363,6 +363,10 @@ class ContaiOnePlatformResponse {
         return $this->trace_id;
     }
 
+    public function isPaymentRequired(): bool {
+        return $this->status_code === 402;
+    }
+
     public function toArray(): array {
         return [
             'success' => $this->success,

--- a/includes/services/billing/CreditGuard.php
+++ b/includes/services/billing/CreditGuard.php
@@ -11,10 +11,17 @@ class ContaiCreditGuard {
 
     public const INSUFFICIENT_CREDITS_PREFIX = 'INSUFFICIENT_CREDITS: ';
 
-    private ContaiBillingService $billingService;
+    private ?ContaiBillingService $billingService;
 
     public function __construct(?ContaiBillingService $billingService = null) {
-        $this->billingService = $billingService ?? new ContaiBillingService();
+        $this->billingService = $billingService;
+    }
+
+    private function getBillingService(): ContaiBillingService {
+        if ($this->billingService === null) {
+            $this->billingService = new ContaiBillingService();
+        }
+        return $this->billingService;
     }
 
     /**
@@ -92,7 +99,7 @@ class ContaiCreditGuard {
      * @return array|null
      */
     private function fetchAndCacheBilling(): ?array {
-        $response = $this->billingService->getBilling();
+        $response = $this->getBillingService()->getBilling();
 
         if (!$response->isSuccess()) {
             return null;

--- a/includes/services/billing/CreditGuard.php
+++ b/includes/services/billing/CreditGuard.php
@@ -1,0 +1,108 @@
+<?php
+
+if (!defined('ABSPATH')) exit;
+
+require_once __DIR__ . '/BillingService.php';
+
+class ContaiCreditGuard {
+
+    private const CACHE_KEY = 'contai_billing_cache';
+    private const CACHE_TTL = 300; // 5 minutes
+
+    public const INSUFFICIENT_CREDITS_PREFIX = 'INSUFFICIENT_CREDITS: ';
+
+    private ContaiBillingService $billingService;
+
+    public function __construct(?ContaiBillingService $billingService = null) {
+        $this->billingService = $billingService ?? new ContaiBillingService();
+    }
+
+    /**
+     * Validate that the user has credits available.
+     *
+     * @return array{has_credits: bool, balance: float, currency: string, message: string}
+     */
+    public function validateCredits(): array {
+        $billing = $this->getCachedBilling();
+
+        if ($billing === null) {
+            return [
+                'has_credits' => false,
+                'balance'     => 0,
+                'currency'    => 'USD',
+                'message'     => __('Unable to verify your balance. Please try again.', '1platform-content-ai'),
+            ];
+        }
+
+        $balance  = (float) ($billing['balance'] ?? 0);
+        $currency = $billing['currency'] ?? 'USD';
+
+        if ($balance <= 0) {
+            return [
+                'has_credits' => false,
+                'balance'     => $balance,
+                'currency'    => $currency,
+                'message'     => __('Insufficient balance. Please add credits before generating content.', '1platform-content-ai'),
+            ];
+        }
+
+        return [
+            'has_credits' => true,
+            'balance'     => $balance,
+            'currency'    => $currency,
+            'message'     => '',
+        ];
+    }
+
+    /**
+     * Get cached billing data. Falls back to API if cache is empty.
+     *
+     * @return array|null Billing data array or null on failure.
+     */
+    public function getCachedBilling(): ?array {
+        $cached = get_transient(self::CACHE_KEY);
+
+        if ($cached !== false && is_array($cached)) {
+            return $cached;
+        }
+
+        return $this->fetchAndCacheBilling();
+    }
+
+    /**
+     * Force-refresh the billing cache (e.g. after a purchase).
+     */
+    public function invalidateCache(): void {
+        delete_transient(self::CACHE_KEY);
+    }
+
+    /**
+     * Check if an error message indicates insufficient credits.
+     *
+     * @param string $errorMessage
+     * @return bool
+     */
+    public static function isInsufficientCreditsError(string $errorMessage): bool {
+        return strpos($errorMessage, self::INSUFFICIENT_CREDITS_PREFIX) === 0;
+    }
+
+    /**
+     * Fetch billing from API and store in transient cache.
+     *
+     * @return array|null
+     */
+    private function fetchAndCacheBilling(): ?array {
+        $response = $this->billingService->getBilling();
+
+        if (!$response->isSuccess()) {
+            return null;
+        }
+
+        $data = $response->getData();
+        $billing = $data['billing'] ?? $data;
+
+        set_transient(self::CACHE_KEY, $billing, self::CACHE_TTL);
+
+        return $billing;
+    }
+}

--- a/includes/services/http/HTTPClientService.php
+++ b/includes/services/http/HTTPClientService.php
@@ -174,4 +174,8 @@ class ContaiHTTPResponse {
     public function isForbidden(): bool {
         return $this->status_code === 403;
     }
+
+    public function isPaymentRequired(): bool {
+        return $this->status_code === 402;
+    }
 }

--- a/includes/services/jobs/JobProcessor.php
+++ b/includes/services/jobs/JobProcessor.php
@@ -11,6 +11,7 @@ require_once __DIR__ . '/KeywordExtractionJob.php';
 require_once __DIR__ . '/SiteGenerationJob.php';
 require_once __DIR__ . '/ContentGenerationPollingJob.php';
 require_once __DIR__ . '/recovery/JobRecoveryService.php';
+require_once __DIR__ . '/../billing/CreditGuard.php';
 
 class ContaiJobProcessor
 {
@@ -100,10 +101,17 @@ class ContaiJobProcessor
             $job->markAsCompleted();
             $this->jobRepository->update($job);
         } catch (Exception $e) {
-            contai_log("ContaiJob {$job->getId()} failed: " . $e->getMessage()); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+            $errorMessage = $e->getMessage(); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+
+            // Tag 402 errors so recovery strategies can skip them
+            if ($this->isInsufficientCreditsException($e)) {
+                $errorMessage = ContaiCreditGuard::INSUFFICIENT_CREDITS_PREFIX . $errorMessage;
+            }
+
+            contai_log("ContaiJob {$job->getId()} failed: " . $errorMessage); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 
             $job->incrementAttempts();
-            $job->markAsFailed($e->getMessage()); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+            $job->markAsFailed($errorMessage); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
             $this->jobRepository->update($job);
         }
     }
@@ -131,6 +139,23 @@ class ContaiJobProcessor
     private function getHandler($jobType)
     {
         return $this->jobHandlers[$jobType] ?? null;
+    }
+
+    private function isInsufficientCreditsException(Exception $e): bool {
+        $message = strtolower($e->getMessage());
+
+        if (strpos($message, 'insufficient balance') !== false
+            || strpos($message, 'insufficient credits') !== false
+            || strpos($message, 'payment required') !== false
+        ) {
+            return true;
+        }
+
+        if (method_exists($e, 'getStatusCode') && $e->getStatusCode() === 402) {
+            return true;
+        }
+
+        return false;
     }
 
     private function acquireLock()

--- a/includes/services/jobs/KeywordExtractionJob.php
+++ b/includes/services/jobs/KeywordExtractionJob.php
@@ -18,6 +18,18 @@ class ContaiKeywordExtractionJob implements ContaiJobInterface
 
     public function handle(array $payload)
     {
+        // Fail-fast credit check before consuming API resources
+        require_once __DIR__ . '/../billing/CreditGuard.php';
+        $creditGuard = new ContaiCreditGuard();
+        $creditCheck = $creditGuard->validateCredits();
+
+        if (!$creditCheck['has_credits']) {
+            return [
+                'success' => false,
+                'error' => $creditCheck['message'],
+            ];
+        }
+
         $topic = $payload['topic'] ?? '';
         $domain = $payload['domain'] ?? '';
         $country = $payload['country'] ?? '';

--- a/includes/services/jobs/PostGenerationJob.php
+++ b/includes/services/jobs/PostGenerationJob.php
@@ -29,6 +29,20 @@ class ContaiPostGenerationJob implements ContaiJobInterface
 
     public function handle(array $payload)
     {
+        // Fail-fast credit check before consuming API resources
+        require_once __DIR__ . '/../billing/CreditGuard.php';
+        $creditGuard = new ContaiCreditGuard();
+        $creditCheck = $creditGuard->validateCredits();
+
+        if (!$creditCheck['has_credits']) {
+            $keyword = $this->loadKeyword($payload);
+            $this->updateKeywordStatus($keyword, ContaiKeyword::STATUS_FAILED);
+            throw new ContaiContentGenerationException(
+                $creditCheck['message'],
+                402
+            );
+        }
+
         $keyword = $this->loadKeyword($payload);
 
         $this->updateKeywordStatus($keyword, ContaiKeyword::STATUS_PROCESSING);

--- a/includes/services/jobs/SiteGenerationJob.php
+++ b/includes/services/jobs/SiteGenerationJob.php
@@ -20,6 +20,7 @@ class ContaiSiteGenerationJob implements ContaiJobInterface
 
     private ContaiJobRepository $jobRepository;
     private array $steps = [
+        'validateCredits',
         'activateLicense',
         'saveSiteConfig',
         'saveLegalInfo',
@@ -35,6 +36,11 @@ class ContaiSiteGenerationJob implements ContaiJobInterface
     public function __construct()
     {
         $this->jobRepository = new ContaiJobRepository();
+    }
+
+    public function getStepCount(): int
+    {
+        return count($this->steps);
     }
 
     public function handle(array $payload)
@@ -96,6 +102,10 @@ class ContaiSiteGenerationJob implements ContaiJobInterface
         $config = $payload['config'] ?? [];
 
         switch ($stepName) {
+            case 'validateCredits':
+                $this->validateCreditsStep();
+                break;
+
             case 'activateLicense':
                 $this->activateLicense();
                 break;
@@ -150,6 +160,24 @@ class ContaiSiteGenerationJob implements ContaiJobInterface
                 break;
         }
         return $payload;
+    }
+
+    private function validateCreditsStep(): void
+    {
+        require_once __DIR__ . '/../billing/CreditGuard.php';
+
+        $creditGuard = new ContaiCreditGuard();
+        $creditCheck = $creditGuard->validateCredits();
+
+        if (!$creditCheck['has_credits']) {
+            throw new Exception(
+                sprintf(
+                    'Insufficient balance (%s %s). Please add credits before generating content.',
+                    number_format($creditCheck['balance'], 2),
+                    $creditCheck['currency']
+                )
+            );
+        }
     }
 
     private function activateLicense(): void

--- a/includes/services/jobs/recovery/ResetToPendingStrategy.php
+++ b/includes/services/jobs/recovery/ResetToPendingStrategy.php
@@ -4,6 +4,7 @@ if (!defined('ABSPATH')) exit;
 
 require_once __DIR__ . '/JobRecoveryStrategy.php';
 require_once __DIR__ . '/../../../helpers/TimestampHelper.php';
+require_once __DIR__ . '/../../billing/CreditGuard.php';
 
 class ContaiResetToPendingStrategy implements ContaiJobRecoveryStrategy
 {
@@ -17,6 +18,12 @@ class ContaiResetToPendingStrategy implements ContaiJobRecoveryStrategy
     public function shouldRecover(ContaiJob $job): bool
     {
         if ($job->getStatus() !== ContaiJobStatus::PROCESSING) {
+            return false;
+        }
+
+        // Never re-queue jobs that failed due to insufficient credits
+        $errorMessage = $job->getErrorMessage() ?? '';
+        if (ContaiCreditGuard::isInsufficientCreditsError($errorMessage)) {
             return false;
         }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -84,6 +84,7 @@ require_once __DIR__ . '/../includes/admin/apps/handlers/SearchConsoleFormHandle
 
 // ── Admin Handlers (Billing, Publisuites, Content Generator) ───
 require_once __DIR__ . '/../includes/services/billing/BillingService.php';
+require_once __DIR__ . '/../includes/services/billing/CreditGuard.php';
 require_once __DIR__ . '/../includes/admin/billing/handlers/TopUpHandler.php';
 require_once __DIR__ . '/../includes/services/publisuites/PublisuitesService.php';
 require_once __DIR__ . '/../includes/admin/apps/handlers/PublisuitesFormHandler.php';

--- a/tests/unit/admin/content-generator/handlers/KeywordExtractionHandlerTest.php
+++ b/tests/unit/admin/content-generator/handlers/KeywordExtractionHandlerTest.php
@@ -22,6 +22,11 @@ class KeywordExtractionHandlerTest extends TestCase
         parent::setUp();
         WP_Mock::setUp();
 
+        // Mock billing cache so CreditGuard passes without hitting BillingService
+        WP_Mock::userFunction('get_transient')
+            ->with('contai_billing_cache')
+            ->andReturn(['balance' => 100.00, 'currency' => 'USD']);
+
         $this->jobRepository = Mockery::mock(ContaiJobRepository::class);
         $this->handler = new ContaiKeywordExtractionHandler($this->jobRepository);
     }

--- a/tests/unit/admin/content-generator/handlers/PostGenerationQueueHandlerTest.php
+++ b/tests/unit/admin/content-generator/handlers/PostGenerationQueueHandlerTest.php
@@ -20,6 +20,11 @@ class PostGenerationQueueHandlerTest extends TestCase
         parent::setUp();
         WP_Mock::setUp();
 
+        // Mock billing cache so CreditGuard passes without hitting BillingService
+        WP_Mock::userFunction('get_transient')
+            ->with('contai_billing_cache')
+            ->andReturn(['balance' => 100.00, 'currency' => 'USD']);
+
         $this->queueManager = Mockery::mock(ContaiQueueManager::class);
         $this->handler = new ContaiPostGenerationQueueHandler($this->queueManager);
     }


### PR DESCRIPTION
## Summary
- Prevents content generation when user has insufficient balance (fixes #17, #19, #25)
- Adds 4-layer validation: UI banners → form submission checks → per-job fail-fast → recovery loop protection
- Creates `CreditGuard` service with 5-min transient cache for billing data

## Changes (16 files, +434 lines)

**New file:**
- `CreditGuard.php` — Central credit validation service with billing cache

**Infrastructure (GAP 4+5):**
- `isPaymentRequired()` on `ContaiHTTPResponse` and `ContaiOnePlatformResponse`
- 5-minute WordPress transient cache for billing API responses

**Entry point pre-validation (GAP 1):**
- Site Wizard, Post Generator, Keyword Extractor, Comments, Agent REST (`run_agent`, `consume_action`)

**Per-job fail-fast (GAP 3):**
- `PostGenerationJob`, `KeywordExtractionJob`, `SiteGenerationJob` (new `validateCredits` step)

**Recovery loop protection (GAP 2):**
- `JobProcessor` tags 402 errors with `INSUFFICIENT_CREDITS:` prefix
- `ResetToPendingStrategy` skips credit-failed jobs

**UX (Phase 3):**
- Balance banners + disabled buttons in Site Wizard, Post Generator, Keyword Extractor, Comments panels

**Misc (GAP 6):**
- Dynamic `getStepCount()` replaces hardcoded `total_steps = 11`

## Test plan
- [ ] With $0 balance: verify all generation forms show warning banner and disabled buttons
- [ ] With $0 balance: submit Site Wizard → verify redirect with error message
- [ ] With $0 balance: submit Post Generator → verify error message
- [ ] With $0 balance: run agent via REST → verify 402 response
- [ ] With credits: verify all forms show balance and buttons are enabled
- [ ] Failed job with INSUFFICIENT_CREDITS: verify recovery service does NOT re-queue it
- [ ] Existing jobs in progress: verify they continue working (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)