### PR TITLE
fix(ci): resolve orphaned tag blocking release pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Content AI are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.12.1] - 2026-03-28
+
+### Fixed
+- **Release pipeline**: Resolved orphaned git tag v2.13.0 that blocked CI tag & release job
+
 ## [2.12.0] - 2026-03-27
 
 ### Added


### PR DESCRIPTION
## Summary
- Resolved orphaned git tag `v2.13.0` that was blocking the CI Tag & Release job
- Added changelog entry documenting the fix

## Root Cause
The analytics PR merge triggered CI which created tag `v2.13.0`, but the release job failed. The rollback deleted the remote tag but the tag creation step fails on retry because CI tries `git tag` which checks local state first.

## Fix
- Deleted the orphaned local tag
- This PR merge will trigger a clean CI run that creates a fresh tag + release

## Test Plan
- [x] 468 tests pass (737 assertions)
- [x] No code changes — only CHANGELOG.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)