### PR TITLE
fix(publisuites): rename 'Link Building' to 'Publisuites' in Tools menu

### DIFF
--- a/1platform-content-ai.php
+++ b/1platform-content-ai.php
@@ -4,7 +4,7 @@
  * Plugin Name: 1Platform Content AI
  * Plugin URI: https://1platform.pro/
  * Description: SaaS client for AI-powered content generation, SEO optimization, and site management. All AI processing happens on 1Platform external servers. Includes free local tools: Table of Contents and Internal Links.
- * Version: 2.12.1
+ * Version: 2.12.2
  * Author: 1Platform
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Content AI are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.12.2] - 2026-03-28
+
+### Changed
+- **Publisuites menu label**: Renamed "Link Building" to "Publisuites" in sidebar, page title, apps panel, and logs adapter (#44)
+
 ## [2.12.1] - 2026-03-28
 
 ### Fixed

--- a/includes/adapters/ContaiLogsAdapter.php
+++ b/includes/adapters/ContaiLogsAdapter.php
@@ -16,7 +16,7 @@ class ContaiLogsAdapter {
     ];
 
     const PROVIDER_DISPLAY_NAMES = [
-        'publisuites'      => 'Link Building',
+        'publisuites'      => 'Publisuites',
         'search_console'   => 'Search Console',
         'openai'           => 'AI Engine',
         'pixabay'          => 'Image Library',

--- a/includes/admin/admin-apps.php
+++ b/includes/admin/admin-apps.php
@@ -178,7 +178,7 @@ function contai_apps_page()
         case 'publisuites':
             $panel = new ContaiPublisuitesPanel();
             $layout->render_page_title(
-                __('Link Building', '1platform-content-ai'),
+                __('Publisuites', '1platform-content-ai'),
                 __('Connect your website to the marketplace to monetize your content', '1platform-content-ai'),
                 'dashicons-money-alt'
             );

--- a/includes/admin/apps/components/AppsSidebar.php
+++ b/includes/admin/apps/components/AppsSidebar.php
@@ -42,7 +42,7 @@ class ContaiAppsSidebar
                 'home' => false
             ],
             'publisuites' => [
-                'title' => __('Link Building', '1platform-content-ai'),
+                'title' => __('Publisuites', '1platform-content-ai'),
                 'icon' => 'dashicons-money-alt',
                 'badge' => null,
                 'home' => false

--- a/includes/admin/apps/panels/AppsPanel.php
+++ b/includes/admin/apps/panels/AppsPanel.php
@@ -34,7 +34,7 @@ class ContaiAppsPanel {
                 'status' => 'active',
             ],
             'publisuites' => [
-                'title' => __('Link Building', '1platform-content-ai'),
+                'title' => __('Publisuites', '1platform-content-ai'),
                 'description' => __('Connect your website to the marketplace to monetize your content and manage sponsored posts', '1platform-content-ai'),
                 'icon' => 'dashicons-money-alt',
                 'url' => add_query_arg(['section' => 'publisuites'], admin_url('admin.php?page=contai-apps')),

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai content, seo, content generation, internal links, table of contents
 Requires at least: 5.9
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.12.1
+Stable tag: 2.12.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -159,6 +159,9 @@ The plugin sends your site URL, API key, and content generation parameters (keyw
 7. Tools — Google Analytics, Google Search Console, Publisuites, and Ads Manager integrations.
 
 == Changelog ==
+
+= 2.12.2 =
+* Changed: Renamed "Link Building" to "Publisuites" in Tools sidebar menu, page title, apps panel, and logs adapter
 
 = 2.12.0 =
 * Added Google Analytics panel with full OAuth2 connection flow and 3-step visual wizard


### PR DESCRIPTION
## Summary
- Renamed all "Link Building" labels to "Publisuites" across the Tools section UI and logs adapter
- Affects sidebar menu, page title, apps panel card, and provider display name in logs

## Changes
- `includes/admin/apps/components/AppsSidebar.php` — sidebar menu item title
- `includes/admin/admin-apps.php` — page title in section renderer
- `includes/admin/apps/panels/AppsPanel.php` — apps grid card title
- `includes/adapters/ContaiLogsAdapter.php` — provider display name in logs

## Audit Results
- Code review: PASS — trivial label-only rename, no logic/security/architecture changes
- All 468 tests passing (737 assertions)
- Version sync validated (plugin 2.12.2 = readme 2.12.2)

## Test Plan
- [x] All 468 tests pass (737 assertions)
- [x] No regressions in existing test suites
- [ ] Verify sidebar shows "Publisuites" at `wp-admin/admin.php?page=contai-apps`
- [ ] Verify page title shows "Publisuites" at `wp-admin/admin.php?page=contai-apps&section=publisuites`
- [ ] Verify apps panel card shows "Publisuites"
- [ ] Verify logs show "Publisuites" as provider display name

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)