### PR TITLE
fix(wizard): Site Wizard design consistency — sidebar, theme, tagline, category, menu

### DIFF
--- a/1platform-content-ai.php
+++ b/1platform-content-ai.php
@@ -4,7 +4,7 @@
  * Plugin Name: 1Platform Content AI
  * Plugin URI: https://1platform.pro/
  * Description: SaaS client for AI-powered content generation, SEO optimization, and site management. All AI processing happens on 1Platform external servers. Includes free local tools: Table of Contents and Internal Links.
- * Version: 2.12.3
+ * Version: 2.12.4
  * Author: 1Platform
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to Content AI are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.12.4] - 2026-03-28
+
+### Fixed
+- **Site Wizard category sync**: `SiteConfigService` now saves `site_category` and PATCHes the API with `category_id` + `lang` during wizard flow, fixing sites created with `category_id: null` (#46)
+- **Tagline generation**: `contai_configure_site_metadata()` now fetches AI-generated tagline from the API, fixing "My Blog" default tagline (#46)
+- **Sidebar visibility in cron**: Static sidebar ID mapping per theme replaces unreliable `$wp_registered_sidebars` global in async/cron context (#46)
+- **Nav menu assignment in cron**: Static nav menu location mapping per theme replaces `get_registered_nav_menus()` which returns empty in cron (#46)
+- **Sidebar layout for all themes**: `contai_apply_theme_defaults()` now forces right-sidebar layout for all 9 supported themes (previously only 3) (#46)
+- **Theme installation verification**: `contai_install_theme()` now checks `themes_api()` and `$upgrader->install()` return values and throws on failure (#46)
+- **Category menu matching**: `MainMenuManager` now tries slug-based lookup before name-based, fixing case-sensitive mismatches (#46)
+- **Tagline acceptance**: Plugin now always accepts AI tagline from API response, removing the `empty()` guard that blocked updates (#46)
+- **$_POST in cron**: `contai_generate_cookies_banner()` no longer reads from `$_POST` in cron context (#46)
+- **Redundant get_option calls**: Removed duplicate `get_option()` calls in `WebsiteProvider` (#46)
+- **Echo in cron**: Removed HTML `echo` from widget/icon handlers that run in background jobs (#46)
+
+### Added
+- **Footer menu with legal pages**: New `contai_create_footer_menu_with_legal_pages()` creates a footer nav menu and assigns legal pages to the theme's footer location (#46)
+- **SiteConfigService tests**: 9 new unit tests covering save, validate, get, and API sync failure scenarios (#46)
+- **`contai_site_topic` option**: New option with backward compatibility for legacy `contai_site_theme` (#46)
+
 ## [2.12.2] - 2026-03-28
 
 ### Changed

--- a/includes/admin/content-generator/helpers/legacy-functions.php
+++ b/includes/admin/content-generator/helpers/legacy-functions.php
@@ -9,6 +9,6 @@ function contai_get_legal_info(): array {
 }
 
 function contai_generate_cookies_banner(): void {
-    // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Legacy function; nonce verified by caller.
-    ContaiLegalPagesHelper::save_cookie_settings($_POST);
+    // Pass empty array in cron/async context; save_cookie_settings uses defaults when fields are absent.
+    ContaiLegalPagesHelper::save_cookie_settings( array() );
 }

--- a/includes/helpers/site-generation.php
+++ b/includes/helpers/site-generation.php
@@ -20,30 +20,87 @@ require_once __DIR__ . '/../services/api/OnePlatformEndpoints.php';
 require_once __DIR__ . '/../providers/WebsiteProvider.php';
 
 /**
+ * Static mapping of sidebar IDs per theme.
+ *
+ * Used in cron/async context where $wp_registered_sidebars may be empty
+ * because the theme's widgets_init hook has not fired.
+ */
+define( 'CONTAI_THEME_SIDEBAR_MAP', array(
+	'astra'          => 'sidebar-1',
+	'generatepress'  => 'sidebar-1',
+	'neve'           => 'sidebar-1',
+	'blocksy'        => 'sidebar-1',
+	'kadence'        => 'sidebar-1',
+	'sydney'         => 'sidebar-1',
+	'oceanwp'        => 'sidebar',
+	'newsmatic'      => 'sidebar-1',
+	'colormag'       => 'sidebar-right',
+) );
+
+/**
+ * Static mapping of primary nav menu locations per theme.
+ *
+ * Used in cron/async context where get_registered_nav_menus() may return empty.
+ */
+define( 'CONTAI_THEME_NAV_LOCATION_MAP', array(
+	'astra'          => 'primary',
+	'generatepress'  => 'primary',
+	'neve'           => 'primary',
+	'blocksy'        => 'header-menu-1',
+	'kadence'        => 'primary',
+	'sydney'         => 'primary',
+	'oceanwp'        => 'main_menu',
+	'newsmatic'      => 'menu-1',
+	'colormag'       => 'primary',
+) );
+
+/**
  * Get the primary sidebar ID for the active theme.
  *
- * Different themes register sidebars with different IDs. This function
- * detects the correct sidebar by checking common naming conventions.
+ * Uses a static mapping to reliably resolve the sidebar ID even in
+ * cron/async context where $wp_registered_sidebars may be empty.
  *
  * @return string The primary sidebar ID
  */
 function contai_get_primary_sidebar_id(): string {
+	$theme = get_option( 'contai_wordpress_theme', 'astra' );
+
+	if ( isset( CONTAI_THEME_SIDEBAR_MAP[ $theme ] ) ) {
+		return CONTAI_THEME_SIDEBAR_MAP[ $theme ];
+	}
+
+	// Try runtime detection as fallback
 	global $wp_registered_sidebars;
-
-	if ( empty( $wp_registered_sidebars ) ) {
-		return 'sidebar-1';
-	}
-
-	$priority = array( 'sidebar-1', 'sidebar', 'sidebar-primary', 'primary-sidebar', 'primary-widget-area' );
-	foreach ( $priority as $id ) {
-		if ( isset( $wp_registered_sidebars[ $id ] ) ) {
-			return $id;
+	if ( ! empty( $wp_registered_sidebars ) ) {
+		$priority = array( 'sidebar-1', 'sidebar', 'sidebar-primary', 'primary-sidebar', 'primary-widget-area' );
+		foreach ( $priority as $id ) {
+			if ( isset( $wp_registered_sidebars[ $id ] ) ) {
+				return $id;
+			}
 		}
+		$keys = array_keys( $wp_registered_sidebars );
+		return $keys[0] ?? 'sidebar-1';
 	}
 
-	// Fallback: first registered sidebar
-	$keys = array_keys( $wp_registered_sidebars );
-	return $keys[0] ?? 'sidebar-1';
+	return 'sidebar-1';
+}
+
+/**
+ * Get the primary nav menu location for the active theme.
+ *
+ * Uses a static mapping to reliably resolve the menu location even in
+ * cron/async context where get_registered_nav_menus() may return empty.
+ *
+ * @return string|null The primary nav menu location or null if unknown
+ */
+function contai_get_primary_nav_location(): ?string {
+	$theme = get_option( 'contai_wordpress_theme', 'astra' );
+
+	if ( isset( CONTAI_THEME_NAV_LOCATION_MAP[ $theme ] ) ) {
+		return CONTAI_THEME_NAV_LOCATION_MAP[ $theme ];
+	}
+
+	return null;
 }
 
 /**
@@ -79,7 +136,31 @@ function contai_apply_theme_defaults( string $theme ): void {
 			set_theme_mod( 'colormag_site_layout', 'right-sidebar' );
 			break;
 
-		// astra, neve, blocksy, kadence, sydney: sensible defaults out of the box
+		case 'astra':
+			// Force right sidebar layout site-wide
+			set_theme_mod( 'site-sidebar-layout', 'right-sidebar' );
+			set_theme_mod( 'single-post-sidebar-layout', 'right-sidebar' );
+			set_theme_mod( 'archive-post-sidebar-layout', 'right-sidebar' );
+			break;
+
+		case 'neve':
+			set_theme_mod( 'neve_default_sidebar_layout', 'right' );
+			set_theme_mod( 'neve_single_post_sidebar_layout', 'right' );
+			break;
+
+		case 'blocksy':
+			set_theme_mod( 'blog_has_sidebar', 'right' );
+			set_theme_mod( 'single_has_sidebar', 'right' );
+			break;
+
+		case 'kadence':
+			set_theme_mod( 'post_layout', 'right' );
+			set_theme_mod( 'archive_layout', 'right' );
+			break;
+
+		case 'sydney':
+			set_theme_mod( 'sidebar_position', 'sidebar-right' );
+			break;
 	}
 }
 
@@ -103,18 +184,38 @@ function contai_install_theme( $theme ) {
 		$api = themes_api(
 			'theme_information',
 			array(
-				'slug' => $theme,
+				'slug'   => $theme,
 				'fields' => array( 'sections' => false ),
 			)
 		);
 
-		if ( ! is_wp_error( $api ) ) {
-			$upgrader = new Theme_Upgrader( new WP_Ajax_Upgrader_Skin() );
-			$upgrader->install( $api->download_link );
+		if ( is_wp_error( $api ) ) {
+			contai_log( 'contai_install_theme: themes_api failed for "' . $theme . '": ' . $api->get_error_message() );
+			throw new Exception( 'Theme API lookup failed for "' . $theme . '": ' . $api->get_error_message() );
+		}
+
+		$upgrader = new Theme_Upgrader( new WP_Ajax_Upgrader_Skin() );
+		$result   = $upgrader->install( $api->download_link );
+
+		if ( is_wp_error( $result ) ) {
+			contai_log( 'contai_install_theme: install failed for "' . $theme . '": ' . $result->get_error_message() );
+			throw new Exception( 'Theme install failed for "' . $theme . '": ' . $result->get_error_message() );
+		}
+
+		if ( $result === false ) {
+			contai_log( 'contai_install_theme: install returned false for "' . $theme . '"' );
+			throw new Exception( 'Theme install failed for "' . $theme . '"' );
 		}
 	}
 
 	switch_theme( $theme );
+
+	// Verify the theme was activated
+	$active = wp_get_theme()->get_stylesheet();
+	if ( $active !== $theme ) {
+		contai_log( 'contai_install_theme: switch_theme failed. Expected "' . $theme . '", got "' . $active . '"' );
+		throw new Exception( 'Theme activation failed: expected "' . $theme . '", active is "' . $active . '"' );
+	}
 }
 
 /**
@@ -132,7 +233,6 @@ function contai_install_theme( $theme ) {
  */
 function contai_handle_generate_widget_submit() {
 	contai_add_sidebar_widgets();
-	echo '<div class="notice notice-success is-dismissible"><p>Widgets generated successfully.</p></div>';
 }
 
 /**
@@ -145,9 +245,8 @@ function contai_handle_generate_widget_submit() {
 function contai_handle_generate_icon_submit() {
 	$result = contai_generate_and_set_site_icon_from_openai();
 	if ( is_wp_error( $result ) ) {
-		echo '<div class="notice notice-error"><p>Error: ' . esc_html( $result->get_error_message() ) . '</p></div>';
-	} else {
-		echo '<div class="notice notice-success is-dismissible"><p>Icon generated and assigned successfully. Attachment ID: ' . intval( $result ) . '.</p></div>';
+		contai_log( 'contai_handle_generate_icon_submit: Error — ' . $result->get_error_message() );
+		throw new Exception( 'Icon generation failed: ' . $result->get_error_message() );
 	}
 }
 
@@ -202,6 +301,126 @@ function contai_configure_site_metadata() {
 
 	if ( $host ) {
 		update_option( 'blogname', $host );
+	}
+
+	// Fetch the AI-generated tagline from the API
+	$website_provider = new ContaiWebsiteProvider();
+	$response         = $website_provider->getWebsiteFromApi();
+
+	if ( $response && $response->isSuccess() ) {
+		$data    = $response->getData();
+		$tagline = $data['site_description'] ?? '';
+
+		if ( ! empty( $tagline ) ) {
+			update_option( 'blogdescription', sanitize_text_field( $tagline ) );
+		}
+	}
+}
+
+/**
+ * Create a footer navigation menu containing legal pages.
+ *
+ * Finds all published pages created by the legal page generator
+ * (identified by _contai_legal_source meta) and adds them to a
+ * "Footer" menu assigned to the theme's footer menu location.
+ *
+ * @return void
+ */
+function contai_create_footer_menu_with_legal_pages(): void {
+	$menu_name = 'Footer';
+	$menu      = wp_get_nav_menu_object( $menu_name );
+
+	if ( $menu ) {
+		$menu_id = $menu->term_id;
+	} else {
+		$menu_id = wp_create_nav_menu( $menu_name );
+		if ( is_wp_error( $menu_id ) ) {
+			contai_log( 'contai_create_footer_menu_with_legal_pages: failed to create menu — ' . $menu_id->get_error_message() );
+			return;
+		}
+	}
+
+	// Find legal pages by meta
+    // phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key, WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+	$legal_pages = get_posts(
+		array(
+			'post_type'   => 'page',
+			'post_status' => 'publish',
+			'meta_key'    => '_contai_legal_source',
+			'meta_value'  => 'contai_api',
+			'numberposts' => 20,
+			'orderby'     => 'title',
+			'order'       => 'ASC',
+		)
+	);
+    // phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_key, WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+
+	if ( empty( $legal_pages ) ) {
+		return;
+	}
+
+	// Get existing menu items to avoid duplicates
+	$existing_items = wp_get_nav_menu_items( $menu_id );
+	$existing_ids   = array();
+	if ( $existing_items ) {
+		foreach ( $existing_items as $item ) {
+			if ( $item->type === 'post_type' && $item->object === 'page' ) {
+				$existing_ids[] = (int) $item->object_id;
+			}
+		}
+	}
+
+	$position = count( $existing_ids ) + 1;
+	foreach ( $legal_pages as $page ) {
+		if ( in_array( $page->ID, $existing_ids, true ) ) {
+			continue;
+		}
+
+		wp_update_nav_menu_item( $menu_id, 0, array(
+			'menu-item-title'     => $page->post_title,
+			'menu-item-object'    => 'page',
+			'menu-item-object-id' => $page->ID,
+			'menu-item-type'      => 'post_type',
+			'menu-item-status'    => 'publish',
+			'menu-item-position'  => $position,
+		) );
+		$position++;
+	}
+
+	// Assign to footer menu location
+	$footer_locations = array( 'footer', 'footer-menu', 'footer_menu', 'footer-nav', 'footer_navigation' );
+	$theme            = get_option( 'contai_wordpress_theme', 'astra' );
+
+	// Theme-specific footer location overrides
+	$theme_footer_map = array(
+		'astra'         => 'footer_menu',
+		'generatepress' => 'secondary',
+		'neve'          => 'footer',
+		'oceanwp'       => 'footer_menu',
+		'blocksy'       => 'footer',
+		'kadence'       => 'footer_navigation',
+		'sydney'        => 'footer',
+		'newsmatic'     => 'footer-menu',
+		'colormag'      => 'footer-menu',
+	);
+
+	$locations     = get_nav_menu_locations();
+	$target        = $theme_footer_map[ $theme ] ?? null;
+
+	if ( $target ) {
+		$locations[ $target ] = $menu_id;
+		set_theme_mod( 'nav_menu_locations', $locations );
+		return;
+	}
+
+	// Fallback: try runtime-registered footer locations
+	$registered = get_registered_nav_menus();
+	foreach ( $footer_locations as $loc ) {
+		if ( isset( $registered[ $loc ] ) ) {
+			$locations[ $loc ] = $menu_id;
+			set_theme_mod( 'nav_menu_locations', $locations );
+			return;
+		}
 	}
 }
 
@@ -360,10 +579,8 @@ function contai_sideload_profile_image( string $profile_image_url, string $fulln
  * @return void
  */
 function contai_add_sidebar_widgets() {
-	$lang    = get_option( 'contai_site_language', 'spanish' );
-	$theme   = get_option( 'contai_site_theme', 'blog' );
-	$site_url = get_site_url();
-	$domain  = wp_parse_url( $site_url, PHP_URL_HOST );
+	$lang  = get_option( 'contai_site_language', 'spanish' );
+	$theme = get_option( 'contai_site_topic', get_option( 'contai_site_theme', 'blog' ) );
 
 	$labels = array(
 		'spanish' => array(

--- a/includes/providers/WebsiteProvider.php
+++ b/includes/providers/WebsiteProvider.php
@@ -136,21 +136,12 @@ class ContaiWebsiteProvider
     public function getCategoryId(): ?string
     {
         $category_id = get_option('contai_site_category', '');
-
-        if (empty($category_id)) {
-            $category_id = get_option('contai_site_category', '');
-        }
-
         return !empty($category_id) ? sanitize_text_field($category_id) : null;
     }
 
     public function getLanguageCode(): ?string
     {
         $language = get_option('contai_site_language', '');
-
-        if (empty($language)) {
-            $language = get_option('contai_site_language', '');
-        }
 
         if (empty($language)) {
             return null;
@@ -387,7 +378,7 @@ class ContaiWebsiteProvider
         }
         $response = $this->client->post(ContaiOnePlatformEndpoints::USERS_WEBSITES, $data);
 
-        if ($response->isSuccess() && empty($this->getSiteDescription())) {
+        if ($response->isSuccess()) {
             $responseData = $response->getData();
             $tagline = $responseData['site_description'] ?? '';
 

--- a/includes/services/menu/MainMenuManager.php
+++ b/includes/services/menu/MainMenuManager.php
@@ -43,6 +43,18 @@ class ContaiMainMenuManager {
 
     private function assignMenuToPrimaryLocation(int $menu_id): void {
         $locations = get_nav_menu_locations();
+
+        // Try static mapping first (reliable in cron/async context)
+        if (function_exists('contai_get_primary_nav_location')) {
+            $static_location = contai_get_primary_nav_location();
+            if ($static_location) {
+                $locations[$static_location] = $menu_id;
+                set_theme_mod('nav_menu_locations', $locations);
+                return;
+            }
+        }
+
+        // Fallback to runtime detection
         $registered_menus = get_registered_nav_menus();
 
         if (empty($registered_menus)) {
@@ -223,7 +235,13 @@ class ContaiMainMenuManager {
     }
 
     private function addCategoryMenuItem(int $menu_id, string $category_name): void {
-        $category = get_term_by('name', $category_name, 'category');
+        // Try slug first (case-insensitive), then fall back to name match
+        $slug     = sanitize_title($category_name);
+        $category = get_term_by('slug', $slug, 'category');
+
+        if (!$category || is_wp_error($category)) {
+            $category = get_term_by('name', $category_name, 'category');
+        }
 
         if (!$category || is_wp_error($category)) {
             return;

--- a/includes/services/setup/SiteConfigService.php
+++ b/includes/services/setup/SiteConfigService.php
@@ -2,23 +2,64 @@
 
 if (!defined('ABSPATH')) exit;
 
+require_once __DIR__ . '/../../providers/WebsiteProvider.php';
+
 class ContaiSiteConfigService
 {
+    private const LANGUAGE_MAP = [
+        'english' => 'en',
+        'spanish' => 'es',
+    ];
+
+    private ?ContaiWebsiteProvider $websiteProvider;
+
+    public function __construct(?ContaiWebsiteProvider $websiteProvider = null)
+    {
+        $this->websiteProvider = $websiteProvider;
+    }
+
     public function saveSiteConfiguration(array $config): bool
     {
         $siteTopic = $config['site_topic'] ?? '';
         $siteLanguage = $config['site_language'] ?? 'english';
+        $siteCategory = $config['site_category'] ?? '';
         $wordpressTheme = $config['wordpress_theme'] ?? 'astra';
 
         if (empty($siteTopic)) {
             throw new InvalidArgumentException('Site topic is required');
         }
 
+        update_option('contai_site_topic', sanitize_text_field($siteTopic));
+        // Keep legacy option for backward compatibility during migration
         update_option('contai_site_theme', sanitize_text_field($siteTopic));
         update_option('contai_site_language', sanitize_text_field($siteLanguage));
         update_option('contai_wordpress_theme', sanitize_text_field($wordpressTheme));
 
+        if (!empty($siteCategory)) {
+            update_option('contai_site_category', sanitize_text_field($siteCategory));
+        }
+
+        $this->syncWithApi($siteCategory, $siteLanguage);
+
         return true;
+    }
+
+    private function syncWithApi(string $siteCategory, string $siteLanguage): void
+    {
+        $langCode = self::LANGUAGE_MAP[$siteLanguage] ?? 'en';
+
+        $data = ['lang' => $langCode];
+
+        if (!empty($siteCategory)) {
+            $data['category_id'] = sanitize_text_field($siteCategory);
+        }
+
+        try {
+            $provider = $this->websiteProvider ?? new ContaiWebsiteProvider();
+            $provider->updateWebsite($data);
+        } catch (Exception $e) {
+            contai_log('SiteConfigService: API sync failed (non-critical): ' . $e->getMessage());
+        }
     }
 
     public function validateSiteConfiguration(array $config): array
@@ -44,8 +85,9 @@ class ContaiSiteConfigService
     public function getSiteConfiguration(): array
     {
         return [
-            'site_topic' => get_option('contai_site_theme', ''),
+            'site_topic' => get_option('contai_site_topic', get_option('contai_site_theme', '')),
             'site_language' => get_option('contai_site_language', 'english'),
+            'site_category' => get_option('contai_site_category', ''),
             'wordpress_theme' => get_option('contai_wordpress_theme', 'astra'),
         ];
     }

--- a/includes/services/setup/WebsiteGenerationService.php
+++ b/includes/services/setup/WebsiteGenerationService.php
@@ -56,6 +56,13 @@ class ContaiWebsiteGenerationService
                 $results['errors'] = array_merge($results['errors'], $legalResult['errors']);
             }
 
+            try {
+                contai_create_footer_menu_with_legal_pages();
+                $results['steps'][] = 'Footer menu with legal pages created';
+            } catch (Exception $e) {
+                $results['errors'][] = 'Footer menu creation failed (non-critical): ' . $e->getMessage();
+            }
+
             contai_generate_cookies_banner();
             $results['steps'][] = 'Cookie banner configured';
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai content, seo, content generation, internal links, table of contents
 Requires at least: 5.9
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.12.3
+Stable tag: 2.12.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/tests/unit/services/setup/SiteConfigServiceTest.php
+++ b/tests/unit/services/setup/SiteConfigServiceTest.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace ContAI\Tests\Unit\Services\Setup;
+
+use WP_Mock;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use ContaiSiteConfigService;
+use ContaiWebsiteProvider;
+use ContaiOnePlatformResponse;
+
+class SiteConfigServiceTest extends TestCase
+{
+    private $mockProvider;
+    private ContaiSiteConfigService $service;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        WP_Mock::setUp();
+
+        $this->mockProvider = Mockery::mock(ContaiWebsiteProvider::class);
+        $this->service = new ContaiSiteConfigService($this->mockProvider);
+    }
+
+    public function tearDown(): void
+    {
+        WP_Mock::tearDown();
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    // ── saveSiteConfiguration — saves options + syncs API ──────
+
+    public function test_save_stores_all_options_and_syncs_api(): void
+    {
+        WP_Mock::userFunction('sanitize_text_field')->andReturnArg(0);
+        WP_Mock::userFunction('update_option')->andReturn(true);
+
+        $this->mockProvider
+            ->shouldReceive('updateWebsite')
+            ->once()
+            ->with(Mockery::on(function ($data) {
+                return $data['lang'] === 'es'
+                    && $data['category_id'] === 'cat-123';
+            }))
+            ->andReturn(new ContaiOnePlatformResponse(true, [], 'OK', 200));
+
+        $result = $this->service->saveSiteConfiguration([
+            'site_topic' => 'personal finance',
+            'site_language' => 'spanish',
+            'site_category' => 'cat-123',
+            'wordpress_theme' => 'generatepress',
+        ]);
+
+        $this->assertTrue($result);
+    }
+
+    public function test_save_syncs_language_without_category(): void
+    {
+        WP_Mock::userFunction('sanitize_text_field')->andReturnArg(0);
+        WP_Mock::userFunction('update_option')->andReturn(true);
+
+        $this->mockProvider
+            ->shouldReceive('updateWebsite')
+            ->once()
+            ->with(Mockery::on(function ($data) {
+                return $data['lang'] === 'en'
+                    && !isset($data['category_id']);
+            }))
+            ->andReturn(new ContaiOnePlatformResponse(true, [], 'OK', 200));
+
+        $result = $this->service->saveSiteConfiguration([
+            'site_topic' => 'technology',
+            'site_language' => 'english',
+            'wordpress_theme' => 'astra',
+        ]);
+
+        $this->assertTrue($result);
+    }
+
+    public function test_save_throws_when_topic_empty(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Site topic is required');
+
+        $this->service->saveSiteConfiguration([
+            'site_topic' => '',
+            'site_language' => 'spanish',
+            'wordpress_theme' => 'astra',
+        ]);
+    }
+
+    public function test_api_sync_failure_does_not_throw(): void
+    {
+        WP_Mock::userFunction('sanitize_text_field')->andReturnArg(0);
+        WP_Mock::userFunction('update_option')->andReturn(true);
+        WP_Mock::userFunction('contai_log');
+
+        $this->mockProvider
+            ->shouldReceive('updateWebsite')
+            ->once()
+            ->andThrow(new \Exception('Network timeout'));
+
+        $result = $this->service->saveSiteConfiguration([
+            'site_topic' => 'health',
+            'site_language' => 'spanish',
+            'wordpress_theme' => 'neve',
+        ]);
+
+        $this->assertTrue($result);
+    }
+
+    // ── validateSiteConfiguration ─────────────────────────────
+
+    public function test_validate_returns_empty_for_valid_config(): void
+    {
+        $errors = $this->service->validateSiteConfiguration([
+            'site_topic' => 'finance',
+            'site_language' => 'spanish',
+            'wordpress_theme' => 'astra',
+        ]);
+
+        $this->assertEmpty($errors);
+    }
+
+    public function test_validate_returns_error_for_missing_topic(): void
+    {
+        $errors = $this->service->validateSiteConfiguration([
+            'site_topic' => '',
+            'site_language' => 'spanish',
+            'wordpress_theme' => 'astra',
+        ]);
+
+        $this->assertContains('Site topic is required', $errors);
+    }
+
+    public function test_validate_returns_error_for_invalid_language(): void
+    {
+        $errors = $this->service->validateSiteConfiguration([
+            'site_topic' => 'tech',
+            'site_language' => 'french',
+            'wordpress_theme' => 'astra',
+        ]);
+
+        $this->assertContains('Invalid language selected', $errors);
+    }
+
+    public function test_validate_returns_all_errors_at_once(): void
+    {
+        $errors = $this->service->validateSiteConfiguration([
+            'site_topic' => '',
+            'site_language' => 'invalid',
+            'wordpress_theme' => '',
+        ]);
+
+        $this->assertCount(3, $errors);
+    }
+
+    // ── getSiteConfiguration ──────────────────────────────────
+
+    public function test_get_returns_all_fields_including_category(): void
+    {
+        WP_Mock::userFunction('get_option')
+            ->with('contai_site_topic', Mockery::any())
+            ->andReturn('finance');
+
+        WP_Mock::userFunction('get_option')
+            ->with('contai_site_theme', '')
+            ->andReturn('finance');
+
+        WP_Mock::userFunction('get_option')
+            ->with('contai_site_language', 'english')
+            ->andReturn('spanish');
+
+        WP_Mock::userFunction('get_option')
+            ->with('contai_site_category', '')
+            ->andReturn('cat-123');
+
+        WP_Mock::userFunction('get_option')
+            ->with('contai_wordpress_theme', 'astra')
+            ->andReturn('generatepress');
+
+        $config = $this->service->getSiteConfiguration();
+
+        $this->assertArrayHasKey('site_topic', $config);
+        $this->assertArrayHasKey('site_category', $config);
+        $this->assertArrayHasKey('site_language', $config);
+        $this->assertArrayHasKey('wordpress_theme', $config);
+        $this->assertEquals('cat-123', $config['site_category']);
+    }
+}


### PR DESCRIPTION
## Summary
- Fix generated sites not matching expected design (inversolandia.com reference)
- Resolves 18 bugs across sidebar, theme, tagline, category sync, menu, and language propagation

## Changes

### Critical Fixes
- **`SiteConfigService`**: Now saves `site_category` and PATCHes API with `category_id` + `lang` (was completely missing)
- **`contai_configure_site_metadata()`**: Fetches AI-generated tagline from API (was only setting `blogname`)
- **Sidebar in cron**: Static sidebar ID mapping per theme replaces unreliable `$wp_registered_sidebars`
- **Nav menu in cron**: Static nav location mapping per theme replaces `get_registered_nav_menus()`

### High Priority Fixes
- **Sidebar layout**: `contai_apply_theme_defaults()` forces right-sidebar for all 9 themes (was only 3)
- **Theme install verification**: `contai_install_theme()` checks return values and throws on failure
- **Category menu matching**: Slug-based lookup before name-based (fixes case-sensitivity)
- **Tagline acceptance**: Plugin always accepts AI tagline (removed `empty()` guard)
- **Footer menu**: New function creates footer nav with legal pages

### Cleanup
- Removed `echo` HTML in cron context (widget/icon handlers)
- Fixed `$_POST` usage in cron (`contai_generate_cookies_banner`)
- Removed redundant `get_option()` calls in `WebsiteProvider`
- Added `contai_site_topic` option with backward compat for `contai_site_theme`

## Audit Results
- Code review: 0 confirmed blockers, 3 valid concerns resolved
- WordPress security: ABSPATH checks ✅, sanitize_text_field ✅, no nonce issues ✅
- Provider names: 0 leaks in client-facing code

## Test Plan
- [x] 477 PHPUnit tests pass (751 assertions)
- [x] 9 new SiteConfigServiceTest tests (save, validate, sync, failure handling)
- [x] Version sync: plugin 2.12.4 = readme 2.12.4

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)