### PR TITLE
feat(adsense): add AdSense account management with OAuth flow

### DIFF
--- a/1platform-content-ai.php
+++ b/1platform-content-ai.php
@@ -4,7 +4,7 @@
  * Plugin Name: 1Platform Content AI
  * Plugin URI: https://1platform.pro/
  * Description: SaaS client for AI-powered content generation, SEO optimization, and site management. All AI processing happens on 1Platform external servers. Includes free local tools: Table of Contents and Internal Links.
- * Version: 2.13.0
+ * Version: 2.13.1
  * Author: 1Platform
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/1platform-content-ai.php
+++ b/1platform-content-ai.php
@@ -4,7 +4,7 @@
  * Plugin Name: 1Platform Content AI
  * Plugin URI: https://1platform.pro/
  * Description: SaaS client for AI-powered content generation, SEO optimization, and site management. All AI processing happens on 1Platform external servers. Includes free local tools: Table of Contents and Internal Links.
- * Version: 2.12.5
+ * Version: 2.13.0
  * Author: 1Platform
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -186,6 +186,10 @@ add_action( 'admin_menu', 'contai_register_admin_menus' );
 add_action( 'rest_api_init', function() {
     $controller = new ContaiAgentRestController();
     $controller->register_routes();
+
+    require_once plugin_dir_path( __FILE__ ) . 'includes/services/adsense/ContaiAdSenseRestController.php';
+    $adsense_controller = new ContaiAdSenseRestController();
+    $adsense_controller->register_routes();
 } );
 
 /**
@@ -342,3 +346,27 @@ function contai_display_migration_error_notice(): void {
     );
 }
 add_action('admin_notices', 'contai_display_migration_error_notice');
+
+/**
+ * Display AdSense policy issue notices.
+ */
+function contai_display_adsense_policy_notice() {
+    if ( ! current_user_can( 'manage_options' ) ) {
+        return;
+    }
+
+    $policy_count = get_transient( 'contai_adsense_policy_count' );
+    if ( $policy_count === false || (int) $policy_count === 0 ) {
+        return;
+    }
+
+    printf(
+        '<div class="notice notice-warning"><p>%s</p></div>',
+        esc_html( sprintf(
+            /* translators: %d: number of policy issues */
+            __( '%d AdSense policy issue(s) detected. Review in Tools > Ads Manager.', '1platform-content-ai' ),
+            (int) $policy_count
+        ) )
+    );
+}
+add_action( 'admin_notices', 'contai_display_adsense_policy_notice' );

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Content AI are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.13.1] - 2026-03-31
+
+### Fixed
+- **AdSense website ID resolution**: Fixed `get_website_id()` to use `ContaiWebsiteProvider::getWebsiteId()` instead of raw `get_option()`, which returned an array instead of a string, causing "No website configured" errors on all AdSense endpoints
+- **AdSense API response serialization**: Fixed all REST handlers passing the raw `ContaiOnePlatformResponse` object instead of `getData()`, causing `{"data":{}}` empty responses (e.g., missing `authorization_url` on OAuth authorize)
+- **AdSense disconnect/revoke state sync**: Guarded `update_option('contai_adsense_connected')` behind `isSuccess()` check to prevent local state desync when the API call fails
+- **AdSense Account tab CSS**: Added complete styles for empty state, OAuth stepper, connect button, connected state, features grid, earnings summary, and disconnect area
+
 ## [2.13.0] - 2026-03-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to Content AI are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.13.0] - 2026-03-31
+
+### Added
+- **AdSense Account management**: New "AdSense Account" tab in Ads Manager with OAuth popup flow for connecting/disconnecting Google AdSense, status display, and earnings overview
+- **AdSense REST controller**: 11 REST endpoints (`authorize`, `connect`, `disconnect`, `revoke`, `status`, `earnings`, `sites`, `sync_sites`, `alerts`, `policy_issues`, `oauth_status`) with admin capability checks and nonce verification
+- **OAuth popup flow**: Secure `postMessage` + origin validation for AdSense authorization with auto-sync of publisher ID after connect
+- **AdSense account JS/CSS**: `adsense-account.js` (OAuth flow, status loading, earnings display) and `adsense-account.css` (account tab styling)
+- **Policy notice**: Admin notice when AdSense policy issues are detected via API
+
+### Fixed
+- **Delete confirmation dialog**: Fixed dead `data-confirm` attribute on "Delete & Reset" button — now uses `onclick` confirm dialog
+- **Period parameter validation**: Added whitelist `validate_callback` for earnings report period parameter
+- **Non-JSON error handling**: JS `apiRequest()` now handles server errors (500 HTML, auth redirects) gracefully
+
 ## [2.12.4] - 2026-03-28
 
 ### Fixed

--- a/includes/admin/admin-apps.php
+++ b/includes/admin/admin-apps.php
@@ -116,6 +116,15 @@ function contai_enqueue_apps_styles()
             );
         }
 
+        // AdSense Account tab CSS (loaded alongside ads-manager)
+        if ($section === 'ads-manager') {
+            contai_enqueue_style_with_version(
+                'contai-adsense-account',
+                $css_base_url . 'adsense-account.css',
+                ['contai-apps-base']
+            );
+        }
+
         $section_js_map = [
             'ads-manager' => 'publisher-panel.js',
         ];
@@ -128,6 +137,21 @@ function contai_enqueue_apps_styles()
                 [],
                 true
             );
+        }
+
+        // AdSense Account tab JS (loaded alongside ads-manager)
+        if ($section === 'ads-manager') {
+            $js_base_url = plugin_dir_url(__FILE__) . 'apps/assets/js/';
+            contai_enqueue_script_with_version(
+                'contai-adsense-account',
+                $js_base_url . 'adsense-account.js',
+                [],
+                true
+            );
+            wp_localize_script('contai-adsense-account', 'contaiAdsense', [
+                'restUrl' => esc_url_raw(rest_url('contai/v1/adsense/')),
+                'nonce'   => wp_create_nonce('wp_rest'),
+            ]);
         }
     }
 }

--- a/includes/admin/apps/assets/css/adsense-account.css
+++ b/includes/admin/apps/assets/css/adsense-account.css
@@ -1,82 +1,389 @@
-/* AdSense Account Tab Styles */
+/* ===================================================
+   AdSense Account Tab
+   Scoped under .contai-ads-manager for specificity
+   =================================================== */
 
-.contai-adsense-connect-section {
-    padding: 24px 0;
+/* --- Empty State (not connected) --- */
+.contai-ads-manager .contai-adsense-empty {
+    padding: var(--contai-spacing-xl) var(--contai-spacing-lg);
+    text-align: center;
+    max-width: 560px;
+    margin: 0 auto;
 }
 
-.contai-adsense-connect-section .button-primary {
-    margin-top: 16px;
+.contai-ads-manager .contai-adsense-empty__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    background: var(--contai-primary-glow);
+    border: 1px solid var(--contai-primary-border);
+    margin-bottom: var(--contai-spacing-md);
+}
+
+.contai-ads-manager .contai-adsense-empty__icon .dashicons {
+    font-size: 28px;
+    width: 28px;
+    height: 28px;
+    color: var(--contai-primary);
+}
+
+.contai-ads-manager .contai-adsense-empty h3 {
+    margin: 0 0 8px;
+    font-size: 18px;
+    font-weight: 700;
+    color: var(--contai-neutral-700);
+}
+
+.contai-ads-manager .contai-adsense-empty > p {
+    margin: 0 0 var(--contai-spacing-lg);
+    font-size: 13.5px;
+    line-height: 1.6;
+    color: var(--contai-neutral-500);
+}
+
+/* --- Steps --- */
+.contai-ads-manager .contai-adsense-steps {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    text-align: left;
+    margin-bottom: var(--contai-spacing-lg);
+    border: 1px solid var(--contai-neutral-200);
+    border-radius: var(--contai-radius-lg);
+    overflow: hidden;
+    background: var(--contai-neutral-50);
+}
+
+.contai-ads-manager .contai-adsense-step {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--contai-spacing-md);
+    padding: var(--contai-spacing-md) 20px;
+    border-bottom: 1px solid var(--contai-neutral-200);
+    transition: background var(--contai-duration-fast) ease;
+}
+
+.contai-ads-manager .contai-adsense-step:last-child {
+    border-bottom: none;
+}
+
+.contai-ads-manager .contai-adsense-step.active {
+    background: #fff;
+}
+
+.contai-ads-manager .contai-adsense-step__num {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    font-size: 13px;
+    font-weight: 700;
+    background: var(--contai-neutral-200);
+    color: var(--contai-neutral-500);
+    margin-top: 2px;
+    transition: background var(--contai-duration-fast) ease, color var(--contai-duration-fast) ease;
+}
+
+.contai-ads-manager .contai-adsense-step.active .contai-adsense-step__num {
+    background: linear-gradient(135deg, var(--contai-primary) 0%, var(--contai-primary-dark) 100%);
+    color: #fff;
+    box-shadow: 0 2px 6px rgba(37, 99, 235, 0.25);
+}
+
+.contai-ads-manager .contai-adsense-step h4 {
+    margin: 0 0 2px;
+    font-size: 13.5px;
+    font-weight: 600;
+    color: var(--contai-neutral-600);
+}
+
+.contai-ads-manager .contai-adsense-step.active h4 {
+    color: var(--contai-neutral-700);
+}
+
+.contai-ads-manager .contai-adsense-step p {
+    margin: 0;
+    font-size: 12.5px;
+    line-height: 1.5;
+    color: var(--contai-neutral-500);
+}
+
+/* --- OAuth Connect Button --- */
+.contai-ads-manager .contai-btn-oauth {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 28px;
+    font-size: 14px;
+    font-weight: 600;
+    color: #fff;
+    background: linear-gradient(135deg, var(--contai-primary) 0%, var(--contai-primary-dark) 100%);
+    border: 1px solid var(--contai-primary);
+    border-radius: var(--contai-radius-md);
+    cursor: pointer;
+    box-shadow: var(--contai-shadow-sm);
+    transition: background 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+    line-height: 1.4;
+}
+
+.contai-ads-manager .contai-btn-oauth .dashicons {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+}
+
+.contai-ads-manager .contai-btn-oauth:hover {
+    background: linear-gradient(135deg, var(--contai-primary-dark) 0%, var(--contai-primary-darker) 100%);
+    border-color: var(--contai-primary-darker);
+    box-shadow: var(--contai-shadow-md);
+    transform: translateY(-1px);
+    color: #fff;
+}
+
+.contai-ads-manager .contai-btn-oauth:active {
+    background: var(--contai-primary-darker);
+    transform: translateY(0);
+    box-shadow: var(--contai-shadow-sm);
+}
+
+.contai-ads-manager .contai-btn-oauth:focus-visible {
+    outline: 2px solid var(--contai-primary);
+    outline-offset: 2px;
+}
+
+.contai-ads-manager .contai-btn-oauth:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    transform: none;
+}
+
+/* --- Connected State --- */
+.contai-ads-manager .contai-adsense-connected {
+    padding: var(--contai-spacing-lg);
+}
+
+.contai-ads-manager .contai-adsense-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: var(--contai-spacing-lg);
+}
+
+.contai-ads-manager .contai-adsense-header__left {
+    display: flex;
+    align-items: center;
+    gap: var(--contai-spacing-sm);
+}
+
+.contai-ads-manager .contai-adsense-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 5px 12px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--contai-success);
+    background: rgba(5, 150, 105, 0.08);
+    border: 1px solid rgba(5, 150, 105, 0.2);
+    border-radius: 20px;
+}
+
+.contai-ads-manager .contai-adsense-badge .dashicons {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+}
+
+.contai-ads-manager .contai-adsense-mid {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--contai-neutral-500);
+    font-family: var(--contai-font-mono);
+}
+
+/* --- Loading State --- */
+.contai-ads-manager .contai-adsense-loading {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: var(--contai-spacing-md) 0;
+    color: var(--contai-neutral-500);
+    font-size: 13px;
+}
+
+/* --- Feature Cards (status grid) --- */
+.contai-ads-manager .contai-adsense-features {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: var(--contai-spacing-sm);
+}
+
+.contai-ads-manager .contai-adsense-feature {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--contai-spacing-sm);
+    padding: var(--contai-spacing-md);
+    background: var(--contai-neutral-50);
+    border: 1px solid var(--contai-neutral-200);
+    border-radius: var(--contai-radius-md);
+}
+
+.contai-ads-manager .contai-adsense-feature__icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 36px;
+    height: 36px;
+    border-radius: var(--contai-radius-sm);
+}
+
+.contai-ads-manager .contai-adsense-feature__icon .dashicons {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+}
+
+.contai-ads-manager .contai-adsense-feature__icon--blue {
+    background: rgba(37, 99, 235, 0.08);
+    color: var(--contai-primary);
+}
+
+.contai-ads-manager .contai-adsense-feature__icon--blue .dashicons {
+    color: var(--contai-primary);
+}
+
+.contai-ads-manager .contai-adsense-feature__icon--green {
+    background: rgba(5, 150, 105, 0.08);
+    color: var(--contai-success);
+}
+
+.contai-ads-manager .contai-adsense-feature__icon--green .dashicons {
+    color: var(--contai-success);
+}
+
+.contai-ads-manager .contai-adsense-feature__icon--amber {
+    background: rgba(217, 119, 6, 0.08);
+    color: var(--contai-warning);
+}
+
+.contai-ads-manager .contai-adsense-feature__icon--amber .dashicons {
+    color: var(--contai-warning);
+}
+
+.contai-ads-manager .contai-adsense-feature__icon--purple {
+    background: rgba(124, 58, 237, 0.08);
+    color: #7c3aed;
+}
+
+.contai-ads-manager .contai-adsense-feature__icon--purple .dashicons {
+    color: #7c3aed;
+}
+
+.contai-ads-manager .contai-adsense-feature h4 {
+    margin: 0 0 2px;
+    font-size: 11.5px;
+    font-weight: 600;
+    color: var(--contai-neutral-500);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.contai-ads-manager .contai-adsense-feature p {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--contai-neutral-700);
+}
+
+/* --- Earnings Summary --- */
+.contai-ads-manager .contai-adsense-earnings-summary {
+    margin-top: var(--contai-spacing-lg);
+    padding-top: var(--contai-spacing-lg);
+    border-top: 1px solid var(--contai-neutral-200);
+}
+
+.contai-ads-manager .contai-adsense-earnings-summary > h4 {
+    margin: 0 0 var(--contai-spacing-sm);
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--contai-neutral-700);
+}
+
+.contai-ads-manager .contai-adsense-earnings-val {
+    color: var(--contai-success) !important;
+}
+
+/* --- Disconnect Area --- */
+.contai-ads-manager .contai-adsense-disconnect {
+    display: flex;
+    align-items: center;
+    gap: var(--contai-spacing-sm);
+    margin-top: var(--contai-spacing-lg);
+    padding-top: var(--contai-spacing-lg);
+    border-top: 1px solid var(--contai-neutral-200);
+}
+
+.contai-ads-manager .contai-adsense-disconnect .button {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.contai-ads-manager .contai-adsense-disconnect .button .dashicons {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+}
+
+.contai-ads-manager .contai-btn-disconnect {
     display: inline-flex;
     align-items: center;
     gap: 6px;
-}
-
-.contai-adsense-status-section {
-    padding: 16px 0;
-}
-
-.contai-adsense-info-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-    gap: 16px;
-    margin: 16px 0;
-}
-
-.contai-adsense-info-item {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-    padding: 12px 16px;
-    background: #f8fafc;
-    border-radius: 8px;
-    border: 1px solid #e2e8f0;
-}
-
-.contai-adsense-label {
-    font-size: 12px;
+    padding: 6px 14px;
+    font-size: 13px;
     font-weight: 500;
-    color: #64748b;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
+    color: var(--contai-error);
+    background: none;
+    border: 1px solid var(--contai-error-border);
+    border-radius: var(--contai-radius-md);
+    cursor: pointer;
+    transition: background 0.15s ease, color 0.15s ease;
 }
 
-.contai-adsense-value {
-    font-size: 16px;
-    font-weight: 600;
-    color: #0f172a;
+.contai-ads-manager .contai-btn-disconnect:hover {
+    background: var(--contai-error-bg);
+    color: #991b1b;
 }
 
-.contai-adsense-earnings-val {
-    color: #059669;
+/* --- Responsive --- */
+@media (max-width: 768px) {
+    .contai-ads-manager .contai-adsense-empty {
+        padding: var(--contai-spacing-lg) var(--contai-spacing-md);
+    }
+
+    .contai-ads-manager .contai-adsense-features {
+        grid-template-columns: 1fr 1fr;
+    }
+
+    .contai-ads-manager .contai-adsense-connected {
+        padding: var(--contai-spacing-md);
+    }
 }
 
-.contai-adsense-earnings-summary {
-    margin-top: 24px;
-    padding-top: 16px;
-    border-top: 1px solid #e2e8f0;
-}
+@media (max-width: 480px) {
+    .contai-ads-manager .contai-adsense-features {
+        grid-template-columns: 1fr;
+    }
 
-.contai-adsense-earnings-summary h4 {
-    margin: 0 0 4px;
-    font-size: 14px;
-    font-weight: 600;
-    color: #334155;
-}
-
-.contai-adsense-actions {
-    display: flex;
-    gap: 8px;
-}
-
-.contai-adsense-actions .button {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-}
-
-#contai-adsense-status-loading {
-    display: flex;
-    align-items: center;
-    padding: 16px 0;
-    color: #64748b;
+    .contai-ads-manager .contai-adsense-disconnect {
+        flex-direction: column;
+        align-items: stretch;
+    }
 }

--- a/includes/admin/apps/assets/css/adsense-account.css
+++ b/includes/admin/apps/assets/css/adsense-account.css
@@ -1,0 +1,82 @@
+/* AdSense Account Tab Styles */
+
+.contai-adsense-connect-section {
+    padding: 24px 0;
+}
+
+.contai-adsense-connect-section .button-primary {
+    margin-top: 16px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.contai-adsense-status-section {
+    padding: 16px 0;
+}
+
+.contai-adsense-info-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 16px;
+    margin: 16px 0;
+}
+
+.contai-adsense-info-item {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 12px 16px;
+    background: #f8fafc;
+    border-radius: 8px;
+    border: 1px solid #e2e8f0;
+}
+
+.contai-adsense-label {
+    font-size: 12px;
+    font-weight: 500;
+    color: #64748b;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.contai-adsense-value {
+    font-size: 16px;
+    font-weight: 600;
+    color: #0f172a;
+}
+
+.contai-adsense-earnings-val {
+    color: #059669;
+}
+
+.contai-adsense-earnings-summary {
+    margin-top: 24px;
+    padding-top: 16px;
+    border-top: 1px solid #e2e8f0;
+}
+
+.contai-adsense-earnings-summary h4 {
+    margin: 0 0 4px;
+    font-size: 14px;
+    font-weight: 600;
+    color: #334155;
+}
+
+.contai-adsense-actions {
+    display: flex;
+    gap: 8px;
+}
+
+.contai-adsense-actions .button {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
+#contai-adsense-status-loading {
+    display: flex;
+    align-items: center;
+    padding: 16px 0;
+    color: #64748b;
+}

--- a/includes/admin/apps/assets/css/publisher-panel.css
+++ b/includes/admin/apps/assets/css/publisher-panel.css
@@ -394,6 +394,326 @@
     transform: translateY(0);
 }
 
+/* ===================================================
+   AdSense Account Tab -- Empty & Connected States
+   Mirrors Google Analytics panel UX
+   =================================================== */
+
+/* --- Empty State --- */
+.contai-ads-manager .contai-adsense-empty {
+    text-align: center;
+    padding: var(--contai-spacing-xl) var(--contai-spacing-lg);
+    max-width: 560px;
+    margin: 0 auto;
+}
+
+.contai-ads-manager .contai-adsense-empty__icon {
+    width: 64px;
+    height: 64px;
+    border-radius: var(--contai-radius-lg);
+    background: var(--contai-primary-glow);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: var(--contai-spacing-md);
+}
+
+.contai-ads-manager .contai-adsense-empty__icon .dashicons {
+    font-size: 32px;
+    width: 32px;
+    height: 32px;
+    color: var(--contai-primary);
+}
+
+.contai-ads-manager .contai-adsense-empty h3 {
+    font-size: 20px;
+    font-weight: 600;
+    color: var(--contai-neutral-700);
+    margin: 0 0 var(--contai-spacing-xs);
+}
+
+.contai-ads-manager .contai-adsense-empty p {
+    color: var(--contai-neutral-500);
+    font-size: 14px;
+    line-height: 1.6;
+    margin: 0 0 var(--contai-spacing-lg);
+}
+
+/* --- Steps --- */
+.contai-ads-manager .contai-adsense-steps {
+    display: flex;
+    flex-direction: column;
+    gap: var(--contai-spacing-md);
+    max-width: 460px;
+    margin: 0 auto var(--contai-spacing-lg);
+    text-align: left;
+}
+
+.contai-ads-manager .contai-adsense-step {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--contai-spacing-sm);
+    padding: var(--contai-spacing-sm) var(--contai-spacing-md);
+    border-radius: var(--contai-radius-md);
+    background: var(--contai-neutral-50);
+    border: 1px solid var(--contai-neutral-200);
+    transition: border-color 0.2s, background 0.2s;
+}
+
+.contai-ads-manager .contai-adsense-step.active {
+    border-color: var(--contai-primary-border);
+    background: var(--contai-primary-glow);
+}
+
+.contai-ads-manager .contai-adsense-step.done {
+    border-color: var(--contai-success-border);
+    background: var(--contai-success-bg);
+}
+
+.contai-ads-manager .contai-adsense-step__num {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: var(--contai-neutral-200);
+    color: var(--contai-neutral-600);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 13px;
+    font-weight: 700;
+    flex-shrink: 0;
+}
+
+.contai-ads-manager .contai-adsense-step.active .contai-adsense-step__num {
+    background: var(--contai-primary);
+    color: #fff;
+}
+
+.contai-ads-manager .contai-adsense-step.done .contai-adsense-step__num {
+    background: var(--contai-success);
+    color: #fff;
+}
+
+.contai-ads-manager .contai-adsense-step h4 {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--contai-neutral-700);
+    margin: 0 0 2px;
+}
+
+.contai-ads-manager .contai-adsense-step p {
+    font-size: 12px;
+    color: var(--contai-neutral-500);
+    margin: 0;
+    line-height: 1.4;
+}
+
+/* --- OAuth Button --- */
+.contai-ads-manager .contai-btn-oauth {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 24px;
+    background: var(--contai-primary);
+    color: #fff;
+    border: none;
+    border-radius: var(--contai-radius-md);
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s, box-shadow 0.2s;
+}
+
+.contai-ads-manager .contai-btn-oauth:hover {
+    background: var(--contai-primary-dark);
+    box-shadow: var(--contai-shadow-md);
+    color: #fff;
+}
+
+.contai-ads-manager .contai-btn-oauth:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.contai-ads-manager .contai-btn-oauth .dashicons {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+}
+
+/* --- Connected State --- */
+.contai-ads-manager .contai-adsense-connected {
+    display: flex;
+    flex-direction: column;
+    gap: var(--contai-spacing-lg);
+    padding: var(--contai-spacing-lg);
+}
+
+.contai-ads-manager .contai-adsense-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding-bottom: var(--contai-spacing-md);
+    border-bottom: 1px solid var(--contai-neutral-200);
+}
+
+.contai-ads-manager .contai-adsense-header__left {
+    display: flex;
+    align-items: center;
+    gap: var(--contai-spacing-sm);
+}
+
+.contai-ads-manager .contai-adsense-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 12px;
+    border-radius: var(--contai-radius-pill);
+    font-size: 13px;
+    font-weight: 600;
+    background: var(--contai-success-bg);
+    color: var(--contai-success-text);
+    border: 1px solid var(--contai-success-border);
+}
+
+.contai-ads-manager .contai-adsense-badge .dashicons {
+    font-size: 14px;
+    width: 14px;
+    height: 14px;
+    color: var(--contai-success);
+}
+
+.contai-ads-manager .contai-adsense-mid {
+    font-family: monospace;
+    font-size: 14px;
+    color: var(--contai-neutral-600);
+    background: var(--contai-neutral-100);
+    padding: 4px 10px;
+    border-radius: var(--contai-radius-sm);
+}
+
+.contai-ads-manager .contai-adsense-loading {
+    display: flex;
+    align-items: center;
+    gap: var(--contai-spacing-xs);
+    font-size: 13px;
+    color: var(--contai-neutral-500);
+}
+
+.contai-ads-manager .contai-adsense-loading .spinner {
+    float: none;
+    margin: 0;
+}
+
+/* --- Feature Grid --- */
+.contai-ads-manager .contai-adsense-features {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: var(--contai-spacing-md);
+}
+
+.contai-ads-manager .contai-adsense-feature {
+    background: var(--contai-neutral-50);
+    border: 1px solid var(--contai-neutral-200);
+    border-radius: var(--contai-radius-md);
+    padding: var(--contai-spacing-md);
+    display: flex;
+    align-items: flex-start;
+    gap: var(--contai-spacing-sm);
+}
+
+.contai-ads-manager .contai-adsense-feature__icon {
+    width: 36px;
+    height: 36px;
+    border-radius: var(--contai-radius-sm);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.contai-ads-manager .contai-adsense-feature__icon--blue {
+    background: var(--contai-info-bg);
+    color: var(--contai-primary);
+}
+
+.contai-ads-manager .contai-adsense-feature__icon--green {
+    background: var(--contai-success-bg);
+    color: var(--contai-success);
+}
+
+.contai-ads-manager .contai-adsense-feature__icon--amber {
+    background: var(--contai-warning-bg);
+    color: var(--contai-warning);
+}
+
+.contai-ads-manager .contai-adsense-feature__icon--purple {
+    background: #f3e8ff;
+    color: #7c3aed;
+}
+
+.contai-ads-manager .contai-adsense-feature__icon .dashicons {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+}
+
+.contai-ads-manager .contai-adsense-feature h4 {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--contai-neutral-700);
+    margin: 0 0 2px;
+}
+
+.contai-ads-manager .contai-adsense-feature p {
+    font-size: 12px;
+    color: var(--contai-neutral-500);
+    margin: 0;
+    line-height: 1.4;
+}
+
+/* --- Earnings Summary --- */
+.contai-ads-manager .contai-adsense-earnings-summary {
+    padding-top: var(--contai-spacing-md);
+    border-top: 1px solid var(--contai-neutral-200);
+}
+
+.contai-ads-manager .contai-adsense-earnings-summary h4 {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--contai-neutral-700);
+    margin: 0 0 var(--contai-spacing-md);
+}
+
+.contai-ads-manager .contai-adsense-earnings-val {
+    font-weight: 700;
+    color: var(--contai-success) !important;
+}
+
+/* --- Disconnect / Actions --- */
+.contai-ads-manager .contai-adsense-disconnect {
+    display: flex;
+    align-items: center;
+    gap: var(--contai-spacing-sm);
+    padding-top: var(--contai-spacing-md);
+    border-top: 1px solid var(--contai-neutral-200);
+}
+
+.contai-ads-manager .contai-btn-disconnect {
+    padding: 6px 16px;
+    background: #fff;
+    color: var(--contai-error);
+    border: 1px solid var(--contai-error-border);
+    border-radius: var(--contai-radius-md);
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+}
+
+.contai-ads-manager .contai-btn-disconnect:hover {
+    background: var(--contai-error-bg);
+}
+
 /* --- Responsive --- */
 @media (max-width: 768px) {
     .contai-ads-manager .contai-ads-tabs-nav {
@@ -424,6 +744,20 @@
 
     .contai-ads-manager .contai-ads-advanced-grid {
         grid-template-columns: 1fr;
+        padding: var(--contai-spacing-md);
+    }
+
+    .contai-ads-manager .contai-adsense-features {
+        grid-template-columns: 1fr;
+    }
+
+    .contai-ads-manager .contai-adsense-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: var(--contai-spacing-xs);
+    }
+
+    .contai-ads-manager .contai-adsense-connected {
         padding: var(--contai-spacing-md);
     }
 }

--- a/includes/admin/apps/assets/js/adsense-account.js
+++ b/includes/admin/apps/assets/js/adsense-account.js
@@ -1,0 +1,209 @@
+/**
+ * AdSense Account tab — OAuth popup, REST calls, status display.
+ */
+(function () {
+    'use strict';
+
+    if (typeof contaiAdsense === 'undefined') {
+        return;
+    }
+
+    var restUrl = contaiAdsense.restUrl;
+    var nonce = contaiAdsense.nonce;
+
+    function apiRequest(endpoint, method, data) {
+        var options = {
+            method: method || 'GET',
+            headers: {
+                'X-WP-Nonce': nonce,
+                'Content-Type': 'application/json',
+            },
+        };
+        if (data && method !== 'GET') {
+            options.body = JSON.stringify(data);
+        }
+        return fetch(restUrl + endpoint, options).then(function (r) {
+            if (!r.ok) {
+                return r.text().then(function (text) {
+                    try { return JSON.parse(text); } catch (e) {
+                        return { success: false, msg: 'Server error (' + r.status + ')' };
+                    }
+                });
+            }
+            return r.json();
+        });
+    }
+
+    // ── OAuth Popup ──
+
+    var connectBtn = document.getElementById('contai-adsense-connect-btn');
+    if (connectBtn) {
+        connectBtn.addEventListener('click', function () {
+            connectBtn.disabled = true;
+            connectBtn.textContent = 'Connecting...';
+
+            apiRequest('authorize', 'GET')
+                .then(function (resp) {
+                    if (!resp.success || !resp.data) {
+                        alert('Failed to start authorization');
+                        connectBtn.disabled = false;
+                        connectBtn.textContent = 'Connect AdSense';
+                        return;
+                    }
+
+                    var authData = resp.data;
+                    var authUrl = authData.authorization_url || (authData.data && authData.data.authorization_url);
+                    if (!authUrl) {
+                        alert('No authorization URL received');
+                        connectBtn.disabled = false;
+                        connectBtn.textContent = 'Connect AdSense';
+                        return;
+                    }
+
+                    var popup = window.open(authUrl, 'contai_adsense_oauth', 'width=600,height=700');
+
+                    window.addEventListener('message', function onMessage(event) {
+                        if (event.origin !== window.location.origin) return;
+                        if (!event.data || event.data.type !== 'contai_adsense_oauth_complete') return;
+
+                        window.removeEventListener('message', onMessage);
+
+                        if (event.data.success) {
+                            apiRequest('connect', 'POST')
+                                .then(function () {
+                                    window.location.reload();
+                                })
+                                .catch(function () {
+                                    window.location.reload();
+                                });
+                        } else {
+                            connectBtn.disabled = false;
+                            connectBtn.textContent = 'Connect AdSense';
+                            alert('Authorization failed: ' + (event.data.error || 'Unknown error'));
+                        }
+                    });
+                })
+                .catch(function () {
+                    connectBtn.disabled = false;
+                    connectBtn.textContent = 'Connect AdSense';
+                    alert('Failed to start authorization');
+                });
+        });
+    }
+
+    // ── Status Loading ──
+
+    var statusLoading = document.getElementById('contai-adsense-status-loading');
+    var statusData = document.getElementById('contai-adsense-status-data');
+
+    if (statusLoading && statusData) {
+        loadStatus();
+    }
+
+    function loadStatus() {
+        apiRequest('status', 'GET')
+            .then(function (resp) {
+                if (!resp.success || !resp.data) {
+                    statusLoading.textContent = 'Failed to load status';
+                    return;
+                }
+                var data = resp.data.data || resp.data;
+                displayStatus(data);
+                if (data.status === 'active') {
+                    loadEarnings();
+                }
+            })
+            .catch(function () {
+                statusLoading.textContent = 'Failed to load status';
+            });
+    }
+
+    function displayStatus(data) {
+        statusLoading.style.display = 'none';
+        statusData.style.display = '';
+
+        setText('contai-adsense-account-name', data.account_name || '—');
+        setText('contai-adsense-publisher-id', data.publisher_id || '—');
+        setText('contai-adsense-site-state', formatSiteState(data.site_state));
+        setText('contai-adsense-connection-status', data.status || '—');
+    }
+
+    function loadEarnings() {
+        apiRequest('earnings?period=7d', 'GET')
+            .then(function (resp) {
+                if (!resp.success || !resp.data) return;
+                var data = resp.data.data || resp.data;
+                displayEarnings(data);
+            })
+            .catch(function () {});
+    }
+
+    function displayEarnings(data) {
+        var earningsSection = document.getElementById('contai-adsense-earnings');
+        if (!earningsSection) return;
+        earningsSection.style.display = '';
+
+        var earnings = extractValue(data.estimated_earnings);
+        var clicks = extractValue(data.clicks);
+        var impressions = extractValue(data.impressions);
+        var rpm = extractValue(data.page_views_rpm);
+
+        setText('contai-adsense-est-earnings', '$' + parseFloat(earnings).toFixed(2));
+        setText('contai-adsense-clicks', Math.round(clicks).toString());
+        setText('contai-adsense-impressions', Math.round(impressions).toString());
+        setText('contai-adsense-rpm', '$' + parseFloat(rpm).toFixed(2));
+    }
+
+    function extractValue(metric) {
+        if (metric === null || metric === undefined) return 0;
+        if (typeof metric === 'object' && metric.current !== undefined) return metric.current;
+        return metric;
+    }
+
+    function formatSiteState(state) {
+        var map = {
+            'REQUIRES_REVIEW': 'Requires Review',
+            'GETTING_READY': 'Getting Ready',
+            'READY': 'Ready',
+            'NEEDS_ATTENTION': 'Needs Attention',
+        };
+        return map[state] || state || '—';
+    }
+
+    function setText(id, text) {
+        var el = document.getElementById(id);
+        if (el) el.textContent = text;
+    }
+
+    // ── Refresh ──
+
+    var refreshBtn = document.getElementById('contai-adsense-refresh-btn');
+    if (refreshBtn) {
+        refreshBtn.addEventListener('click', function () {
+            refreshBtn.disabled = true;
+            loadStatus();
+            setTimeout(function () {
+                refreshBtn.disabled = false;
+            }, 3000);
+        });
+    }
+
+    // ── Disconnect ──
+
+    var disconnectBtn = document.getElementById('contai-adsense-disconnect-btn');
+    if (disconnectBtn) {
+        disconnectBtn.addEventListener('click', function () {
+            if (!confirm('Are you sure you want to disconnect AdSense?')) return;
+            disconnectBtn.disabled = true;
+
+            apiRequest('disconnect', 'DELETE')
+                .then(function () {
+                    window.location.reload();
+                })
+                .catch(function () {
+                    disconnectBtn.disabled = false;
+                    alert('Failed to disconnect');
+                });
+        });
+    }
+})();

--- a/includes/admin/apps/panels/AdsManagerPanel.php
+++ b/includes/admin/apps/panels/AdsManagerPanel.php
@@ -153,7 +153,11 @@ class ContaiAdsManagerPanel {
 		<div class="contai-ads-manager">
 			<!-- Tab Navigation -->
 			<nav class="contai-ads-tabs-nav" role="tablist">
-				<button type="button" class="contai-ads-tab active" data-tab="publishers" role="tab" aria-selected="true">
+				<button type="button" class="contai-ads-tab active" data-tab="adsense-account" role="tab" aria-selected="true">
+					<span class="dashicons dashicons-chart-area"></span>
+					<span class="contai-ads-tab-label"><?php esc_html_e( 'AdSense Account', '1platform-content-ai' ); ?></span>
+				</button>
+				<button type="button" class="contai-ads-tab" data-tab="publishers" role="tab" aria-selected="false">
 					<span class="dashicons dashicons-media-text"></span>
 					<span class="contai-ads-tab-label"><?php esc_html_e( 'Publisher List', '1platform-content-ai' ); ?></span>
 				</button>
@@ -165,16 +169,12 @@ class ContaiAdsManagerPanel {
 					<span class="dashicons dashicons-admin-generic"></span>
 					<span class="contai-ads-tab-label"><?php esc_html_e( 'Advanced', '1platform-content-ai' ); ?></span>
 				</button>
-				<button type="button" class="contai-ads-tab" data-tab="adsense-account" role="tab" aria-selected="false">
-					<span class="dashicons dashicons-chart-area"></span>
-					<span class="contai-ads-tab-label"><?php esc_html_e( 'AdSense Account', '1platform-content-ai' ); ?></span>
-				</button>
 			</nav>
 
+			<?php $this->renderAdSenseAccountTab(); ?>
 			<?php $this->renderPublishersTab(); ?>
 			<?php $this->renderCustomHeaderTab(); ?>
 			<?php $this->renderAdvancedTab(); ?>
-			<?php $this->renderAdSenseAccountTab(); ?>
 		</div>
 		<?php
 	}
@@ -187,7 +187,7 @@ class ContaiAdsManagerPanel {
 		}
 		$ads_txt_exists = file_exists( ABSPATH . 'ads.txt' );
 		?>
-		<div class="contai-ads-tab-content active" id="tab-publishers" role="tabpanel">
+		<div class="contai-ads-tab-content" id="tab-publishers" role="tabpanel">
 			<form method="post">
 				<?php wp_nonce_field( 'contai_adsense_injector_save', 'contai_settings_nonce' ); ?>
 				<input type="hidden" name="form_type" value="publishers">
@@ -365,7 +365,7 @@ class ContaiAdsManagerPanel {
 	private function renderAdSenseAccountTab(): void {
 		$is_connected = get_option( 'contai_adsense_connected', false );
 		?>
-		<div class="contai-ads-tab-content" id="tab-adsense-account" role="tabpanel">
+		<div class="contai-ads-tab-content active" id="tab-adsense-account" role="tabpanel">
 			<div id="contai-adsense-account-root">
 				<?php if ( ! $is_connected ) : ?>
 				<div class="contai-adsense-connect-section">

--- a/includes/admin/apps/panels/AdsManagerPanel.php
+++ b/includes/admin/apps/panels/AdsManagerPanel.php
@@ -368,74 +368,122 @@ class ContaiAdsManagerPanel {
 		<div class="contai-ads-tab-content active" id="tab-adsense-account" role="tabpanel">
 			<div id="contai-adsense-account-root">
 				<?php if ( ! $is_connected ) : ?>
-				<div class="contai-adsense-connect-section">
-					<div class="contai-ads-callout contai-ads-callout-info">
+				<div class="contai-adsense-empty">
+					<div class="contai-adsense-empty__icon">
 						<span class="dashicons dashicons-chart-area"></span>
-						<div>
-							<strong><?php esc_html_e( 'Connect Your AdSense Account', '1platform-content-ai' ); ?></strong>
-							<p><?php esc_html_e( 'Connect via OAuth to see earnings, site approval status, and policy alerts directly in your dashboard.', '1platform-content-ai' ); ?></p>
+					</div>
+					<h3><?php esc_html_e( 'Connect Your AdSense Account', '1platform-content-ai' ); ?></h3>
+					<p><?php esc_html_e( 'Connect via OAuth to see earnings, site approval status, and policy alerts directly in your WordPress dashboard.', '1platform-content-ai' ); ?></p>
+
+					<div class="contai-adsense-steps">
+						<div class="contai-adsense-step active">
+							<span class="contai-adsense-step__num">1</span>
+							<div>
+								<h4><?php esc_html_e( 'Authorize with Google', '1platform-content-ai' ); ?></h4>
+								<p><?php esc_html_e( 'Sign in with your Google account that has access to AdSense', '1platform-content-ai' ); ?></p>
+							</div>
+						</div>
+						<div class="contai-adsense-step">
+							<span class="contai-adsense-step__num">2</span>
+							<div>
+								<h4><?php esc_html_e( 'Select AdSense Account', '1platform-content-ai' ); ?></h4>
+								<p><?php esc_html_e( 'Choose which AdSense account to connect to this site', '1platform-content-ai' ); ?></p>
+							</div>
+						</div>
+						<div class="contai-adsense-step">
+							<span class="contai-adsense-step__num">3</span>
+							<div>
+								<h4><?php esc_html_e( 'Auto-Configure', '1platform-content-ai' ); ?></h4>
+								<p><?php esc_html_e( 'Earnings, approval status, and policy alerts set up automatically', '1platform-content-ai' ); ?></p>
+							</div>
 						</div>
 					</div>
-					<button type="button" id="contai-adsense-connect-btn" class="button button-primary">
+
+					<button type="button" id="contai-adsense-connect-btn" class="contai-btn-oauth">
 						<span class="dashicons dashicons-admin-links"></span>
 						<?php esc_html_e( 'Connect AdSense', '1platform-content-ai' ); ?>
 					</button>
 				</div>
 				<?php else : ?>
-				<div class="contai-adsense-status-section">
-					<div id="contai-adsense-status-loading">
-						<span class="spinner is-active" style="float:none;margin:0 8px 0 0;"></span>
+				<div class="contai-adsense-connected">
+					<div class="contai-adsense-header">
+						<div class="contai-adsense-header__left">
+							<span class="contai-adsense-badge">
+								<span class="dashicons dashicons-yes-alt"></span>
+								<?php esc_html_e( 'Connected', '1platform-content-ai' ); ?>
+							</span>
+							<span class="contai-adsense-mid" id="contai-adsense-publisher-id">&mdash;</span>
+						</div>
+					</div>
+					<div id="contai-adsense-status-loading" class="contai-adsense-loading">
+						<span class="spinner is-active"></span>
 						<?php esc_html_e( 'Loading AdSense data...', '1platform-content-ai' ); ?>
 					</div>
 					<div id="contai-adsense-status-data" style="display:none;">
-						<div class="contai-adsense-info-grid">
-							<div class="contai-adsense-info-item">
-								<span class="contai-adsense-label"><?php esc_html_e( 'Account', '1platform-content-ai' ); ?></span>
-								<span class="contai-adsense-value" id="contai-adsense-account-name">&mdash;</span>
+						<div class="contai-adsense-features">
+							<div class="contai-adsense-feature">
+								<div class="contai-adsense-feature__icon contai-adsense-feature__icon--blue"><span class="dashicons dashicons-businessperson"></span></div>
+								<div>
+									<h4><?php esc_html_e( 'Account', '1platform-content-ai' ); ?></h4>
+									<p id="contai-adsense-account-name">&mdash;</p>
+								</div>
 							</div>
-							<div class="contai-adsense-info-item">
-								<span class="contai-adsense-label"><?php esc_html_e( 'Publisher ID', '1platform-content-ai' ); ?></span>
-								<span class="contai-adsense-value" id="contai-adsense-publisher-id">&mdash;</span>
+							<div class="contai-adsense-feature">
+								<div class="contai-adsense-feature__icon contai-adsense-feature__icon--green"><span class="dashicons dashicons-admin-site-alt3"></span></div>
+								<div>
+									<h4><?php esc_html_e( 'Site State', '1platform-content-ai' ); ?></h4>
+									<p id="contai-adsense-site-state">&mdash;</p>
+								</div>
 							</div>
-							<div class="contai-adsense-info-item">
-								<span class="contai-adsense-label"><?php esc_html_e( 'Site State', '1platform-content-ai' ); ?></span>
-								<span class="contai-adsense-value" id="contai-adsense-site-state">&mdash;</span>
-							</div>
-							<div class="contai-adsense-info-item">
-								<span class="contai-adsense-label"><?php esc_html_e( 'Status', '1platform-content-ai' ); ?></span>
-								<span class="contai-adsense-value" id="contai-adsense-connection-status">&mdash;</span>
+							<div class="contai-adsense-feature">
+								<div class="contai-adsense-feature__icon contai-adsense-feature__icon--amber"><span class="dashicons dashicons-flag"></span></div>
+								<div>
+									<h4><?php esc_html_e( 'Status', '1platform-content-ai' ); ?></h4>
+									<p id="contai-adsense-connection-status">&mdash;</p>
+								</div>
 							</div>
 						</div>
 						<div class="contai-adsense-earnings-summary" id="contai-adsense-earnings" style="display:none;">
 							<h4><?php esc_html_e( 'Earnings (Last 7 Days)', '1platform-content-ai' ); ?></h4>
-							<div class="contai-adsense-info-grid">
-								<div class="contai-adsense-info-item">
-									<span class="contai-adsense-label"><?php esc_html_e( 'Earnings', '1platform-content-ai' ); ?></span>
-									<span class="contai-adsense-value contai-adsense-earnings-val" id="contai-adsense-est-earnings">$0.00</span>
+							<div class="contai-adsense-features">
+								<div class="contai-adsense-feature">
+									<div class="contai-adsense-feature__icon contai-adsense-feature__icon--green"><span class="dashicons dashicons-money-alt"></span></div>
+									<div>
+										<h4><?php esc_html_e( 'Earnings', '1platform-content-ai' ); ?></h4>
+										<p class="contai-adsense-earnings-val" id="contai-adsense-est-earnings">$0.00</p>
+									</div>
 								</div>
-								<div class="contai-adsense-info-item">
-									<span class="contai-adsense-label"><?php esc_html_e( 'Clicks', '1platform-content-ai' ); ?></span>
-									<span class="contai-adsense-value" id="contai-adsense-clicks">0</span>
+								<div class="contai-adsense-feature">
+									<div class="contai-adsense-feature__icon contai-adsense-feature__icon--blue"><span class="dashicons dashicons-pressthis"></span></div>
+									<div>
+										<h4><?php esc_html_e( 'Clicks', '1platform-content-ai' ); ?></h4>
+										<p id="contai-adsense-clicks">0</p>
+									</div>
 								</div>
-								<div class="contai-adsense-info-item">
-									<span class="contai-adsense-label"><?php esc_html_e( 'Impressions', '1platform-content-ai' ); ?></span>
-									<span class="contai-adsense-value" id="contai-adsense-impressions">0</span>
+								<div class="contai-adsense-feature">
+									<div class="contai-adsense-feature__icon contai-adsense-feature__icon--purple"><span class="dashicons dashicons-visibility"></span></div>
+									<div>
+										<h4><?php esc_html_e( 'Impressions', '1platform-content-ai' ); ?></h4>
+										<p id="contai-adsense-impressions">0</p>
+									</div>
 								</div>
-								<div class="contai-adsense-info-item">
-									<span class="contai-adsense-label"><?php esc_html_e( 'RPM', '1platform-content-ai' ); ?></span>
-									<span class="contai-adsense-value" id="contai-adsense-rpm">$0.00</span>
+								<div class="contai-adsense-feature">
+									<div class="contai-adsense-feature__icon contai-adsense-feature__icon--amber"><span class="dashicons dashicons-chart-line"></span></div>
+									<div>
+										<h4><?php esc_html_e( 'RPM', '1platform-content-ai' ); ?></h4>
+										<p id="contai-adsense-rpm">$0.00</p>
+									</div>
 								</div>
 							</div>
 						</div>
 					</div>
-					<div class="contai-adsense-actions" style="margin-top:16px;">
+					<div class="contai-adsense-disconnect">
 						<button type="button" id="contai-adsense-refresh-btn" class="button">
 							<span class="dashicons dashicons-update"></span>
 							<?php esc_html_e( 'Refresh', '1platform-content-ai' ); ?>
 						</button>
-						<button type="button" id="contai-adsense-disconnect-btn" class="button">
-							<span class="dashicons dashicons-dismiss"></span>
-							<?php esc_html_e( 'Disconnect', '1platform-content-ai' ); ?>
+						<button type="button" id="contai-adsense-disconnect-btn" class="contai-btn-disconnect">
+							<?php esc_html_e( 'Disconnect AdSense', '1platform-content-ai' ); ?>
 						</button>
 					</div>
 				</div>

--- a/includes/admin/apps/panels/AdsManagerPanel.php
+++ b/includes/admin/apps/panels/AdsManagerPanel.php
@@ -165,11 +165,16 @@ class ContaiAdsManagerPanel {
 					<span class="dashicons dashicons-admin-generic"></span>
 					<span class="contai-ads-tab-label"><?php esc_html_e( 'Advanced', '1platform-content-ai' ); ?></span>
 				</button>
+				<button type="button" class="contai-ads-tab" data-tab="adsense-account" role="tab" aria-selected="false">
+					<span class="dashicons dashicons-chart-area"></span>
+					<span class="contai-ads-tab-label"><?php esc_html_e( 'AdSense Account', '1platform-content-ai' ); ?></span>
+				</button>
 			</nav>
 
 			<?php $this->renderPublishersTab(); ?>
 			<?php $this->renderCustomHeaderTab(); ?>
 			<?php $this->renderAdvancedTab(); ?>
+			<?php $this->renderAdSenseAccountTab(); ?>
 		</div>
 		<?php
 	}
@@ -345,13 +350,96 @@ class ContaiAdsManagerPanel {
 							<?php wp_nonce_field( 'contai_adsense_delete_ads_txt', 'contai_ads_txt_nonce' ); ?>
 							<button type="submit" name="delete_ads_txt_and_reset_publishers"
 									class="button button-danger"
-									data-confirm="<?php esc_attr_e( 'Are you sure? This will permanently delete ads.txt and reset all publisher IDs.', '1platform-content-ai' ); ?>">
+									onclick="return confirm('<?php echo esc_js( __( 'Are you sure? This will permanently delete ads.txt and reset all publisher IDs.', '1platform-content-ai' ) ); ?>')">
 								<span class="dashicons dashicons-trash"></span>
 								<?php esc_html_e( 'Delete & Reset', '1platform-content-ai' ); ?>
 							</button>
 						</form>
 					</div>
 				</div>
+			</div>
+		</div>
+		<?php
+	}
+
+	private function renderAdSenseAccountTab(): void {
+		$is_connected = get_option( 'contai_adsense_connected', false );
+		?>
+		<div class="contai-ads-tab-content" id="tab-adsense-account" role="tabpanel">
+			<div id="contai-adsense-account-root">
+				<?php if ( ! $is_connected ) : ?>
+				<div class="contai-adsense-connect-section">
+					<div class="contai-ads-callout contai-ads-callout-info">
+						<span class="dashicons dashicons-chart-area"></span>
+						<div>
+							<strong><?php esc_html_e( 'Connect Your AdSense Account', '1platform-content-ai' ); ?></strong>
+							<p><?php esc_html_e( 'Connect via OAuth to see earnings, site approval status, and policy alerts directly in your dashboard.', '1platform-content-ai' ); ?></p>
+						</div>
+					</div>
+					<button type="button" id="contai-adsense-connect-btn" class="button button-primary">
+						<span class="dashicons dashicons-admin-links"></span>
+						<?php esc_html_e( 'Connect AdSense', '1platform-content-ai' ); ?>
+					</button>
+				</div>
+				<?php else : ?>
+				<div class="contai-adsense-status-section">
+					<div id="contai-adsense-status-loading">
+						<span class="spinner is-active" style="float:none;margin:0 8px 0 0;"></span>
+						<?php esc_html_e( 'Loading AdSense data...', '1platform-content-ai' ); ?>
+					</div>
+					<div id="contai-adsense-status-data" style="display:none;">
+						<div class="contai-adsense-info-grid">
+							<div class="contai-adsense-info-item">
+								<span class="contai-adsense-label"><?php esc_html_e( 'Account', '1platform-content-ai' ); ?></span>
+								<span class="contai-adsense-value" id="contai-adsense-account-name">&mdash;</span>
+							</div>
+							<div class="contai-adsense-info-item">
+								<span class="contai-adsense-label"><?php esc_html_e( 'Publisher ID', '1platform-content-ai' ); ?></span>
+								<span class="contai-adsense-value" id="contai-adsense-publisher-id">&mdash;</span>
+							</div>
+							<div class="contai-adsense-info-item">
+								<span class="contai-adsense-label"><?php esc_html_e( 'Site State', '1platform-content-ai' ); ?></span>
+								<span class="contai-adsense-value" id="contai-adsense-site-state">&mdash;</span>
+							</div>
+							<div class="contai-adsense-info-item">
+								<span class="contai-adsense-label"><?php esc_html_e( 'Status', '1platform-content-ai' ); ?></span>
+								<span class="contai-adsense-value" id="contai-adsense-connection-status">&mdash;</span>
+							</div>
+						</div>
+						<div class="contai-adsense-earnings-summary" id="contai-adsense-earnings" style="display:none;">
+							<h4><?php esc_html_e( 'Earnings (Last 7 Days)', '1platform-content-ai' ); ?></h4>
+							<div class="contai-adsense-info-grid">
+								<div class="contai-adsense-info-item">
+									<span class="contai-adsense-label"><?php esc_html_e( 'Earnings', '1platform-content-ai' ); ?></span>
+									<span class="contai-adsense-value contai-adsense-earnings-val" id="contai-adsense-est-earnings">$0.00</span>
+								</div>
+								<div class="contai-adsense-info-item">
+									<span class="contai-adsense-label"><?php esc_html_e( 'Clicks', '1platform-content-ai' ); ?></span>
+									<span class="contai-adsense-value" id="contai-adsense-clicks">0</span>
+								</div>
+								<div class="contai-adsense-info-item">
+									<span class="contai-adsense-label"><?php esc_html_e( 'Impressions', '1platform-content-ai' ); ?></span>
+									<span class="contai-adsense-value" id="contai-adsense-impressions">0</span>
+								</div>
+								<div class="contai-adsense-info-item">
+									<span class="contai-adsense-label"><?php esc_html_e( 'RPM', '1platform-content-ai' ); ?></span>
+									<span class="contai-adsense-value" id="contai-adsense-rpm">$0.00</span>
+								</div>
+							</div>
+						</div>
+					</div>
+					<div class="contai-adsense-actions" style="margin-top:16px;">
+						<button type="button" id="contai-adsense-refresh-btn" class="button">
+							<span class="dashicons dashicons-update"></span>
+							<?php esc_html_e( 'Refresh', '1platform-content-ai' ); ?>
+						</button>
+						<button type="button" id="contai-adsense-disconnect-btn" class="button">
+							<span class="dashicons dashicons-dismiss"></span>
+							<?php esc_html_e( 'Disconnect', '1platform-content-ai' ); ?>
+						</button>
+					</div>
+				</div>
+				<?php endif; ?>
 			</div>
 		</div>
 		<?php

--- a/includes/services/adsense/ContaiAdSenseRestController.php
+++ b/includes/services/adsense/ContaiAdSenseRestController.php
@@ -113,11 +113,7 @@ class ContaiAdSenseRestController {
 		$api    = ContaiOnePlatformClient::create();
 		$result = $api->get( '/adsense/oauth/authorize', array( 'website_id' => $website_id ) );
 
-		if ( is_wp_error( $result ) ) {
-			return new \WP_REST_Response( array( 'success' => false, 'message' => $result->get_error_message() ), 502 );
-		}
-
-		return new \WP_REST_Response( array( 'success' => true, 'data' => $result ), 200 );
+		return $this->apiResponse( $result );
 	}
 
 	public function connect( \WP_REST_Request $request ): \WP_REST_Response {
@@ -129,11 +125,11 @@ class ContaiAdSenseRestController {
 		$api    = ContaiOnePlatformClient::create();
 		$result = $api->post( '/adsense/connect', array(), array( 'website_id' => $website_id ) );
 
-		if ( is_wp_error( $result ) ) {
-			return new \WP_REST_Response( array( 'success' => false, 'message' => $result->get_error_message() ), 502 );
+		if ( ! $result->isSuccess() ) {
+			return $this->apiResponse( $result );
 		}
 
-		$data = is_object( $result ) && method_exists( $result, 'getData' ) ? $result->getData() : $result;
+		$data = $result->getData();
 
 		if ( is_array( $data ) && ! empty( $data['publisher_id'] ) ) {
 			$this->sync_publisher_id( $data['publisher_id'] );
@@ -153,13 +149,11 @@ class ContaiAdSenseRestController {
 		$api    = ContaiOnePlatformClient::create();
 		$result = $api->delete( '/adsense/disconnect', array( 'website_id' => $website_id ) );
 
-		if ( is_wp_error( $result ) ) {
-			return new \WP_REST_Response( array( 'success' => false, 'message' => $result->get_error_message() ), 502 );
+		if ( $result->isSuccess() ) {
+			update_option( 'contai_adsense_connected', false, false );
 		}
 
-		update_option( 'contai_adsense_connected', false, false );
-
-		return new \WP_REST_Response( array( 'success' => true, 'data' => $result ), 200 );
+		return $this->apiResponse( $result );
 	}
 
 	public function revoke( \WP_REST_Request $request ): \WP_REST_Response {
@@ -171,13 +165,11 @@ class ContaiAdSenseRestController {
 		$api    = ContaiOnePlatformClient::create();
 		$result = $api->post( '/adsense/oauth/revoke', array(), array( 'website_id' => $website_id ) );
 
-		if ( is_wp_error( $result ) ) {
-			return new \WP_REST_Response( array( 'success' => false, 'message' => $result->get_error_message() ), 502 );
+		if ( $result->isSuccess() ) {
+			update_option( 'contai_adsense_connected', false, false );
 		}
 
-		update_option( 'contai_adsense_connected', false, false );
-
-		return new \WP_REST_Response( array( 'success' => true, 'data' => $result ), 200 );
+		return $this->apiResponse( $result );
 	}
 
 	public function status( \WP_REST_Request $request ): \WP_REST_Response {
@@ -189,11 +181,7 @@ class ContaiAdSenseRestController {
 		$api    = ContaiOnePlatformClient::create();
 		$result = $api->get( '/adsense/status', array( 'website_id' => $website_id ) );
 
-		if ( is_wp_error( $result ) ) {
-			return new \WP_REST_Response( array( 'success' => false, 'message' => $result->get_error_message() ), 502 );
-		}
-
-		return new \WP_REST_Response( array( 'success' => true, 'data' => $result ), 200 );
+		return $this->apiResponse( $result );
 	}
 
 	public function earnings( \WP_REST_Request $request ): \WP_REST_Response {
@@ -211,11 +199,7 @@ class ContaiAdSenseRestController {
 			'compare'    => 'true',
 		) );
 
-		if ( is_wp_error( $result ) ) {
-			return new \WP_REST_Response( array( 'success' => false, 'message' => $result->get_error_message() ), 502 );
-		}
-
-		return new \WP_REST_Response( array( 'success' => true, 'data' => $result ), 200 );
+		return $this->apiResponse( $result );
 	}
 
 	public function sites( \WP_REST_Request $request ): \WP_REST_Response {
@@ -227,11 +211,7 @@ class ContaiAdSenseRestController {
 		$api    = ContaiOnePlatformClient::create();
 		$result = $api->get( '/adsense/sites', array( 'website_id' => $website_id ) );
 
-		if ( is_wp_error( $result ) ) {
-			return new \WP_REST_Response( array( 'success' => false, 'message' => $result->get_error_message() ), 502 );
-		}
-
-		return new \WP_REST_Response( array( 'success' => true, 'data' => $result ), 200 );
+		return $this->apiResponse( $result );
 	}
 
 	public function sync_sites( \WP_REST_Request $request ): \WP_REST_Response {
@@ -243,11 +223,7 @@ class ContaiAdSenseRestController {
 		$api    = ContaiOnePlatformClient::create();
 		$result = $api->post( '/adsense/sites/sync', array(), array( 'website_id' => $website_id ) );
 
-		if ( is_wp_error( $result ) ) {
-			return new \WP_REST_Response( array( 'success' => false, 'message' => $result->get_error_message() ), 502 );
-		}
-
-		return new \WP_REST_Response( array( 'success' => true, 'data' => $result ), 200 );
+		return $this->apiResponse( $result );
 	}
 
 	public function alerts( \WP_REST_Request $request ): \WP_REST_Response {
@@ -259,11 +235,7 @@ class ContaiAdSenseRestController {
 		$api    = ContaiOnePlatformClient::create();
 		$result = $api->get( '/adsense/alerts', array( 'website_id' => $website_id ) );
 
-		if ( is_wp_error( $result ) ) {
-			return new \WP_REST_Response( array( 'success' => false, 'message' => $result->get_error_message() ), 502 );
-		}
-
-		return new \WP_REST_Response( array( 'success' => true, 'data' => $result ), 200 );
+		return $this->apiResponse( $result );
 	}
 
 	public function policy_issues( \WP_REST_Request $request ): \WP_REST_Response {
@@ -275,11 +247,7 @@ class ContaiAdSenseRestController {
 		$api    = ContaiOnePlatformClient::create();
 		$result = $api->get( '/adsense/policy-issues', array( 'website_id' => $website_id ) );
 
-		if ( is_wp_error( $result ) ) {
-			return new \WP_REST_Response( array( 'success' => false, 'message' => $result->get_error_message() ), 502 );
-		}
-
-		return new \WP_REST_Response( array( 'success' => true, 'data' => $result ), 200 );
+		return $this->apiResponse( $result );
 	}
 
 	public function oauth_status( \WP_REST_Request $request ): \WP_REST_Response {
@@ -291,20 +259,21 @@ class ContaiAdSenseRestController {
 		$api    = ContaiOnePlatformClient::create();
 		$result = $api->get( '/adsense/oauth/status', array( 'website_id' => $website_id ) );
 
-		if ( is_wp_error( $result ) ) {
-			return new \WP_REST_Response( array( 'success' => false, 'message' => $result->get_error_message() ), 502 );
-		}
-
-		return new \WP_REST_Response( array( 'success' => true, 'data' => $result ), 200 );
+		return $this->apiResponse( $result );
 	}
 
 	// ── Private Helpers ──
 
-	private function get_website_id() {
-		$website_id = sanitize_text_field( get_option( '1platform_website_id', '' ) );
-		if ( empty( $website_id ) ) {
-			$website_id = sanitize_text_field( get_option( 'contai_user_website', '' ) );
+	private function apiResponse( ContaiOnePlatformResponse $result ): \WP_REST_Response {
+		if ( ! $result->isSuccess() ) {
+			return new \WP_REST_Response( array( 'success' => false, 'message' => $result->getMessage() ), 502 );
 		}
+		return new \WP_REST_Response( array( 'success' => true, 'data' => $result->getData() ), 200 );
+	}
+
+	private function get_website_id() {
+		$provider   = new ContaiWebsiteProvider();
+		$website_id = $provider->getWebsiteId();
 		if ( empty( $website_id ) ) {
 			return new \WP_Error( 'no_website', 'No website configured. Complete the initial setup first.' );
 		}

--- a/includes/services/adsense/ContaiAdSenseRestController.php
+++ b/includes/services/adsense/ContaiAdSenseRestController.php
@@ -1,0 +1,331 @@
+<?php
+/**
+ * REST API controller for AdSense integration.
+ *
+ * Proxies requests from the WP admin UI to the 1Platform API via
+ * ContaiOnePlatformClient. All routes are registered under the 'contai/v1'
+ * namespace and are restricted to users with 'manage_options' capability.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class ContaiAdSenseRestController {
+
+	private $namespace = 'contai/v1';
+
+	public function register_routes(): void {
+
+		register_rest_route( $this->namespace, '/adsense/authorize', array(
+			'methods'             => 'GET',
+			'callback'            => array( $this, 'authorize' ),
+			'permission_callback' => array( $this, 'check_admin_permission' ),
+			'show_in_index'       => false,
+		) );
+
+		register_rest_route( $this->namespace, '/adsense/connect', array(
+			'methods'             => 'POST',
+			'callback'            => array( $this, 'connect' ),
+			'permission_callback' => array( $this, 'check_admin_permission' ),
+			'show_in_index'       => false,
+		) );
+
+		register_rest_route( $this->namespace, '/adsense/disconnect', array(
+			'methods'             => 'DELETE',
+			'callback'            => array( $this, 'disconnect' ),
+			'permission_callback' => array( $this, 'check_admin_permission' ),
+			'show_in_index'       => false,
+		) );
+
+		register_rest_route( $this->namespace, '/adsense/revoke', array(
+			'methods'             => 'POST',
+			'callback'            => array( $this, 'revoke' ),
+			'permission_callback' => array( $this, 'check_admin_permission' ),
+			'show_in_index'       => false,
+		) );
+
+		register_rest_route( $this->namespace, '/adsense/status', array(
+			'methods'             => 'GET',
+			'callback'            => array( $this, 'status' ),
+			'permission_callback' => array( $this, 'check_admin_permission' ),
+		) );
+
+		register_rest_route( $this->namespace, '/adsense/earnings', array(
+			'methods'             => 'GET',
+			'callback'            => array( $this, 'earnings' ),
+			'permission_callback' => array( $this, 'check_admin_permission' ),
+			'args'                => array(
+				'period' => array(
+					'default'           => '7d',
+					'sanitize_callback' => 'sanitize_text_field',
+					'validate_callback' => function ( $value ) {
+						$allowed = array( '7d', '28d', '30d', '90d', 'lifetime', 'LAST_7_DAYS', 'LAST_28_DAYS', 'LAST_30_DAYS', 'LAST_90_DAYS' );
+						return in_array( $value, $allowed, true );
+					},
+				),
+			),
+		) );
+
+		register_rest_route( $this->namespace, '/adsense/sites', array(
+			'methods'             => 'GET',
+			'callback'            => array( $this, 'sites' ),
+			'permission_callback' => array( $this, 'check_admin_permission' ),
+		) );
+
+		register_rest_route( $this->namespace, '/adsense/sites/sync', array(
+			'methods'             => 'POST',
+			'callback'            => array( $this, 'sync_sites' ),
+			'permission_callback' => array( $this, 'check_admin_permission' ),
+		) );
+
+		register_rest_route( $this->namespace, '/adsense/alerts', array(
+			'methods'             => 'GET',
+			'callback'            => array( $this, 'alerts' ),
+			'permission_callback' => array( $this, 'check_admin_permission' ),
+		) );
+
+		register_rest_route( $this->namespace, '/adsense/policy-issues', array(
+			'methods'             => 'GET',
+			'callback'            => array( $this, 'policy_issues' ),
+			'permission_callback' => array( $this, 'check_admin_permission' ),
+		) );
+
+		register_rest_route( $this->namespace, '/adsense/oauth-status', array(
+			'methods'             => 'GET',
+			'callback'            => array( $this, 'oauth_status' ),
+			'permission_callback' => array( $this, 'check_admin_permission' ),
+		) );
+	}
+
+	public function check_admin_permission(): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	// ── Handlers ──
+
+	public function authorize( \WP_REST_Request $request ): \WP_REST_Response {
+		$website_id = $this->get_website_id();
+		if ( is_wp_error( $website_id ) ) {
+			return new \WP_REST_Response( array( 'success' => false, 'message' => $website_id->get_error_message() ), 400 );
+		}
+
+		$api    = ContaiOnePlatformClient::create();
+		$result = $api->get( '/adsense/oauth/authorize', array( 'website_id' => $website_id ) );
+
+		if ( is_wp_error( $result ) ) {
+			return new \WP_REST_Response( array( 'success' => false, 'message' => $result->get_error_message() ), 502 );
+		}
+
+		return new \WP_REST_Response( array( 'success' => true, 'data' => $result ), 200 );
+	}
+
+	public function connect( \WP_REST_Request $request ): \WP_REST_Response {
+		$website_id = $this->get_website_id();
+		if ( is_wp_error( $website_id ) ) {
+			return new \WP_REST_Response( array( 'success' => false, 'message' => $website_id->get_error_message() ), 400 );
+		}
+
+		$api    = ContaiOnePlatformClient::create();
+		$result = $api->post( '/adsense/connect', array(), array( 'website_id' => $website_id ) );
+
+		if ( is_wp_error( $result ) ) {
+			return new \WP_REST_Response( array( 'success' => false, 'message' => $result->get_error_message() ), 502 );
+		}
+
+		$data = is_object( $result ) && method_exists( $result, 'getData' ) ? $result->getData() : $result;
+
+		if ( is_array( $data ) && ! empty( $data['publisher_id'] ) ) {
+			$this->sync_publisher_id( $data['publisher_id'] );
+		}
+
+		update_option( 'contai_adsense_connected', true, false );
+
+		return new \WP_REST_Response( array( 'success' => true, 'data' => $data ), 200 );
+	}
+
+	public function disconnect( \WP_REST_Request $request ): \WP_REST_Response {
+		$website_id = $this->get_website_id();
+		if ( is_wp_error( $website_id ) ) {
+			return new \WP_REST_Response( array( 'success' => false, 'message' => $website_id->get_error_message() ), 400 );
+		}
+
+		$api    = ContaiOnePlatformClient::create();
+		$result = $api->delete( '/adsense/disconnect', array( 'website_id' => $website_id ) );
+
+		if ( is_wp_error( $result ) ) {
+			return new \WP_REST_Response( array( 'success' => false, 'message' => $result->get_error_message() ), 502 );
+		}
+
+		update_option( 'contai_adsense_connected', false, false );
+
+		return new \WP_REST_Response( array( 'success' => true, 'data' => $result ), 200 );
+	}
+
+	public function revoke( \WP_REST_Request $request ): \WP_REST_Response {
+		$website_id = $this->get_website_id();
+		if ( is_wp_error( $website_id ) ) {
+			return new \WP_REST_Response( array( 'success' => false, 'message' => $website_id->get_error_message() ), 400 );
+		}
+
+		$api    = ContaiOnePlatformClient::create();
+		$result = $api->post( '/adsense/oauth/revoke', array(), array( 'website_id' => $website_id ) );
+
+		if ( is_wp_error( $result ) ) {
+			return new \WP_REST_Response( array( 'success' => false, 'message' => $result->get_error_message() ), 502 );
+		}
+
+		update_option( 'contai_adsense_connected', false, false );
+
+		return new \WP_REST_Response( array( 'success' => true, 'data' => $result ), 200 );
+	}
+
+	public function status( \WP_REST_Request $request ): \WP_REST_Response {
+		$website_id = $this->get_website_id();
+		if ( is_wp_error( $website_id ) ) {
+			return new \WP_REST_Response( array( 'success' => false, 'message' => $website_id->get_error_message() ), 400 );
+		}
+
+		$api    = ContaiOnePlatformClient::create();
+		$result = $api->get( '/adsense/status', array( 'website_id' => $website_id ) );
+
+		if ( is_wp_error( $result ) ) {
+			return new \WP_REST_Response( array( 'success' => false, 'message' => $result->get_error_message() ), 502 );
+		}
+
+		return new \WP_REST_Response( array( 'success' => true, 'data' => $result ), 200 );
+	}
+
+	public function earnings( \WP_REST_Request $request ): \WP_REST_Response {
+		$website_id = $this->get_website_id();
+		if ( is_wp_error( $website_id ) ) {
+			return new \WP_REST_Response( array( 'success' => false, 'message' => $website_id->get_error_message() ), 400 );
+		}
+
+		$period = sanitize_text_field( $request->get_param( 'period' ) ?: '7d' );
+
+		$api    = ContaiOnePlatformClient::create();
+		$result = $api->get( '/adsense/earnings/overview', array(
+			'website_id' => $website_id,
+			'period'     => $period,
+			'compare'    => 'true',
+		) );
+
+		if ( is_wp_error( $result ) ) {
+			return new \WP_REST_Response( array( 'success' => false, 'message' => $result->get_error_message() ), 502 );
+		}
+
+		return new \WP_REST_Response( array( 'success' => true, 'data' => $result ), 200 );
+	}
+
+	public function sites( \WP_REST_Request $request ): \WP_REST_Response {
+		$website_id = $this->get_website_id();
+		if ( is_wp_error( $website_id ) ) {
+			return new \WP_REST_Response( array( 'success' => false, 'message' => $website_id->get_error_message() ), 400 );
+		}
+
+		$api    = ContaiOnePlatformClient::create();
+		$result = $api->get( '/adsense/sites', array( 'website_id' => $website_id ) );
+
+		if ( is_wp_error( $result ) ) {
+			return new \WP_REST_Response( array( 'success' => false, 'message' => $result->get_error_message() ), 502 );
+		}
+
+		return new \WP_REST_Response( array( 'success' => true, 'data' => $result ), 200 );
+	}
+
+	public function sync_sites( \WP_REST_Request $request ): \WP_REST_Response {
+		$website_id = $this->get_website_id();
+		if ( is_wp_error( $website_id ) ) {
+			return new \WP_REST_Response( array( 'success' => false, 'message' => $website_id->get_error_message() ), 400 );
+		}
+
+		$api    = ContaiOnePlatformClient::create();
+		$result = $api->post( '/adsense/sites/sync', array(), array( 'website_id' => $website_id ) );
+
+		if ( is_wp_error( $result ) ) {
+			return new \WP_REST_Response( array( 'success' => false, 'message' => $result->get_error_message() ), 502 );
+		}
+
+		return new \WP_REST_Response( array( 'success' => true, 'data' => $result ), 200 );
+	}
+
+	public function alerts( \WP_REST_Request $request ): \WP_REST_Response {
+		$website_id = $this->get_website_id();
+		if ( is_wp_error( $website_id ) ) {
+			return new \WP_REST_Response( array( 'success' => false, 'message' => $website_id->get_error_message() ), 400 );
+		}
+
+		$api    = ContaiOnePlatformClient::create();
+		$result = $api->get( '/adsense/alerts', array( 'website_id' => $website_id ) );
+
+		if ( is_wp_error( $result ) ) {
+			return new \WP_REST_Response( array( 'success' => false, 'message' => $result->get_error_message() ), 502 );
+		}
+
+		return new \WP_REST_Response( array( 'success' => true, 'data' => $result ), 200 );
+	}
+
+	public function policy_issues( \WP_REST_Request $request ): \WP_REST_Response {
+		$website_id = $this->get_website_id();
+		if ( is_wp_error( $website_id ) ) {
+			return new \WP_REST_Response( array( 'success' => false, 'message' => $website_id->get_error_message() ), 400 );
+		}
+
+		$api    = ContaiOnePlatformClient::create();
+		$result = $api->get( '/adsense/policy-issues', array( 'website_id' => $website_id ) );
+
+		if ( is_wp_error( $result ) ) {
+			return new \WP_REST_Response( array( 'success' => false, 'message' => $result->get_error_message() ), 502 );
+		}
+
+		return new \WP_REST_Response( array( 'success' => true, 'data' => $result ), 200 );
+	}
+
+	public function oauth_status( \WP_REST_Request $request ): \WP_REST_Response {
+		$website_id = $this->get_website_id();
+		if ( is_wp_error( $website_id ) ) {
+			return new \WP_REST_Response( array( 'success' => false, 'message' => $website_id->get_error_message() ), 400 );
+		}
+
+		$api    = ContaiOnePlatformClient::create();
+		$result = $api->get( '/adsense/oauth/status', array( 'website_id' => $website_id ) );
+
+		if ( is_wp_error( $result ) ) {
+			return new \WP_REST_Response( array( 'success' => false, 'message' => $result->get_error_message() ), 502 );
+		}
+
+		return new \WP_REST_Response( array( 'success' => true, 'data' => $result ), 200 );
+	}
+
+	// ── Private Helpers ──
+
+	private function get_website_id() {
+		$website_id = sanitize_text_field( get_option( '1platform_website_id', '' ) );
+		if ( empty( $website_id ) ) {
+			$website_id = sanitize_text_field( get_option( 'contai_user_website', '' ) );
+		}
+		if ( empty( $website_id ) ) {
+			return new \WP_Error( 'no_website', 'No website configured. Complete the initial setup first.' );
+		}
+		return $website_id;
+	}
+
+	private function sync_publisher_id( string $publisher_id ): void {
+		if ( ! preg_match( '/^pub-\d{10,20}$/', $publisher_id ) ) {
+			return;
+		}
+
+		$current = get_option( 'contai_adsense_publisher_id', '' );
+		if ( $current !== $publisher_id ) {
+			update_option( 'contai_adsense_publisher_id', $publisher_id, false );
+		}
+
+		$publishers = get_option( 'contai_adsense_publishers', '' );
+		if ( strpos( $publishers, $publisher_id ) === false ) {
+			$publishers = trim( $publishers . "\n" . $publisher_id );
+			update_option( 'contai_adsense_publishers', $publishers );
+			contai_generate_adsense_ads();
+		}
+	}
+}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai content, seo, content generation, internal links, table of contents
 Requires at least: 5.9
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.12.5
+Stable tag: 2.13.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -159,6 +159,14 @@ The plugin sends your site URL, API key, and content generation parameters (keyw
 7. Tools — Google Analytics, Google Search Console, Publisuites, and Ads Manager integrations.
 
 == Changelog ==
+
+= 2.13.0 =
+* Added AdSense Account management tab in Ads Manager with OAuth connect/disconnect flow
+* Added 11 REST endpoints for AdSense integration (earnings, sites, alerts, policy issues)
+* Added earnings overview display and publisher ID auto-sync
+* Fix: Delete confirmation dialog now works (was dead data-confirm attribute)
+* Fix: Period parameter validation on earnings endpoint
+* Fix: Graceful handling of non-JSON server error responses in JS
 
 = 2.12.2 =
 * Changed: Renamed "Link Building" to "Publisuites" in Tools sidebar menu, page title, apps panel, and logs adapter

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai content, seo, content generation, internal links, table of contents
 Requires at least: 5.9
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.13.0
+Stable tag: 2.13.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -62,6 +62,8 @@ $content_ai_options = array(
 	'contai_user_token_error',
 	// Site hardening.
 	'contai_adsense_approved',
+	'contai_adsense_connected',
+	'contai_adsense_publisher_id',
 	'contai_disable_feeds',
 	'contai_disable_author_pages',
 	'contai_redirect_404',


### PR DESCRIPTION
## Summary
- Add AdSense account management with OAuth flow, status display, and earnings overview
- Fix critical bugs in AdSense REST controller (website ID resolution, API response serialization)
- Complete AdSense Account tab UI with proper CSS styling

## Changes

### New Features (v2.13.0)
- **AdSense Account tab**: OAuth popup flow for connecting/disconnecting Google AdSense
- **11 REST endpoints**: `authorize`, `connect`, `disconnect`, `revoke`, `status`, `earnings`, `sites`, `sync_sites`, `alerts`, `policy_issues`, `oauth_status`
- **Status & earnings display**: Account info, site state, earnings overview with 7-day metrics
- **Policy notice**: Admin notice when AdSense policy issues are detected

### Bug Fixes (v2.13.1)
- **`get_website_id()` resolution**: Replaced raw `get_option('contai_user_website')` with `ContaiWebsiteProvider::getWebsiteId()` — the option stores an array, not a string
- **API response serialization**: All REST handlers were passing raw `ContaiOnePlatformResponse` object instead of `getData()`, causing empty `{"data":{}}` responses
- **Disconnect/revoke state sync**: Guarded `update_option` behind `isSuccess()` to prevent local state desync on API failure
- **Complete CSS**: Empty state, OAuth stepper, connect button, connected state, features grid, earnings, disconnect area

## Audit Results
- Code review: 1 confirmed bug found (state desync) and fixed
- Provider name scan: PASS
- Security: PASS — all routes use capability checks
- Tests: 477 passed, 751 assertions

## Test Plan
- [x] All 477 unit tests pass (751 assertions)
- [x] Version sync validated (plugin 2.13.1 = readme 2.13.1)
- [x] No provider name exposure
- [ ] Manual: AdSense Account tab renders correctly
- [ ] Manual: Connect button triggers OAuth popup with authorization URL
- [ ] Manual: Disconnect properly syncs state only on success

🤖 Generated with [Claude Code](https://claude.com/claude-code)