### PR TITLE
feat(publisuites): one-click setup + remove provider name exposure

### DIFF
--- a/1platform-content-ai.php
+++ b/1platform-content-ai.php
@@ -4,7 +4,7 @@
  * Plugin Name: 1Platform Content AI
  * Plugin URI: https://1platform.pro/
  * Description: SaaS client for AI-powered content generation, SEO optimization, and site management. All AI processing happens on 1Platform external servers. Includes free local tools: Table of Contents and Internal Links.
- * Version: 2.11.3
+ * Version: 2.12.0
  * Author: 1Platform
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Content AI are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.12.0] - 2026-03-26
+
+### Added
+
+- **One-click link building setup**: Unified the 3-step Publisuites flow (connect, create file, verify) into a single click, matching the Search Console one-click pattern. New `PublisuitesSetupService` orchestrates the full flow with error recovery via existing manual fallback panels
+- **11 new tests**: 7 unit tests for `PublisuitesSetupService` (success, 3 failure points, idempotency, config validation) + 4 tests for `PublisuitesFormHandler` (setup success/failure, backward compatibility)
+
+### Fixed
+
+- **Provider name exposure**: Removed all instances of "Publisuites" from client-facing UI strings across ConnectSection, VerificationSection, ConnectedSection, PublisuitesPanel, AppsPanel, AppsSidebar, admin-apps, and FormHandler. Replaced with "marketplace" or "link building" per 1Platform branding rules
+
 ## [2.11.2] - 2026-03-26
 
 ### Fixed

--- a/docs/PLAN_PUBLISUITES_ONE_CLICK_SETUP.md
+++ b/docs/PLAN_PUBLISUITES_ONE_CLICK_SETUP.md
@@ -1,0 +1,544 @@
+# Plan: Publisuites One-Click Setup
+
+**Objetivo**: Unificar todo el flujo de Publisuites (agregar sitio, crear archivo de verificacion, verificar sitio) en un solo paso desde el plugin de WordPress, igual que se hizo con Search Console.
+
+**Estado**: Draft
+**Fecha**: 2026-03-26
+
+**Skills a invocar**: `wordpress-plugin-core`, `web-design-guidelines`
+
+---
+
+## 1. Contexto del Proyecto
+
+### Stack
+
+- **Plugin**: 1Platform Content AI (WordPress, PHP 7.4+)
+- **API**: 1Platform API (FastAPI, Python 3.14+, MongoDB/Beanie)
+- **Patron de referencia**: `SearchConsoleSetupService::activateSearchConsole()` — flujo 1-click ya implementado para Search Console
+- **Test framework**: PHPUnit 9.6+ con WP_Mock + Mockery
+
+### Estado Actual
+
+#### Flujo Manual (3 pasos con recarga de pagina)
+
+```
+Usuario ve panel "Connect" (ConnectSection.php)
+    ↓ Click "Connect to Publisuites" (contai_connect_publisuites)
+    ↓ PublisuitesFormHandler::handleConnect()
+    ↓ API call: action=add → obtiene publisuites_id + verification_file_name + verification_file_content
+    ↓ savePublisuitesConfig() → guarda en wp_options
+    ↓ Redirect → panel "Verification Pending" (VerificationSection.php)
+
+Usuario ve panel "Verification Pending"
+    ↓ Click "Create File Automatically" (contai_create_verification_file)
+    ↓ PublisuitesFormHandler::handleCreateVerificationFile()
+    ↓ WP_Filesystem → crea archivo HTML en ABSPATH
+    ↓ Redirect → panel sigue en "Verification Pending"
+
+Usuario ve panel "Verification Pending"
+    ↓ Click "Verify Website" (contai_verify_publisuites)
+    ↓ PublisuitesFormHandler::handleVerify()
+    ↓ API call: action=verify → Publisuites verifica el archivo
+    ↓ Redirect → panel "Connected" (ConnectedSection.php) o "Pending" (si fallo)
+```
+
+**Problema**: 3 clics + 3 recargas para algo que puede ser 1 clic.
+
+### Componentes clave que ya existen
+
+| Componente | Ubicacion | Proposito |
+|---|---|---|
+| `ContaiPublisuitesService::connectWebsite()` | `services/publisuites/PublisuitesService.php` | API call `action=add` → retorna `ContaiOnePlatformResponse` |
+| `ContaiPublisuitesService::createVerificationFile()` | `services/publisuites/PublisuitesService.php` | Crea archivo en `ABSPATH` via `WP_Filesystem` → retorna `['success' => bool, 'message' => string]` |
+| `ContaiPublisuitesService::verifyWebsite()` | `services/publisuites/PublisuitesService.php` | API call `action=verify` → retorna `ContaiOnePlatformResponse` |
+| `ContaiPublisuitesService::savePublisuitesConfig()` | `services/publisuites/PublisuitesService.php` | Guarda config en `contai_publisuites_config` (wp_options) |
+| `ContaiPublisuitesService::getPublisuitesConfig()` | `services/publisuites/PublisuitesService.php` | Lee config de wp_options |
+| `ContaiPublisuitesFormHandler` | `admin/apps/handlers/PublisuitesFormHandler.php` | Maneja 4 acciones separadas: `contai_connect_publisuites`, `contai_verify_publisuites`, `contai_create_verification_file`, `contai_disconnect_publisuites` |
+| `ContaiSearchConsoleSetupService` | `services/setup/SearchConsoleSetupService.php` | **Patron a seguir** — orquesta add → file → verify en 1 paso |
+| `ContaiSearchConsoleFormHandler::handleSetup()` | `admin/apps/handlers/SearchConsoleFormHandler.php` | **Patron a seguir** — handler que delega al setup service |
+| `PublisuitesService` (API) | `app/services/publisuites/publisuites_service.py` | Backend: add y verify con idempotencia |
+| `PublisuitesProvider` (API) | `app/services/providers/publisuites/publisuites_provider.py` | Backend: login, step2, step3, download, verify |
+
+### ⚠️ Clases existentes de test a reusar
+
+| Test existente | Ubicacion | Patrones reutilizables |
+|---|---|---|
+| `PublisuitesFormHandlerTest` | `tests/unit/admin/apps/handlers/PublisuitesFormHandlerTest.php` | `mockValidRequest()`, `expectRedirect()`, `PublisuitesRedirectException`, fixtures de nonce/capability |
+| `SearchConsoleFormHandlerTest` | `tests/unit/admin/apps/handlers/SearchConsoleFormHandlerTest.php` | Tests de `handleSetup()` — `test_setup_success_redirects_with_success_message`, `test_setup_failure_at_add_redirects_with_error`, etc. |
+
+### Decisiones de Diseno Resueltas
+
+1. **La orquestacion vive en el plugin**, no en la API — porque el paso de crear el archivo de verificacion es local (WP_Filesystem)
+2. **No se necesitan cambios en la API** — la API ya soporta `add` y `verify` con idempotencia
+3. **El patron es identico a Search Console** — nuevo `PublisuitesSetupService` que orquesta: add → create file → verify
+4. **Form POST sincrono** — no AJAX. El flujo completo toma ~5-15s, dentro del timeout de PHP (30s)
+5. **Error recovery via UI existente** — los estados intermedios ya tienen paneles con botones manuales
+6. ⚠️ **No eliminar `handleConnect()`** — mantenerlo como fallback. Solo agregar `handleOneClickSetup()` como nueva accion. Razon: si un usuario quedo en estado intermedio (connect hecho pero no verificado), el boton de VerificationSection podria necesitar re-connect
+7. ⚠️ **El handler usa `handleSetup()`** no `handleOneClickSetup()` — para consistencia con `SearchConsoleFormHandler::handleSetup()`
+8. ⚠️ **El require del setup service va en el archivo**, no dentro del metodo — para consistencia con `SearchConsoleFormHandler` que hace `require_once` al inicio del archivo
+
+---
+
+## 2. Requerimientos Funcionales
+
+1. **RF-01**: El usuario debe poder conectar, crear archivo y verificar su sitio con 1 solo clic
+2. **RF-02**: Si algun paso falla, el usuario queda en un estado intermedio valido con acciones manuales de fallback
+3. **RF-03**: Si el sitio ya esta agregado (idempotencia de API), el flujo continua desde donde quedo
+4. **RF-04**: El boton debe mostrar claramente los pasos que se ejecutaran automaticamente
+5. ⚠️ **RF-05**: Las acciones manuales individuales (connect, verify, create file, disconnect) deben seguir funcionando sin cambios
+
+---
+
+## 3. Cambios
+
+### 3.1 Nuevo servicio: `PublisuitesSetupService`
+
+**Archivo**: `includes/services/setup/PublisuitesSetupService.php`
+
+Orquesta el flujo completo igual que `SearchConsoleSetupService`:
+
+```php
+<?php
+
+if (!defined('ABSPATH')) exit;
+
+require_once __DIR__ . '/../publisuites/PublisuitesService.php';
+
+class ContaiPublisuitesSetupService
+{
+    private ContaiPublisuitesService $publisuiteService;
+
+    public function __construct(
+        ?ContaiPublisuitesService $publisuiteService = null
+    ) {
+        $this->publisuiteService = $publisuiteService ?? new ContaiPublisuitesService();
+    }
+
+    public function activatePublisuites(): array
+    {
+        $results = [
+            'success' => true,
+            'steps' => [],
+            'errors' => []
+        ];
+
+        try {
+            // Step 1: Add website to marketplace (API call action=add)
+            $connectResponse = $this->publisuiteService->connectWebsite();
+            if (!$connectResponse->isSuccess()) {
+                throw new Exception('Failed to register website: ' . $connectResponse->getMessage());
+            }
+
+            $data = $connectResponse->getData();
+            $this->publisuiteService->savePublisuitesConfig([
+                'publisuites_id' => $data['publisuites_id'] ?? '',
+                'verification_file_name' => $data['verification_file_name'] ?? '',
+                'verification_file_content' => $data['verification_file_content'] ?? '',
+                'status' => 'pending_verification',
+                'verified' => false,
+            ]);
+            $results['steps'][] = 'Website registered in marketplace';
+
+            // Step 2: Create verification file in WordPress root
+            $fileResult = $this->publisuiteService->createVerificationFile();
+            if (!$fileResult['success']) {
+                throw new Exception('Failed to create verification file: ' . $fileResult['message']);
+            }
+            $results['steps'][] = 'Verification file created';
+
+            // Step 3: Verify website ownership (API call action=verify)
+            $verifyResponse = $this->publisuiteService->verifyWebsite();
+            if (!$verifyResponse->isSuccess()) {
+                throw new Exception('Failed to verify website: ' . $verifyResponse->getMessage());
+            }
+
+            $verifyData = $verifyResponse->getData();
+            $config = $this->publisuiteService->getPublisuitesConfig();
+            if ($config) {
+                $config['verified'] = $verifyData['verified'] ?? false;
+                $config['verifiedAt'] = $verifyData['verified_at'] ?? null;
+                $config['status'] = ($verifyData['verified'] ?? false) ? 'active' : 'pending_verification';
+                $this->publisuiteService->savePublisuitesConfig($config);
+            }
+            $results['steps'][] = 'Website verified';
+
+        } catch (Exception $e) {
+            $results['success'] = false;
+            $results['errors'][] = $e->getMessage();
+            return $results;
+        }
+
+        return $results;
+    }
+}
+```
+
+### 3.2 Form Handler: nueva accion `contai_setup_publisuites`
+
+**Archivo**: `includes/admin/apps/handlers/PublisuitesFormHandler.php`
+
+⚠️ **Cambios respecto al plan original:**
+- El `require_once` del setup service va al inicio del archivo (no dentro del metodo)
+- El metodo se llama `handleSetup()` (no `handleOneClickSetup()`) para consistencia con `SearchConsoleFormHandler`
+- `handleConnect()` NO se elimina — se mantiene como fallback
+
+```php
+// Al inicio del archivo, agregar:
+require_once __DIR__ . '/../../../services/setup/PublisuitesSetupService.php';
+
+// En handleRequest(), agregar ANTES del check de contai_connect_publisuites:
+if (isset($_POST['contai_setup_publisuites'])) {
+    $this->handleSetup();
+}
+
+// Nuevo metodo privado:
+private function handleSetup(): void
+{
+    $setupService = new ContaiPublisuitesSetupService($this->service);
+    $result = $setupService->activatePublisuites();
+
+    if (!$result['success']) {
+        $errorMsg = implode('. ', $result['errors']);
+        $this->redirectWithMessage('error', $errorMsg);
+        return;
+    }
+
+    $this->redirectWithMessage(
+        'success',
+        __('Website connected to marketplace successfully', '1platform-content-ai')
+    );
+}
+```
+
+⚠️ **Nota**: El mensaje de success usa `__()` para i18n, no `implode()` de steps. Esto es consistente con `SearchConsoleFormHandler::handleSetup()` que usa un mensaje fijo traducible, no la lista de steps.
+
+### 3.3 UI: boton unico en ConnectSection
+
+**Archivo**: `includes/admin/apps/panels/publisuites/ConnectSection.php`
+
+Cambiar el form action de `contai_connect_publisuites` a `contai_setup_publisuites`. Agregar lista de pasos:
+
+```
+┌──────────────────────────────────────────────┐
+│ Connect to Link Building                     │
+│                                              │
+│ Website URL: https://example.com             │
+│                                              │
+│ This will automatically:                     │
+│  1. Register your site in the marketplace    │
+│  2. Create the verification file             │
+│  3. Verify your website ownership            │
+│                                              │
+│ [Connect to Marketplace]                     │
+└──────────────────────────────────────────────┘
+```
+
+⚠️ **Detalle de implementacion**: El `ConnectSection.php` actual usa `$view_data['primary_cta_action']` como nombre del boton. El cambio es solo en `PublisuitesPanel.php` donde se define el `primary_cta_action`:
+
+```php
+// En PublisuitesPanel.php, cambiar:
+'primary_cta_action' => 'contai_setup_publisuites',  // era 'contai_connect_publisuites'
+'primary_cta_label'  => __('Connect to Marketplace', '1platform-content-ai'),  // era 'Connect to Publisuites'
+```
+
+### ⚠️ 3.4 Form Handler: limpiar tearDown de tests
+
+**Archivo**: `tests/unit/admin/apps/handlers/PublisuitesFormHandlerTest.php`
+
+Agregar `contai_setup_publisuites` al `tearDown()`:
+
+```php
+public function tearDown(): void
+{
+    unset(
+        $_POST['contai_publisuites_nonce'],
+        $_POST['contai_connect_publisuites'],
+        $_POST['contai_verify_publisuites'],
+        $_POST['contai_disconnect_publisuites'],
+        $_POST['contai_create_verification_file'],
+        $_POST['contai_setup_publisuites']  // ⚠️ NUEVO
+    );
+    WP_Mock::tearDown();
+    Mockery::close();
+    parent::tearDown();
+}
+```
+
+---
+
+## 4. Flujo Resultante
+
+```
+Usuario ve panel "Connect to Link Building" (ConnectSection.php)
+    ↓ Click "Connect to Marketplace" (contai_setup_publisuites)
+    ↓ PublisuitesFormHandler::handleSetup()
+    ↓   → PublisuitesSetupService::activatePublisuites()
+    ↓     1. connectWebsite() → API action=add → obtiene archivo de verificacion
+    ↓     2. savePublisuitesConfig() → guarda en wp_options
+    ↓     3. createVerificationFile() → WP_Filesystem → crea publisuites-verify-{token}.html
+    ↓     4. verifyWebsite() → API action=verify → Publisuites verifica el archivo
+    ↓     5. savePublisuitesConfig() → actualiza verified=true, status=active
+    ↓ Redirect → panel "Connected" (ConnectedSection.php)
+```
+
+1 clic + 1 recarga.
+
+---
+
+## 5. Error Recovery
+
+No se necesita logica nueva. Los estados intermedios ya tienen UI:
+
+| Fallo en | Estado wp_options | Panel que ve el usuario | Fallback disponible |
+|---|---|---|---|
+| Step 1 (connect) | Sin datos | ConnectSection → puede reintentar con mismo boton | El boton reintenta todo el flujo |
+| Step 2 (create file) | `publisuites_id` guardado, `verified=false` | VerificationSection → boton "Create File" + "Verify" | Acciones manuales individuales |
+| Step 3 (verify) | Archivo existe, `verified=false` | VerificationSection → boton "Verify" | Accion manual de verify |
+
+La API tiene idempotencia en ambos endpoints:
+- `add`: si ya tiene `publisuites_id`, retorna datos existentes (no duplica registro en Publisuites)
+- `verify`: si ya esta verificado, retorna resultado cacheado con `status=already_verified`
+
+⚠️ **Edge case: fallo entre step 1 y step 2** — `publisuites_id` ya fue guardado pero el archivo no se creo. En este caso, el panel muestra `VerificationSection` con dos botones: "Create File" y "Verify". El usuario puede crear el archivo manualmente y luego verificar. Si el usuario hace clic en "Connect to Marketplace" de nuevo, la API retorna `already_added` con los datos existentes → el setup service continua al step 2.
+
+---
+
+## 6. Restricciones Tecnicas
+
+1. **NO crear endpoints nuevos en la API** — los existentes (`action=add` y `action=verify`) son suficientes
+2. **NO usar AJAX** — form POST sincrono es suficiente para ~5-15s
+3. **NO exponer nombre "Publisuites"** en la UI — usar "Link Building" o "Marketplace"
+4. **NO romper acciones manuales existentes** — verify, create file y disconnect siguen funcionando como fallback
+5. ⚠️ **NO eliminar `handleConnect()`** — mantenerlo por backward compat y fallback de VerificationSection
+
+---
+
+## 7. Patrones a Seguir
+
+- Mismo patron que `SearchConsoleSetupService`: constructor con DI opcional, metodo `activate*()` que retorna `['success', 'steps', 'errors']`
+- Mismo patron de `SearchConsoleFormHandler::handleSetup()`: delega al setup service, usa `__()` para mensaje de exito
+- Usar `WP_Filesystem` para crear archivos (nunca `file_put_contents`)
+- Verificar nonce + `current_user_can('manage_options')` antes de procesar (ya lo hace `handleRequest()`)
+- ⚠️ El `require_once` del setup service va al inicio del archivo handler, igual que en `SearchConsoleFormHandler` (linea 7)
+- ⚠️ Test fixtures reusan `mockValidRequest()` y `expectRedirect()` del `PublisuitesFormHandlerTest` existente
+
+---
+
+## 8. Tests
+
+### 8.1 Unit Tests — `PublisuitesSetupService`
+
+**Archivo**: `tests/unit/services/setup/PublisuitesSetupServiceTest.php`
+
+⚠️ **Namespace**: `ContAI\Tests\Unit\Services\Setup` (consistente con estructura existente)
+
+```
+class PublisuitesSetupServiceTest extends TestCase
+
+TestActivatePublisuites:
+├── test_activate_success_completes_three_steps
+│   Setup: Mock service con connect→success(data con publisuites_id, file_name, file_content),
+│          createFile→['success'=>true], verify→success(data con verified=true, verified_at)
+│   Action: activatePublisuites()
+│   Assert: success=true, count(steps)==3, errors vacio
+│   Assert: savePublisuitesConfig llamado 2 veces (post-connect y post-verify)
+│   Assert: getPublisuitesConfig llamado 1 vez (en post-verify)
+│
+├── test_activate_connect_fails_stops_flow
+│   Setup: Mock connect→failure(message='API error', status=502)
+│   Action: activatePublisuites()
+│   Assert: success=false, steps vacio, errors contiene "Failed to register website: API error"
+│   Assert: createVerificationFile NO llamado
+│   Assert: verifyWebsite NO llamado
+│
+├── test_activate_create_file_fails_stops_at_step2
+│   Setup: Mock connect→success, createFile→['success'=>false, 'message'=>'Permission denied']
+│   Action: activatePublisuites()
+│   Assert: success=false, count(steps)==1, errors contiene "Failed to create verification file: Permission denied"
+│   Assert: verifyWebsite NO llamado
+│   Assert: savePublisuitesConfig llamado 1 vez (post-connect)
+│
+├── test_activate_verify_fails_stops_at_step3
+│   Setup: Mock connect→success, createFile→success, verify→failure(message='Verification pending')
+│   Action: activatePublisuites()
+│   Assert: success=false, count(steps)==2, errors contiene "Failed to verify website: Verification pending"
+│
+├── test_activate_idempotent_add_continues_flow
+│   Setup: Mock connect→success con data con status="already_added"
+│          (publisuites_id presente, verification data presente)
+│   Action: activatePublisuites()
+│   Assert: Flujo completa los 3 steps sin error
+│
+├── test_activate_saves_config_with_correct_data_after_connect
+│   Setup: Mock connect→success con data={publisuites_id:'ps-123', verification_file_name:'verify.html', verification_file_content:'<html>verify</html>'}
+│   Action: activatePublisuites()
+│   Assert: savePublisuitesConfig llamado con:
+│       publisuites_id='ps-123', verification_file_name='verify.html',
+│       verification_file_content='<html>verify</html>',
+│       status='pending_verification', verified=false
+│
+└── test_activate_updates_config_to_active_after_verify
+    Setup: Mock completo hasta verify→success(verified=true, verified_at='2026-03-26T10:00:00Z')
+           Mock getPublisuitesConfig→config existente con publisuites_id
+    Action: activatePublisuites()
+    Assert: Segundo savePublisuitesConfig llamado con verified=true, status='active', verifiedAt='2026-03-26T10:00:00Z'
+```
+
+### 8.2 Unit Tests — Form Handler (extender existente)
+
+**Archivo**: `tests/unit/admin/apps/handlers/PublisuitesFormHandlerTest.php`
+
+⚠️ **Agregar tests al archivo existente**, no crear archivo nuevo. Reusar `mockValidRequest()`, `expectRedirect()`, `PublisuitesRedirectException`.
+
+```
+// Agregar al bloque de tests existente:
+
+├── test_setup_success_redirects_with_success_message
+│   Setup: mockValidRequest('contai_setup_publisuites')
+│          Mock PublisuitesSetupService via constructor injection o patch
+│          → activatePublisuites() returns ['success'=>true, 'steps'=>['Step1','Step2','Step3'], 'errors'=>[]]
+│   Action: handler.handleRequest()
+│   Assert: Redirect con contai_ps_type=success
+│   Assert: Redirect URL contiene "connected to marketplace"
+│
+├── test_setup_failure_redirects_with_error_message
+│   Setup: mockValidRequest('contai_setup_publisuites')
+│          → activatePublisuites() returns ['success'=>false, 'steps'=>['Step1'], 'errors'=>['Failed to create verification file']]
+│   Action: handler.handleRequest()
+│   Assert: Redirect con contai_ps_type=error
+│   Assert: Redirect URL contiene "Failed to create verification file"
+│
+├── test_setup_does_not_break_existing_connect_action
+│   Setup: mockValidRequest('contai_connect_publisuites')
+│          Mock connectWebsite→success
+│   Action: handler.handleRequest()
+│   Assert: handleConnect() se ejecuta normalmente (backward compat)
+│
+└── test_setup_does_not_break_existing_verify_action
+    Setup: mockValidRequest('contai_verify_publisuites')
+           Mock verifyWebsite→success
+    Action: handler.handleRequest()
+    Assert: handleVerify() se ejecuta normalmente (backward compat)
+```
+
+⚠️ **Nota sobre inyeccion del setup service en tests**: El handler actual crea el setup service internamente (`new ContaiPublisuitesSetupService($this->service)`). Para testearlo, hay dos opciones:
+1. **Opcion A (preferida)**: El setup service recibe el `PublisuitesService` mock que ya se inyecta en el handler → los mocks del service controlan el flujo
+2. **Opcion B**: Hacer el setup service inyectable en el handler via constructor (pero rompe consistencia con `SearchConsoleFormHandler`)
+
+→ Usar **Opcion A**: el `PublisuitesSetupService` usa el mismo `$this->service` que ya esta mockeado. Los tests del handler controlan el resultado mockendo `connectWebsite()`, `createVerificationFile()`, `verifyWebsite()` en el service mock.
+
+---
+
+## 9. Consideraciones
+
+### Timeout
+
+2 llamadas API secuenciales + 1 escritura local: ~5-15s total. Dentro del timeout de PHP (30s) y de la API (180s configurado en el plugin). El step 1 (add) es el mas lento (~5-10s) porque Publisuites extrae metricas SEO del sitio.
+
+### Permisos de Filesystem
+
+`createVerificationFile()` usa `WP_Filesystem`. Si el servidor requiere credenciales FTP (raro en hosting moderno), el archivo no se crea y el flujo falla en step 2. El usuario queda en estado "conectado pero sin verificar" → el panel muestra VerificationSection con los botones manuales existentes como fallback.
+
+### Idempotencia
+
+Si el usuario hace clic dos veces o recarga:
+- **API `add`**: retorna datos existentes si ya tiene `publisuites_id` (no duplica registro)
+- **File creation**: sobreescribe archivo si ya existe (`WP_Filesystem::put_contents` es idempotente)
+- **API `verify`**: retorna `already_verified` si ya fue verificado
+
+### ⚠️ Propagacion de errores API
+
+La API retorna distintos HTTP status segun el error:
+
+| Error | HTTP Status | Impacto en plugin |
+|---|---|---|
+| `PublisuitesCredentialsNotFoundError` | 400 | `isSuccess()=false`, usuario no tiene credenciales configuradas |
+| `PublisuitesWebsiteNotFoundError` | 404 | `isSuccess()=false`, website ID invalido |
+| `PublisuitesVerificationPendingError` | 400 | `isSuccess()=false`, verificacion aun pendiente (archivo no encontrado por Publisuites) |
+| `PublisuitesServiceError` | 502 | `isSuccess()=false`, error externo de Publisuites |
+| Exception generica | 500 | `isSuccess()=false`, error inesperado |
+
+Todos estos retornan `isSuccess()=false` en `ContaiOnePlatformResponse`, lo cual hace que el setup service lance `Exception` y detenga el flujo. El mensaje de error de la API se propaga al usuario via el flash message.
+
+### ⚠️ Estado de credenciales
+
+La API requiere que el usuario tenga credenciales de Publisuites configuradas (`user.keys.publisuites.email` y `user.keys.publisuites.password`). Si no las tiene, la API retorna 400 con "Publisuites credentials not configured". Esto ya esta manejado por `PublisuitesCredentialsNotFoundError` → el plugin muestra el error. No se necesita logica adicional.
+
+---
+
+## 10. Archivos a Crear / Modificar
+
+| # | Archivo | Cambio | Proyecto |
+|---|---|---|---|
+| 1 | `includes/services/setup/PublisuitesSetupService.php` | **CREAR** — Servicio de orquestacion 1-click (patron identico a `SearchConsoleSetupService`) | Plugin |
+| 2 | `includes/admin/apps/handlers/PublisuitesFormHandler.php` | **MODIFICAR** — Agregar `require_once` del setup service + agregar `handleSetup()` + agregar check de `contai_setup_publisuites` en `handleRequest()` | Plugin |
+| 3 | `includes/admin/apps/panels/publisuites/ConnectSection.php` | **MODIFICAR** — Agregar lista de pasos automaticos (texto descriptivo) | Plugin |
+| 4 | ⚠️ `includes/admin/apps/panels/PublisuitesPanel.php` | **MODIFICAR** — Cambiar `primary_cta_action` a `contai_setup_publisuites` y `primary_cta_label` a "Connect to Marketplace" | Plugin |
+| 5 | `tests/unit/services/setup/PublisuitesSetupServiceTest.php` | **CREAR** — Tests del setup service (7 tests) | Plugin |
+| 6 | `tests/unit/admin/apps/handlers/PublisuitesFormHandlerTest.php` | **MODIFICAR** — Agregar 4 tests de setup + agregar `contai_setup_publisuites` al tearDown | Plugin |
+
+⚠️ 6 archivos plugin (no 5). Se agrego `PublisuitesPanel.php` que es donde realmente se define el `primary_cta_action`.
+
+### ⚠️ Cambios en la API (ya aplicados)
+
+| # | Archivo | Cambio | Proyecto |
+|---|---|---|---|
+| 7 | `app/services/publisuites/publisuites_service.py` | **MODIFICADO** — Agregar `verification_file_content` a respuesta idempotente `already_added` | API |
+| 8 | `tests/unit/services/test_publisuites_service.py` | **MODIFICADO** — Agregar test `test_add_website_already_added_returns_existing_data_with_file_content` | API |
+
+**Estado**: Ya aplicados y tests pasando (8/8).
+
+---
+
+## 11. Plan de Implementacion
+
+1. **Crear `PublisuitesSetupService.php`** en `includes/services/setup/` — copiar estructura de `SearchConsoleSetupService`, adaptar a Publisuites
+2. **Modificar `PublisuitesFormHandler.php`** — agregar `require_once` al inicio, agregar `handleSetup()`, agregar check en `handleRequest()`
+3. **Modificar `PublisuitesPanel.php`** — cambiar `primary_cta_action` y `primary_cta_label` para el estado `not_connected`
+4. **Modificar `ConnectSection.php`** — agregar lista de pasos automaticos debajo del hero text
+5. **Crear `PublisuitesSetupServiceTest.php`** en `tests/unit/services/setup/` — 7 tests unitarios
+6. **Modificar `PublisuitesFormHandlerTest.php`** — agregar `contai_setup_publisuites` al tearDown + 4 tests nuevos
+7. **Ejecutar tests** — `composer test` para verificar que tests existentes no se rompen
+8. **Test manual** — verificar flujo completo en Local by Flywheel:
+   - ⚠️ Verificar que 1-click funciona en estado limpio (sin config previa)
+   - ⚠️ Verificar que 1-click funciona con config parcial (idempotencia)
+   - ⚠️ Verificar que acciones manuales individuales siguen funcionando
+   - ⚠️ Verificar que el error se muestra correctamente cuando falla un paso
+
+---
+
+## 12. Criterios de Aceptacion
+
+- [ ] El usuario puede conectar, crear archivo y verificar con 1 solo clic
+- [ ] Si el sitio ya esta agregado (idempotencia), el flujo continua sin error
+- [ ] Si falla un paso, el usuario ve el error descriptivo y puede completar manualmente con acciones de fallback
+- [ ] Las acciones manuales existentes (connect, verify, create file, disconnect) siguen funcionando sin cambios
+- [ ] No se expone el nombre "Publisuites" en la UI — se usa "Marketplace" o "Link Building"
+- [ ] No se necesitan cambios en la API
+- [ ] Tests cubren happy path, cada punto de fallo, y backward compat de acciones existentes
+- [ ] ⚠️ El test `test_setup_does_not_break_existing_connect_action` pasa (backward compat)
+- [ ] ⚠️ El flash message de exito es traducible via `__()`
+
+---
+
+## 13. Riesgos y Mitigacion
+
+| Riesgo | Probabilidad | Impacto | Mitigacion |
+|---|---|---|---|
+| ⚠️ Step 1 (API add) tarda >15s por analisis SEO en Publisuites | Media | Medio — timeout PHP | El timeout del plugin es 180s. El timeout de step2 de la API es 60s. Dentro de limites. Si falla, el usuario ve error y puede reintentar. |
+| ⚠️ Verificacion falla porque Publisuites no detecta el archivo inmediatamente | Media | Bajo — el archivo ya fue creado | El usuario queda en VerificationSection con boton "Verify" manual. Puede reintentar tras unos segundos. |
+| WP_Filesystem no disponible (hosting restrictivo con FTP) | Baja | Medio — archivo no se crea | El usuario queda en VerificationSection con instrucciones manuales para subir el archivo |
+| Credenciales de Publisuites no configuradas | Media | Bajo — error claro | La API retorna 400 con mensaje descriptivo. El error se muestra en flash message |
+
+---
+
+## 14. Fuera de Scope
+
+- Cambios en la API (los endpoints ya existen con idempotencia)
+- Refactor del `PublisuitesService` existente (ya funciona)
+- AJAX con progress bar (el form POST es suficiente para ~10s de espera)
+- Cambios en VerificationSection (ya sirve como fallback)
+- Cambios en ConnectedSection (panel post-verificacion)
+- ⚠️ Retry automatico si verify falla (el usuario tiene el boton manual como fallback)
+- ⚠️ Delay entre crear archivo y verificar (Publisuites suele detectar inmediatamente)

--- a/includes/admin/admin-apps.php
+++ b/includes/admin/admin-apps.php
@@ -174,8 +174,8 @@ function contai_apps_page()
         case 'publisuites':
             $panel = new ContaiPublisuitesPanel();
             $layout->render_page_title(
-                __('Publisuites', '1platform-content-ai'),
-                __('Connect your website to Publisuites to monetize your content', '1platform-content-ai'),
+                __('Link Building', '1platform-content-ai'),
+                __('Connect your website to the marketplace to monetize your content', '1platform-content-ai'),
                 'dashicons-money-alt'
             );
             $panel->render();

--- a/includes/admin/apps/components/AppsSidebar.php
+++ b/includes/admin/apps/components/AppsSidebar.php
@@ -42,7 +42,7 @@ class ContaiAppsSidebar
                 'home' => false
             ],
             'publisuites' => [
-                'title' => __('Publisuites', '1platform-content-ai'),
+                'title' => __('Link Building', '1platform-content-ai'),
                 'icon' => 'dashicons-money-alt',
                 'badge' => null,
                 'home' => false

--- a/includes/admin/apps/handlers/PublisuitesFormHandler.php
+++ b/includes/admin/apps/handlers/PublisuitesFormHandler.php
@@ -3,6 +3,7 @@
 if (!defined('ABSPATH')) exit;
 
 require_once __DIR__ . '/../../../services/publisuites/PublisuitesService.php';
+require_once __DIR__ . '/../../../services/setup/PublisuitesSetupService.php';
 
 class ContaiPublisuitesFormHandler
 {
@@ -31,6 +32,10 @@ class ContaiPublisuitesFormHandler
             return;
         }
 
+        if (isset($_POST['contai_setup_publisuites'])) {
+            $this->handleSetup();
+        }
+
         if (isset($_POST['contai_connect_publisuites'])) {
             $this->handleConnect();
         }
@@ -46,6 +51,23 @@ class ContaiPublisuitesFormHandler
         if (isset($_POST['contai_create_verification_file'])) {
             $this->handleCreateVerificationFile();
         }
+    }
+
+    private function handleSetup(): void
+    {
+        $setupService = new ContaiPublisuitesSetupService($this->service);
+        $result = $setupService->activatePublisuites();
+
+        if (!$result['success']) {
+            $errorMsg = implode('. ', $result['errors']);
+            $this->redirectWithMessage('error', $errorMsg);
+            return;
+        }
+
+        $this->redirectWithMessage(
+            'success',
+            __('Website connected to marketplace successfully', '1platform-content-ai')
+        );
     }
 
     private function handleConnect(): void
@@ -71,7 +93,7 @@ class ContaiPublisuitesFormHandler
 
         $this->service->savePublisuitesConfig($configData);
 
-        $this->redirectWithMessage('success', __('Connected to Publisuites successfully. Please verify your website.', '1platform-content-ai'));
+        $this->redirectWithMessage('success', __('Connected to marketplace successfully. Please verify your website.', '1platform-content-ai'));
     }
 
     private function handleVerify(): void
@@ -95,7 +117,7 @@ class ContaiPublisuitesFormHandler
             $this->service->savePublisuitesConfig($config);
         }
 
-        $this->redirectWithMessage('success', __('Website verified successfully with Publisuites', '1platform-content-ai'));
+        $this->redirectWithMessage('success', __('Website verified successfully', '1platform-content-ai'));
     }
 
     private function handleDisconnect(): void
@@ -103,7 +125,7 @@ class ContaiPublisuitesFormHandler
         // Only delete local configuration, don't call API
         $this->service->deletePublisuitesConfig();
 
-        $this->redirectWithMessage('success', __('Disconnected from Publisuites successfully', '1platform-content-ai'));
+        $this->redirectWithMessage('success', __('Disconnected from marketplace successfully', '1platform-content-ai'));
     }
 
     private function handleCreateVerificationFile(): void

--- a/includes/admin/apps/panels/AppsPanel.php
+++ b/includes/admin/apps/panels/AppsPanel.php
@@ -34,8 +34,8 @@ class ContaiAppsPanel {
                 'status' => 'active',
             ],
             'publisuites' => [
-                'title' => __('Publisuites', '1platform-content-ai'),
-                'description' => __('Connect your website to Publisuites to monetize your content and manage sponsored posts', '1platform-content-ai'),
+                'title' => __('Link Building', '1platform-content-ai'),
+                'description' => __('Connect your website to the marketplace to monetize your content and manage sponsored posts', '1platform-content-ai'),
                 'icon' => 'dashicons-money-alt',
                 'url' => add_query_arg(['section' => 'publisuites'], admin_url('admin.php?page=contai-apps')),
                 'status' => 'active',

--- a/includes/admin/apps/panels/PublisuitesPanel.php
+++ b/includes/admin/apps/panels/PublisuitesPanel.php
@@ -85,7 +85,7 @@ class ContaiPublisuitesPanel
                     'status_class'      => 'contai-badge--warning',
                     'primary_cta_label' => null,
                     'primary_cta_action'=> null,
-                    'message'           => $status['message'] ?? __('Website registration is required before connecting to Publisuites.', '1platform-content-ai'),
+                    'message'           => $status['message'] ?? __('Website registration is required before connecting to the marketplace.', '1platform-content-ai'),
                 ]);
 
             case 'not_connected':
@@ -93,8 +93,8 @@ class ContaiPublisuitesPanel
                     'status_key'        => 'not_connected',
                     'status_label'      => __('Not Connected', '1platform-content-ai'),
                     'status_class'      => 'contai-badge--neutral',
-                    'primary_cta_label' => __('Connect to Publisuites', '1platform-content-ai'),
-                    'primary_cta_action'=> 'contai_connect_publisuites',
+                    'primary_cta_label' => __('Connect to Marketplace', '1platform-content-ai'),
+                    'primary_cta_action'=> 'contai_setup_publisuites',
                 ]);
 
             case 'configured':
@@ -208,7 +208,7 @@ class ContaiPublisuitesPanel
                 <div>
                     <p><strong><?php esc_html_e('Active License Required', '1platform-content-ai'); ?></strong></p>
                     <p>
-                        <?php esc_html_e('You need an active license to use the Publisuites integration. Please activate your license to access this feature.', '1platform-content-ai'); ?>
+                        <?php esc_html_e('You need an active license to use the link building integration. Please activate your license to access this feature.', '1platform-content-ai'); ?>
                     </p>
                     <a href="<?php echo esc_url(admin_url('admin.php?page=contai-licenses')); ?>" class="button button-primary">
                         <?php esc_html_e('Activate License', '1platform-content-ai'); ?>

--- a/includes/admin/apps/panels/publisuites/ConnectSection.php
+++ b/includes/admin/apps/panels/publisuites/ConnectSection.php
@@ -29,12 +29,13 @@ class ContaiPublisuitesConnectSection
 
             <div class="contai-ps-hero">
                 <p class="contai-ps-hero__text">
-                    <?php esc_html_e('Connect your website to Publisuites to unlock sponsored content opportunities and start earning revenue from your posts.', '1platform-content-ai'); ?>
+                    <?php esc_html_e('Connect your website to the link building marketplace to unlock sponsored content opportunities and start earning revenue from your posts.', '1platform-content-ai'); ?>
                 </p>
             </div>
 
             <?php $this->renderBenefitsGrid(); ?>
             <?php $this->renderWebsiteCard(); ?>
+            <?php $this->renderSetupSteps(); ?>
             <?php $this->renderConnectForm(); ?>
 
         </div>
@@ -57,7 +58,7 @@ class ContaiPublisuitesConnectSection
         <div class="contai-ps-benefits">
             <h3 class="contai-ps-section-title">
                 <span class="dashicons dashicons-star-filled" aria-hidden="true"></span>
-                <?php esc_html_e('Why Connect to Publisuites?', '1platform-content-ai'); ?>
+                <?php esc_html_e('Why Connect to the Marketplace?', '1platform-content-ai'); ?>
             </h3>
             <div class="contai-ps-benefits__grid" role="list">
                 <?php foreach ($this->view_data['benefits'] as $benefit) : ?>
@@ -92,6 +93,26 @@ class ContaiPublisuitesConnectSection
         <?php
     }
 
+    private function renderSetupSteps(): void
+    {
+        ?>
+        <div class="contai-ps-card contai-ps-card--info">
+            <h3 class="contai-ps-card__header">
+                <span class="dashicons dashicons-update" aria-hidden="true"></span>
+                <?php esc_html_e('What will happen', '1platform-content-ai'); ?>
+            </h3>
+            <p class="contai-ps-card__desc" style="margin-bottom: 8px;">
+                <?php esc_html_e('Clicking the button below will automatically:', '1platform-content-ai'); ?>
+            </p>
+            <ol class="contai-ps-info-list" style="padding-left: 20px; margin: 0;">
+                <li><?php esc_html_e('Register your site in the marketplace', '1platform-content-ai'); ?></li>
+                <li><?php esc_html_e('Create the verification file', '1platform-content-ai'); ?></li>
+                <li><?php esc_html_e('Verify your website ownership', '1platform-content-ai'); ?></li>
+            </ol>
+        </div>
+        <?php
+    }
+
     private function renderConnectForm(): void
     {
         if (empty($this->view_data['primary_cta_action'])) {
@@ -104,7 +125,7 @@ class ContaiPublisuitesConnectSection
                 type="submit"
                 name="<?php echo esc_attr($this->view_data['primary_cta_action']); ?>"
                 class="button button-primary button-hero contai-ps-cta"
-                aria-label="<?php esc_attr_e('Connect your website to Publisuites', '1platform-content-ai'); ?>"
+                aria-label="<?php esc_attr_e('Connect your website to the marketplace', '1platform-content-ai'); ?>"
             >
                 <span class="dashicons dashicons-plus-alt2" aria-hidden="true"></span>
                 <?php echo esc_html($this->view_data['primary_cta_label']); ?>

--- a/includes/admin/apps/panels/publisuites/ConnectedSection.php
+++ b/includes/admin/apps/panels/publisuites/ConnectedSection.php
@@ -51,7 +51,7 @@ class ContaiPublisuitesConnectedSection
             <div>
                 <h3 class="contai-ps-card__title"><?php esc_html_e('Website Verified', '1platform-content-ai'); ?></h3>
                 <p class="contai-ps-card__desc">
-                    <?php esc_html_e('Your website is connected to Publisuites and ready to receive sponsored content opportunities.', '1platform-content-ai'); ?>
+                    <?php esc_html_e('Your website is connected to the marketplace and ready to receive sponsored content opportunities.', '1platform-content-ai'); ?>
                 </p>
             </div>
         </div>
@@ -77,7 +77,7 @@ class ContaiPublisuitesConnectedSection
                     </dd>
                 </div>
                 <div class="contai-ps-info-list__row">
-                    <dt><?php esc_html_e('Publisuites ID', '1platform-content-ai'); ?></dt>
+                    <dt><?php esc_html_e('Marketplace ID', '1platform-content-ai'); ?></dt>
                     <dd class="contai-ps-mono"><?php echo esc_html($config['publisuitesId'] ?? '—'); ?></dd>
                 </div>
                 <?php if (!empty($config['verifiedAt'])) : ?>
@@ -106,7 +106,7 @@ class ContaiPublisuitesConnectedSection
         }
 
         $confirm_message = esc_js(
-            __('Are you sure you want to disconnect from Publisuites? You will need to reconnect later.', '1platform-content-ai')
+            __('Are you sure you want to disconnect from the marketplace? You will need to reconnect later.', '1platform-content-ai')
         );
         ?>
         <div class="contai-ps-danger">
@@ -118,13 +118,13 @@ class ContaiPublisuitesConnectedSection
                 <?php wp_nonce_field($this->view_data['nonce_action'], $this->view_data['nonce_field']); ?>
                 <div class="contai-ps-danger__row">
                     <p class="contai-ps-danger__desc">
-                        <?php esc_html_e('Disconnect from Publisuites. This will only remove the local connection data.', '1platform-content-ai'); ?>
+                        <?php esc_html_e('Disconnect from the marketplace. This will only remove the local connection data.', '1platform-content-ai'); ?>
                     </p>
                     <button
                         type="submit"
                         name="<?php echo esc_attr($this->view_data['secondary_cta_action']); ?>"
                         class="button button-secondary contai-ps-btn--danger"
-                        aria-label="<?php esc_attr_e('Disconnect from Publisuites', '1platform-content-ai'); ?>"
+                        aria-label="<?php esc_attr_e('Disconnect from the marketplace', '1platform-content-ai'); ?>"
                     >
                         <span class="dashicons dashicons-dismiss" aria-hidden="true"></span>
                         <?php echo esc_html($this->view_data['secondary_cta_label']); ?>

--- a/includes/admin/apps/panels/publisuites/VerificationSection.php
+++ b/includes/admin/apps/panels/publisuites/VerificationSection.php
@@ -28,7 +28,7 @@ class ContaiPublisuitesVerificationSection
 
             <div class="contai-ps-hero">
                 <p class="contai-ps-hero__text">
-                    <?php esc_html_e('Your website needs to be verified with Publisuites. Follow the steps below to complete the verification process.', '1platform-content-ai'); ?>
+                    <?php esc_html_e('Your website needs to be verified. Follow the steps below to complete the verification process.', '1platform-content-ai'); ?>
                 </p>
             </div>
 
@@ -128,7 +128,7 @@ class ContaiPublisuitesVerificationSection
             <div class="contai-ps-step-body">
                 <h4 class="contai-ps-card__title"><?php esc_html_e('Verify your website', '1platform-content-ai'); ?></h4>
                 <p class="contai-ps-card__desc">
-                    <?php esc_html_e('Once the file is in place, click the button below to verify your website with Publisuites.', '1platform-content-ai'); ?>
+                    <?php esc_html_e('Once the file is in place, click the button below to verify your website.', '1platform-content-ai'); ?>
                 </p>
             </div>
         </div>
@@ -163,7 +163,7 @@ class ContaiPublisuitesVerificationSection
                 type="submit"
                 name="<?php echo esc_attr($this->view_data['primary_cta_action']); ?>"
                 class="button button-primary button-hero contai-ps-cta"
-                aria-label="<?php esc_attr_e('Verify your website with Publisuites', '1platform-content-ai'); ?>"
+                aria-label="<?php esc_attr_e('Verify your website ownership', '1platform-content-ai'); ?>"
             >
                 <span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
                 <?php echo esc_html($this->view_data['primary_cta_label']); ?>
@@ -179,7 +179,7 @@ class ContaiPublisuitesVerificationSection
         }
 
         $confirm_message = esc_js(
-            __('Are you sure you want to disconnect from Publisuites? You will need to reconnect later.', '1platform-content-ai')
+            __('Are you sure you want to disconnect from the marketplace? You will need to reconnect later.', '1platform-content-ai')
         );
         ?>
         <div class="contai-ps-danger">
@@ -191,13 +191,13 @@ class ContaiPublisuitesVerificationSection
                 <?php wp_nonce_field($this->view_data['nonce_action'], $this->view_data['nonce_field']); ?>
                 <div class="contai-ps-danger__row">
                     <p class="contai-ps-danger__desc">
-                        <?php esc_html_e('Disconnect from Publisuites. This will only remove the local connection data.', '1platform-content-ai'); ?>
+                        <?php esc_html_e('Disconnect from the marketplace. This will only remove the local connection data.', '1platform-content-ai'); ?>
                     </p>
                     <button
                         type="submit"
                         name="<?php echo esc_attr($this->view_data['secondary_cta_action']); ?>"
                         class="button button-secondary contai-ps-btn--danger"
-                        aria-label="<?php esc_attr_e('Disconnect from Publisuites', '1platform-content-ai'); ?>"
+                        aria-label="<?php esc_attr_e('Disconnect from the marketplace', '1platform-content-ai'); ?>"
                     >
                         <span class="dashicons dashicons-dismiss" aria-hidden="true"></span>
                         <?php echo esc_html($this->view_data['secondary_cta_label']); ?>

--- a/includes/services/setup/PublisuitesSetupService.php
+++ b/includes/services/setup/PublisuitesSetupService.php
@@ -1,0 +1,73 @@
+<?php
+
+if (!defined('ABSPATH')) exit;
+
+require_once __DIR__ . '/../publisuites/PublisuitesService.php';
+
+class ContaiPublisuitesSetupService
+{
+    private ContaiPublisuitesService $publisuiteService;
+
+    public function __construct(
+        ?ContaiPublisuitesService $publisuiteService = null
+    ) {
+        $this->publisuiteService = $publisuiteService ?? new ContaiPublisuitesService();
+    }
+
+    public function activatePublisuites(): array
+    {
+        $results = [
+            'success' => true,
+            'steps' => [],
+            'errors' => []
+        ];
+
+        try {
+            // Step 1: Register website in marketplace (API call action=add)
+            $connectResponse = $this->publisuiteService->connectWebsite();
+            if (!$connectResponse->isSuccess()) {
+                throw new Exception('Failed to register website: ' . $connectResponse->getMessage());
+            }
+
+            $data = $connectResponse->getData();
+            $this->publisuiteService->savePublisuitesConfig([
+                'publisuites_id' => $data['publisuites_id'] ?? '',
+                'verification_file_name' => $data['verification_file_name'] ?? '',
+                'verification_file_content' => $data['verification_file_content'] ?? '',
+                'status' => 'pending_verification',
+                'verified' => false,
+            ]);
+            $results['steps'][] = 'Website registered in marketplace';
+
+            // Step 2: Create verification file in WordPress root
+            $fileResult = $this->publisuiteService->createVerificationFile();
+            if (!$fileResult['success']) {
+                throw new Exception('Failed to create verification file: ' . $fileResult['message']);
+            }
+            $results['steps'][] = 'Verification file created';
+
+            // Step 3: Verify website ownership (API call action=verify)
+            $verifyResponse = $this->publisuiteService->verifyWebsite();
+            if (!$verifyResponse->isSuccess()) {
+                throw new Exception('Failed to verify website: ' . $verifyResponse->getMessage());
+            }
+
+            $verifyData = $verifyResponse->getData();
+            $config = $this->publisuiteService->getPublisuitesConfig();
+            if ($config) {
+                $config['verified'] = $verifyData['verified'] ?? false;
+                $config['verifiedAt'] = $verifyData['verified_at'] ?? null;
+                $config['status'] = ($verifyData['verified'] ?? false) ? 'active' : 'pending_verification';
+                $this->publisuiteService->savePublisuitesConfig($config);
+            }
+            $results['steps'][] = 'Website verified';
+
+        } catch (Exception $e) {
+            $results['success'] = false;
+            $results['errors'][] = $e->getMessage();
+            return $results;
+        }
+
+        return $results;
+    }
+}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai content, seo, content generation, internal links, table of contents
 Requires at least: 5.9
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.11.3
+Stable tag: 2.12.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -87,6 +87,7 @@ require_once __DIR__ . '/../includes/services/billing/BillingService.php';
 require_once __DIR__ . '/../includes/services/billing/CreditGuard.php';
 require_once __DIR__ . '/../includes/admin/billing/handlers/TopUpHandler.php';
 require_once __DIR__ . '/../includes/services/publisuites/PublisuitesService.php';
+require_once __DIR__ . '/../includes/services/setup/PublisuitesSetupService.php';
 require_once __DIR__ . '/../includes/admin/apps/handlers/PublisuitesFormHandler.php';
 require_once __DIR__ . '/../includes/services/jobs/KeywordExtractionJob.php';
 require_once __DIR__ . '/../includes/admin/content-generator/handlers/KeywordExtractionHandler.php';

--- a/tests/unit/admin/apps/handlers/PublisuitesFormHandlerTest.php
+++ b/tests/unit/admin/apps/handlers/PublisuitesFormHandlerTest.php
@@ -32,7 +32,8 @@ class PublisuitesFormHandlerTest extends TestCase
             $_POST['contai_connect_publisuites'],
             $_POST['contai_verify_publisuites'],
             $_POST['contai_disconnect_publisuites'],
-            $_POST['contai_create_verification_file']
+            $_POST['contai_create_verification_file'],
+            $_POST['contai_setup_publisuites']
         );
         WP_Mock::tearDown();
         Mockery::close();
@@ -277,6 +278,144 @@ class PublisuitesFormHandlerTest extends TestCase
             $this->fail('Expected redirect');
         } catch (PublisuitesRedirectException $e) {
             $this->assertStringContainsString('contai_ps_type=error', $redirectUrl->url);
+        }
+    }
+
+    // ── One-Click Setup Tests ─────────────────────────────────────
+
+    public function test_setup_success_redirects_with_success_message(): void
+    {
+        $this->mockValidRequest('contai_setup_publisuites');
+
+        $connectData = [
+            'publisuites_id' => 'ps-123',
+            'verification_file_name' => 'verify.html',
+            'verification_file_content' => '<html>verify</html>',
+        ];
+
+        $this->service
+            ->shouldReceive('connectWebsite')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(true, $connectData, 'Added', 200));
+
+        $this->service
+            ->shouldReceive('savePublisuitesConfig')
+            ->twice();
+
+        $this->service
+            ->shouldReceive('createVerificationFile')
+            ->once()
+            ->andReturn(['success' => true, 'message' => 'File created']);
+
+        $this->service
+            ->shouldReceive('verifyWebsite')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(true, ['verified' => true, 'verified_at' => '2026-03-26'], 'Verified', 200));
+
+        $this->service
+            ->shouldReceive('getPublisuitesConfig')
+            ->once()
+            ->andReturn(['publisuites_id' => 'ps-123']);
+
+        WP_Mock::userFunction('__')->andReturnUsing(function ($text) { return $text; });
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected redirect');
+        } catch (PublisuitesRedirectException $e) {
+            $this->assertStringContainsString('contai_ps_type=success', $redirectUrl->url);
+            $this->assertStringContainsString('marketplace', urldecode($redirectUrl->url));
+        }
+    }
+
+    public function test_setup_failure_redirects_with_error_message(): void
+    {
+        $this->mockValidRequest('contai_setup_publisuites');
+
+        $this->service
+            ->shouldReceive('connectWebsite')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(false, null, 'Credentials not configured', 400));
+
+        $this->service->shouldNotReceive('savePublisuitesConfig');
+        $this->service->shouldNotReceive('createVerificationFile');
+        $this->service->shouldNotReceive('verifyWebsite');
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected redirect');
+        } catch (PublisuitesRedirectException $e) {
+            $this->assertStringContainsString('contai_ps_type=error', $redirectUrl->url);
+            $this->assertStringContainsString('Failed', urldecode($redirectUrl->url));
+        }
+    }
+
+    public function test_setup_does_not_break_existing_connect_action(): void
+    {
+        $this->mockValidRequest('contai_connect_publisuites');
+
+        $responseData = [
+            'publisuites_id' => 'ps-999',
+            'verification_file_name' => 'verify.html',
+            'verification_file_content' => 'content',
+            'message' => 'Connected',
+        ];
+
+        $this->service
+            ->shouldReceive('connectWebsite')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(true, $responseData, 'Connected', 200));
+
+        $this->service
+            ->shouldReceive('savePublisuitesConfig')
+            ->once();
+
+        WP_Mock::userFunction('__')->andReturnUsing(function ($text) { return $text; });
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected redirect');
+        } catch (PublisuitesRedirectException $e) {
+            $this->assertStringContainsString('contai_ps_type=success', $redirectUrl->url);
+        }
+    }
+
+    public function test_setup_does_not_break_existing_verify_action(): void
+    {
+        $this->mockValidRequest('contai_verify_publisuites');
+
+        $this->service
+            ->shouldReceive('verifyWebsite')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(true, ['verified' => true, 'verified_at' => '2026-01-01'], 'Verified', 200));
+
+        $this->service
+            ->shouldReceive('getPublisuitesConfig')
+            ->once()
+            ->andReturn(['publisuites_id' => 'ps-123', 'status' => 'pending_verification']);
+
+        $this->service
+            ->shouldReceive('savePublisuitesConfig')
+            ->once()
+            ->with(Mockery::on(function ($config) {
+                return $config['verified'] === true && $config['status'] === 'active';
+            }));
+
+        WP_Mock::userFunction('__')->andReturnUsing(function ($text) { return $text; });
+
+        $redirectUrl = $this->expectRedirect();
+
+        try {
+            $this->handler->handleRequest();
+            $this->fail('Expected redirect');
+        } catch (PublisuitesRedirectException $e) {
+            $this->assertStringContainsString('contai_ps_type=success', $redirectUrl->url);
         }
     }
 

--- a/tests/unit/services/setup/PublisuitesSetupServiceTest.php
+++ b/tests/unit/services/setup/PublisuitesSetupServiceTest.php
@@ -1,0 +1,317 @@
+<?php
+
+namespace ContAI\Tests\Unit\Services\Setup;
+
+use WP_Mock;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use ContaiPublisuitesSetupService;
+use ContaiPublisuitesService;
+use ContaiOnePlatformResponse;
+
+class PublisuitesSetupServiceTest extends TestCase
+{
+    private ContaiPublisuitesService $service;
+    private ContaiPublisuitesSetupService $setupService;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        WP_Mock::setUp();
+
+        $this->service = Mockery::mock(ContaiPublisuitesService::class);
+        $this->setupService = new ContaiPublisuitesSetupService($this->service);
+    }
+
+    public function tearDown(): void
+    {
+        WP_Mock::tearDown();
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    // ── Happy Path ───────────────────────────────────────────────
+
+    public function test_activate_success_completes_three_steps(): void
+    {
+        $connectData = [
+            'publisuites_id' => 'ps-123',
+            'verification_file_name' => 'publisuites-verify-token.html',
+            'verification_file_content' => '<html>verify</html>',
+        ];
+
+        $this->service
+            ->shouldReceive('connectWebsite')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(true, $connectData, 'Added', 200));
+
+        $this->service
+            ->shouldReceive('savePublisuitesConfig')
+            ->twice();
+
+        $this->service
+            ->shouldReceive('createVerificationFile')
+            ->once()
+            ->andReturn(['success' => true, 'message' => 'File created']);
+
+        $this->service
+            ->shouldReceive('verifyWebsite')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(true, ['verified' => true, 'verified_at' => '2026-03-26T10:00:00Z'], 'Verified', 200));
+
+        $this->service
+            ->shouldReceive('getPublisuitesConfig')
+            ->once()
+            ->andReturn(['publisuites_id' => 'ps-123', 'status' => 'pending_verification']);
+
+        $result = $this->setupService->activatePublisuites();
+
+        $this->assertTrue($result['success']);
+        $this->assertCount(3, $result['steps']);
+        $this->assertEmpty($result['errors']);
+        $this->assertEquals('Website registered in marketplace', $result['steps'][0]);
+        $this->assertEquals('Verification file created', $result['steps'][1]);
+        $this->assertEquals('Website verified', $result['steps'][2]);
+    }
+
+    // ── Failure at Step 1 (connect) ──────────────────────────────
+
+    public function test_activate_connect_fails_stops_flow(): void
+    {
+        $this->service
+            ->shouldReceive('connectWebsite')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(false, null, 'API error', 502));
+
+        $this->service->shouldNotReceive('savePublisuitesConfig');
+        $this->service->shouldNotReceive('createVerificationFile');
+        $this->service->shouldNotReceive('verifyWebsite');
+
+        $result = $this->setupService->activatePublisuites();
+
+        $this->assertFalse($result['success']);
+        $this->assertEmpty($result['steps']);
+        $this->assertStringContainsString('Failed to register website: API error', $result['errors'][0]);
+    }
+
+    // ── Failure at Step 2 (create file) ──────────────────────────
+
+    public function test_activate_create_file_fails_stops_at_step2(): void
+    {
+        $connectData = [
+            'publisuites_id' => 'ps-123',
+            'verification_file_name' => 'verify.html',
+            'verification_file_content' => '<html>verify</html>',
+        ];
+
+        $this->service
+            ->shouldReceive('connectWebsite')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(true, $connectData, 'Added', 200));
+
+        $this->service
+            ->shouldReceive('savePublisuitesConfig')
+            ->once();
+
+        $this->service
+            ->shouldReceive('createVerificationFile')
+            ->once()
+            ->andReturn(['success' => false, 'message' => 'Permission denied']);
+
+        $this->service->shouldNotReceive('verifyWebsite');
+        $this->service->shouldNotReceive('getPublisuitesConfig');
+
+        $result = $this->setupService->activatePublisuites();
+
+        $this->assertFalse($result['success']);
+        $this->assertCount(1, $result['steps']);
+        $this->assertEquals('Website registered in marketplace', $result['steps'][0]);
+        $this->assertStringContainsString('Failed to create verification file: Permission denied', $result['errors'][0]);
+    }
+
+    // ── Failure at Step 3 (verify) ───────────────────────────────
+
+    public function test_activate_verify_fails_stops_at_step3(): void
+    {
+        $connectData = [
+            'publisuites_id' => 'ps-123',
+            'verification_file_name' => 'verify.html',
+            'verification_file_content' => '<html>verify</html>',
+        ];
+
+        $this->service
+            ->shouldReceive('connectWebsite')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(true, $connectData, 'Added', 200));
+
+        $this->service
+            ->shouldReceive('savePublisuitesConfig')
+            ->once();
+
+        $this->service
+            ->shouldReceive('createVerificationFile')
+            ->once()
+            ->andReturn(['success' => true, 'message' => 'File created']);
+
+        $this->service
+            ->shouldReceive('verifyWebsite')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(false, null, 'Verification pending', 400));
+
+        $this->service->shouldNotReceive('getPublisuitesConfig');
+
+        $result = $this->setupService->activatePublisuites();
+
+        $this->assertFalse($result['success']);
+        $this->assertCount(2, $result['steps']);
+        $this->assertStringContainsString('Failed to verify website: Verification pending', $result['errors'][0]);
+    }
+
+    // ── Idempotent add (already_added) ───────────────────────────
+
+    public function test_activate_idempotent_add_continues_flow(): void
+    {
+        $connectData = [
+            'publisuites_id' => 'ps-123',
+            'status' => 'already_added',
+            'verification_file_name' => 'publisuites-verify-token.html',
+            'verification_file_content' => '<html>verify</html>',
+        ];
+
+        $this->service
+            ->shouldReceive('connectWebsite')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(true, $connectData, 'Already added', 200));
+
+        $this->service
+            ->shouldReceive('savePublisuitesConfig')
+            ->twice();
+
+        $this->service
+            ->shouldReceive('createVerificationFile')
+            ->once()
+            ->andReturn(['success' => true, 'message' => 'File created']);
+
+        $this->service
+            ->shouldReceive('verifyWebsite')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(true, ['verified' => true, 'verified_at' => '2026-03-26T10:00:00Z'], 'Verified', 200));
+
+        $this->service
+            ->shouldReceive('getPublisuitesConfig')
+            ->once()
+            ->andReturn(['publisuites_id' => 'ps-123', 'status' => 'pending_verification']);
+
+        $result = $this->setupService->activatePublisuites();
+
+        $this->assertTrue($result['success']);
+        $this->assertCount(3, $result['steps']);
+        $this->assertEmpty($result['errors']);
+    }
+
+    // ── Config saved with correct data after connect ─────────────
+
+    public function test_activate_saves_config_with_correct_data_after_connect(): void
+    {
+        $connectData = [
+            'publisuites_id' => 'ps-456',
+            'verification_file_name' => 'publisuites-verify-abc.html',
+            'verification_file_content' => '<html>abc-verify</html>',
+        ];
+
+        $this->service
+            ->shouldReceive('connectWebsite')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(true, $connectData, 'Added', 200));
+
+        $this->service
+            ->shouldReceive('savePublisuitesConfig')
+            ->once()
+            ->with(Mockery::on(function ($config) {
+                return $config['publisuites_id'] === 'ps-456'
+                    && $config['verification_file_name'] === 'publisuites-verify-abc.html'
+                    && $config['verification_file_content'] === '<html>abc-verify</html>'
+                    && $config['status'] === 'pending_verification'
+                    && $config['verified'] === false;
+            }))
+            ->ordered();
+
+        // Allow second savePublisuitesConfig call (post-verify)
+        $this->service->shouldReceive('savePublisuitesConfig')->once()->ordered();
+
+        $this->service
+            ->shouldReceive('createVerificationFile')
+            ->once()
+            ->andReturn(['success' => true, 'message' => 'File created']);
+
+        $this->service
+            ->shouldReceive('verifyWebsite')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(true, ['verified' => true, 'verified_at' => '2026-03-26'], 'Verified', 200));
+
+        $this->service
+            ->shouldReceive('getPublisuitesConfig')
+            ->once()
+            ->andReturn(['publisuites_id' => 'ps-456']);
+
+        $result = $this->setupService->activatePublisuites();
+
+        $this->assertTrue($result['success']);
+    }
+
+    // ── Config updated to active after verify ────────────────────
+
+    public function test_activate_updates_config_to_active_after_verify(): void
+    {
+        $connectData = [
+            'publisuites_id' => 'ps-789',
+            'verification_file_name' => 'verify.html',
+            'verification_file_content' => '<html>verify</html>',
+        ];
+
+        $this->service
+            ->shouldReceive('connectWebsite')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(true, $connectData, 'Added', 200));
+
+        // First save: post-connect (pending)
+        $this->service
+            ->shouldReceive('savePublisuitesConfig')
+            ->once()
+            ->with(Mockery::on(function ($config) {
+                return $config['status'] === 'pending_verification' && $config['verified'] === false;
+            }))
+            ->ordered();
+
+        $this->service
+            ->shouldReceive('createVerificationFile')
+            ->once()
+            ->andReturn(['success' => true, 'message' => 'File created']);
+
+        $this->service
+            ->shouldReceive('verifyWebsite')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(true, ['verified' => true, 'verified_at' => '2026-03-26T12:00:00Z'], 'Verified', 200));
+
+        $this->service
+            ->shouldReceive('getPublisuitesConfig')
+            ->once()
+            ->andReturn(['publisuites_id' => 'ps-789', 'status' => 'pending_verification']);
+
+        // Second save: post-verify (active)
+        $this->service
+            ->shouldReceive('savePublisuitesConfig')
+            ->once()
+            ->with(Mockery::on(function ($config) {
+                return $config['verified'] === true
+                    && $config['status'] === 'active'
+                    && $config['verifiedAt'] === '2026-03-26T12:00:00Z';
+            }))
+            ->ordered();
+
+        $result = $this->setupService->activatePublisuites();
+
+        $this->assertTrue($result['success']);
+        $this->assertCount(3, $result['steps']);
+    }
+}


### PR DESCRIPTION
## Summary
- **One-click link building setup**: Unified 3-step Publisuites flow (connect → create file → verify) into a single click
- **Provider name removal**: Eliminated all "Publisuites" from 21 client-facing UI strings
- **11 new tests**: Full coverage for setup service + backward compatibility

## Changes

### New files
- `includes/services/setup/PublisuitesSetupService.php` — Orchestration service (mirrors SearchConsoleSetupService)
- `tests/unit/services/setup/PublisuitesSetupServiceTest.php` — 7 unit tests
- `docs/PLAN_PUBLISUITES_ONE_CLICK_SETUP.md` — Implementation plan

### Modified files
- `PublisuitesFormHandler.php` — Added `handleSetup()` + `contai_setup_publisuites` action
- `PublisuitesPanel.php` — Changed CTA to `contai_setup_publisuites` / "Connect to Marketplace"
- `ConnectSection.php` — Added setup steps card, removed provider name
- `VerificationSection.php` — Removed 6 "Publisuites" strings from UI
- `ConnectedSection.php` — Removed 5 "Publisuites" strings, "Publisuites ID" → "Marketplace ID"
- `AppsPanel.php` — "Publisuites" → "Link Building" in nav
- `AppsSidebar.php` — "Publisuites" → "Link Building" in sidebar
- `admin-apps.php` — "Publisuites" → "Link Building" in page title
- `PublisuitesFormHandler.php` — Removed provider name from 3 success messages
- `tests/bootstrap.php` — Register PublisuitesSetupService for tests
- `PublisuitesFormHandlerTest.php` — 4 new tests + tearDown cleanup

## Audit Results
- Security: Nonce + capability checks inherited from handleRequest() ✅
- Architecture: Follows SearchConsoleSetupService pattern exactly ✅
- Provider exposure: 0 instances remain in client-facing strings ✅
- Tests: 468 pass, 737 assertions ✅
- Backward compat: All manual actions (connect, verify, create file, disconnect) preserved ✅

## Test Plan
- [x] All 468 tests pass (737 assertions)
- [x] 7 setup service tests: success, 3 failure points, idempotency, config validation
- [x] 4 handler tests: success, failure, backward compat for connect and verify
- [x] Version sync: plugin 2.12.0 = readme 2.12.0
- [ ] Manual test: full 1-click flow in Local by Flywheel

🤖 Generated with [Claude Code](https://claude.com/claude-code)