### PR TITLE
fix(cron): add self-healing cron registration and immediate job trigger (#39)

### DIFF
--- a/1platform-content-ai.php
+++ b/1platform-content-ai.php
@@ -4,7 +4,7 @@
  * Plugin Name: 1Platform Content AI
  * Plugin URI: https://1platform.pro/
  * Description: SaaS client for AI-powered content generation, SEO optimization, and site management. All AI processing happens on 1Platform external servers. Includes free local tools: Table of Contents and Internal Links.
- * Version: 2.11.1
+ * Version: 2.11.2
  * Author: 1Platform
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Content AI are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.11.2] - 2026-03-26
+
+### Fixed
+
+- **Job queue stuck in PENDING**: Cron event `contai_process_job_queue` was only registered on plugin activation. If the WP-Cron event was lost (database operations, object-cache flushes, plugin auto-updates, caching-plugin interference), jobs would stay in PENDING forever. Added self-healing `init` hook to re-register the cron event automatically (#39)
+
+### Added
+
+- **Immediate job processing trigger**: After enqueuing jobs, the plugin now calls `spawn_cron()` to kick WP-Cron immediately instead of waiting up to 60 seconds for the next scheduled cycle
+- **4 new regression tests**: Self-healing cron re-registration (2 tests) and immediate trigger behavior (2 tests)
+
 ## [2.10.6] - 2026-03-25
 
 ### Added

--- a/includes/cron/job-processor-cron.php
+++ b/includes/cron/job-processor-cron.php
@@ -13,6 +13,36 @@ function contai_register_job_processor_cron()
     }
 }
 
+/**
+ * Self-healing: re-register the cron event if it was lost.
+ *
+ * WordPress cron events (stored in wp_options) can disappear after database
+ * operations, object-cache flushes, plugin auto-updates that skip the
+ * activation hook, or caching-plugin interference.  Checking on every `init`
+ * is cheap — wp_next_scheduled reads a cached option — and guarantees the
+ * job-processor cron is always present.
+ */
+add_action('init', 'contai_ensure_job_processor_cron');
+
+function contai_ensure_job_processor_cron()
+{
+    contai_register_job_processor_cron();
+}
+
+/**
+ * Schedule an immediate one-shot cron event and kick wp-cron so that
+ * newly-enqueued jobs begin processing without waiting for the next
+ * scheduled cycle (up to 60 s away).
+ */
+function contai_trigger_immediate_job_processing()
+{
+    if (!wp_next_scheduled('contai_process_job_queue')) {
+        contai_register_job_processor_cron();
+    }
+
+    spawn_cron();
+}
+
 function contai_unregister_job_processor_cron()
 {
     wp_clear_scheduled_hook('contai_process_job_queue');

--- a/includes/services/jobs/QueueManager.php
+++ b/includes/services/jobs/QueueManager.php
@@ -64,6 +64,10 @@ class ContaiQueueManager
             }
         }
 
+        if ($enqueuedCount > 0) {
+            contai_trigger_immediate_job_processing();
+        }
+
         return $enqueuedCount;
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai content, seo, content generation, internal links, table of contents
 Requires at least: 5.9
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.11.1
+Stable tag: 2.11.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/tests/unit/cron/CronDeactivationTest.php
+++ b/tests/unit/cron/CronDeactivationTest.php
@@ -94,4 +94,60 @@ class CronDeactivationTest extends TestCase {
 
         $this->assertTrue( true );
     }
+
+    // ── Self-healing & Immediate Trigger ──────────────────────────
+
+    public function test_ensure_job_processor_cron_re_registers_when_missing(): void {
+        WP_Mock::userFunction( 'wp_next_scheduled' )
+            ->with( 'contai_process_job_queue' )
+            ->andReturn( false );
+
+        WP_Mock::userFunction( 'wp_schedule_event' )
+            ->once()
+            ->with( \Mockery::type( 'int' ), 'contai_every_minute', 'contai_process_job_queue' );
+
+        contai_ensure_job_processor_cron();
+
+        $this->assertTrue( true );
+    }
+
+    public function test_ensure_job_processor_cron_skips_when_present(): void {
+        WP_Mock::userFunction( 'wp_next_scheduled' )
+            ->with( 'contai_process_job_queue' )
+            ->andReturn( 1234567890 );
+
+        WP_Mock::userFunction( 'wp_schedule_event' )->never();
+
+        contai_ensure_job_processor_cron();
+
+        $this->assertTrue( true );
+    }
+
+    public function test_trigger_immediate_job_processing_calls_spawn_cron(): void {
+        WP_Mock::userFunction( 'wp_next_scheduled' )
+            ->with( 'contai_process_job_queue' )
+            ->andReturn( 1234567890 );
+
+        WP_Mock::userFunction( 'spawn_cron' )->once();
+
+        contai_trigger_immediate_job_processing();
+
+        $this->assertTrue( true );
+    }
+
+    public function test_trigger_immediate_re_registers_cron_when_missing(): void {
+        WP_Mock::userFunction( 'wp_next_scheduled' )
+            ->with( 'contai_process_job_queue' )
+            ->andReturn( false );
+
+        WP_Mock::userFunction( 'wp_schedule_event' )
+            ->once()
+            ->with( \Mockery::type( 'int' ), 'contai_every_minute', 'contai_process_job_queue' );
+
+        WP_Mock::userFunction( 'spawn_cron' )->once();
+
+        contai_trigger_immediate_job_processing();
+
+        $this->assertTrue( true );
+    }
 }


### PR DESCRIPTION
## Summary
- Job queue cron event was only registered on plugin activation — if lost, jobs stayed PENDING forever
- Added `init` hook for self-healing cron re-registration (standard WordPress pattern)
- Added `spawn_cron()` trigger after enqueuing jobs for immediate processing

## Changes
- **`includes/cron/job-processor-cron.php`**: Added `contai_ensure_job_processor_cron()` on `init` hook to re-register the cron event if it goes missing. Added `contai_trigger_immediate_job_processing()` to ensure cron is present and call `spawn_cron()` for immediate processing.
- **`includes/services/jobs/QueueManager.php`**: After successfully enqueuing jobs, calls `contai_trigger_immediate_job_processing()` so jobs start processing right away instead of waiting up to 60 seconds.
- **`tests/unit/cron/CronDeactivationTest.php`**: 4 new regression tests covering self-healing re-registration and immediate trigger behavior.

## Root Cause
`contai_register_job_processor_cron()` was only called inside `contai_activate_plugin()` (activation hook). WordPress cron events (stored in `wp_options`) can disappear due to database operations, object-cache flushes, plugin auto-updates that skip the activation hook, or caching-plugin interference. Once lost, the cron was never re-registered, leaving jobs stuck in PENDING.

## Audit Results
- Code review: PASS — no blockers, no concerns
- Security: no user input involved, no nonce/capability concerns
- Provider names: no exposure in modified code
- Architecture: follows standard WordPress cron self-healing pattern

## Test Plan
- [x] All 457 tests pass (709 assertions)
- [x] No regressions in existing test suites
- [x] 4 new regression tests for cron self-healing and immediate trigger
- [ ] Manual verification: enqueue jobs on a site where cron event was cleared

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)