### PR TITLE
fix(wizard): add complete navigation setup to Site Wizard (#48)

### DIFF
--- a/1platform-content-ai.php
+++ b/1platform-content-ai.php
@@ -4,7 +4,7 @@
  * Plugin Name: 1Platform Content AI
  * Plugin URI: https://1platform.pro/
  * Description: SaaS client for AI-powered content generation, SEO optimization, and site management. All AI processing happens on 1Platform external servers. Includes free local tools: Table of Contents and Internal Links.
- * Version: 2.15.0
+ * Version: 2.15.1
  * Author: 1Platform
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Content AI are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.15.1] - 2026-04-01
+
+### Fixed
+- **Site Wizard navigation**: Integrated `MainMenuManager` (previously dead code) into the site generation flow as a new `setupNavigation` step — creates "Main Navigation" menu with Home + all generated categories assigned to the theme's primary menu location (#48)
+- **Breadcrumbs missing**: Added per-theme breadcrumb configuration in `contai_apply_theme_defaults()` for 8 supported themes (Astra, Neve, Blocksy, Kadence, OceanWP, Sydney, Newsmatic, ColorMag) (#48)
+- **Comments not enabled**: Set `default_comment_status` to `open` during site config setup so new posts accept comments by default (#48)
+
 ## [2.14.0] - 2026-04-01
 
 ### Added

--- a/includes/helpers/site-generation.php
+++ b/includes/helpers/site-generation.php
@@ -122,10 +122,12 @@ function contai_apply_theme_defaults( string $theme ): void {
 			if ( function_exists( 'contai_set_newsmatic_reading_defaults' ) ) {
 				contai_set_newsmatic_reading_defaults();
 			}
+			set_theme_mod( 'newsmatic_breadcrumb_option', true );
 			break;
 
 		case 'oceanwp':
 			set_theme_mod( 'ocean_blog_layout', 'right-sidebar' );
+			set_theme_mod( 'ocean_breadcrumbs', true );
 			break;
 
 		case 'generatepress':
@@ -134,6 +136,7 @@ function contai_apply_theme_defaults( string $theme ): void {
 
 		case 'colormag':
 			set_theme_mod( 'colormag_site_layout', 'right-sidebar' );
+			set_theme_mod( 'colormag_breadcrumb_display', true );
 			break;
 
 		case 'astra':
@@ -141,25 +144,32 @@ function contai_apply_theme_defaults( string $theme ): void {
 			set_theme_mod( 'site-sidebar-layout', 'right-sidebar' );
 			set_theme_mod( 'single-post-sidebar-layout', 'right-sidebar' );
 			set_theme_mod( 'archive-post-sidebar-layout', 'right-sidebar' );
+			// Enable breadcrumbs on single posts and archives
+			set_theme_mod( 'ast-breadcrumbs-position', 'astra_entry_top' );
+			set_theme_mod( 'ast-breadcrumbs-separator', '»' );
 			break;
 
 		case 'neve':
 			set_theme_mod( 'neve_default_sidebar_layout', 'right' );
 			set_theme_mod( 'neve_single_post_sidebar_layout', 'right' );
+			set_theme_mod( 'neve_breadcrumbs', true );
 			break;
 
 		case 'blocksy':
 			set_theme_mod( 'blog_has_sidebar', 'right' );
 			set_theme_mod( 'single_has_sidebar', 'right' );
+			set_theme_mod( 'breadcrumb_visibility', 'yes' );
 			break;
 
 		case 'kadence':
 			set_theme_mod( 'post_layout', 'right' );
 			set_theme_mod( 'archive_layout', 'right' );
+			set_theme_mod( 'breadcrumb_enable', true );
 			break;
 
 		case 'sydney':
 			set_theme_mod( 'sidebar_position', 'sidebar-right' );
+			set_theme_mod( 'enable_breadcrumbs', 1 );
 			break;
 	}
 }
@@ -279,6 +289,9 @@ function contai_delete_sample_content(): void {
 function contai_setup_site_config() {
 	update_option( 'permalink_structure', '/%postname%/' );
 	update_option( 'contai_flush_rewrite', true );
+
+	// Enable comments on new posts by default
+	update_option( 'default_comment_status', 'open' );
 
 	contai_delete_sample_content();
 }

--- a/includes/services/jobs/SiteGenerationJob.php
+++ b/includes/services/jobs/SiteGenerationJob.php
@@ -13,6 +13,7 @@ require_once __DIR__ . '/../setup/PostGenerationSetupService.php';
 require_once __DIR__ . '/../setup/CommentsGenerationService.php';
 require_once __DIR__ . '/../setup/SearchConsoleSetupService.php';
 require_once __DIR__ . '/../setup/AdsenseSetupService.php';
+require_once __DIR__ . '/../menu/MainMenuManager.php';
 
 class ContaiSiteGenerationJob implements ContaiJobInterface
 {
@@ -30,7 +31,8 @@ class ContaiSiteGenerationJob implements ContaiJobInterface
         'waitForPosts',
         'generateComments',
         'setupSearchConsole',
-        'setupAdsManager'
+        'setupAdsManager',
+        'setupNavigation'
     ];
 
     public function __construct()
@@ -156,6 +158,14 @@ class ContaiSiteGenerationJob implements ContaiJobInterface
                     $this->setupAdsManager($config['adsense']['publisher_id'] ?? '');
                 } catch (Exception $e) {
                     contai_log("Optional step 'setupAdsManager' failed: " . $e->getMessage()); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+                }
+                break;
+
+            case 'setupNavigation':
+                try {
+                    $this->setupNavigation();
+                } catch (Exception $e) {
+                    contai_log("Optional step 'setupNavigation' failed: " . $e->getMessage()); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
                 }
                 break;
         }
@@ -330,6 +340,25 @@ class ContaiSiteGenerationJob implements ContaiJobInterface
         }
 
         $service->setupAdsense($publisherId);
+    }
+
+    private function setupNavigation(): void
+    {
+        $categories = get_categories([
+            'hide_empty' => false,
+            'exclude'    => [get_option('default_category')],
+        ]);
+
+        if (empty($categories)) {
+            return;
+        }
+
+        $category_names = array_map(function ($cat) {
+            return sanitize_text_field($cat->name);
+        }, $categories);
+
+        $menuManager = new ContaiMainMenuManager();
+        $menuManager->updateMainMenuWithCategories($category_names);
     }
 
     private function updateJobPayload(int $jobId, array $payload, int $currentStep, array $completedSteps): void

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai content, seo, content generation, internal links, table of contents
 Requires at least: 5.9
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.15.0
+Stable tag: 2.15.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -159,6 +159,12 @@ The plugin sends your site URL, API key, and content generation parameters (keyw
 7. Tools — Google Analytics, Google Search Console, Publisuites, and Ads Manager integrations.
 
 == Changelog ==
+
+= 2.15.1 =
+* Fixed Site Wizard not generating complete navigation (menu, breadcrumbs, comments)
+* Integrated MainMenuManager to auto-create primary menu with Home + categories
+* Added breadcrumb configuration for 8 supported themes
+* Enabled comments on new posts by default
 
 = 2.14.0 =
 * Added breadcrumb defaults for 8 supported themes during site generation


### PR DESCRIPTION
## Summary
- Integrates the existing `MainMenuManager` (previously dead code) into the Site Wizard as a new `setupNavigation` step
- Adds per-theme breadcrumb configuration for 8 supported themes
- Enables comments on new posts by default via `default_comment_status`

## Changes
- **`includes/services/jobs/SiteGenerationJob.php`** — Added `setupNavigation` step at the END of the steps array (index 11) to avoid breaking in-progress jobs. Creates "Main Navigation" menu with Home + all generated categories using `ContaiMainMenuManager`
- **`includes/helpers/site-generation.php`** — Added breadcrumb `set_theme_mod()` calls per-theme in `contai_apply_theme_defaults()` (Astra, Neve, Blocksy, Kadence, OceanWP, Sydney, Newsmatic, ColorMag). Added `update_option('default_comment_status', 'open')` in `contai_setup_site_config()`

## Root Cause
`MainMenuManager` was created but never called — dead code since initial commit. Breadcrumb configuration and comment enablement were never implemented in the wizard flow.

## Audit Results
- Code review: PASS (2 issues found and fixed — step array index safety, category name sanitization)
- Provider name scan: CLEAN
- PHP lint: CLEAN
- PHPUnit: 480 tests, 754 assertions — all passing

## Test Plan
- [ ] Run Site Wizard on a fresh site — verify main menu with Home + categories appears
- [ ] Verify footer menu with legal pages still works
- [ ] Verify breadcrumbs display on single posts (Astra theme)
- [ ] Verify comments are open on generated posts
- [ ] Verify in-progress site generation jobs complete without errors after deploy

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)