### PR TITLE
fix(api-client): parse FastAPI detail field in error responses (#53)

### DIFF
--- a/1platform-content-ai.php
+++ b/1platform-content-ai.php
@@ -4,7 +4,7 @@
  * Plugin Name: 1Platform Content AI
  * Plugin URI: https://1platform.pro/
  * Description: SaaS client for AI-powered content generation, SEO optimization, and site management. All AI processing happens on 1Platform external servers. Includes free local tools: Table of Contents and Internal Links.
- * Version: 2.15.2
+ * Version: 2.15.3
  * Author: 1Platform
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Content AI are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.15.3] - 2026-04-01
+
+### Fixed
+- **API error messages lost**: `OnePlatformClient::createErrorResponse()` only checked `$json['msg']` for error messages, but FastAPI dependency/validation errors return `{"detail": "..."}` — all such errors silently became generic "Request failed". Added `$json['detail']` fallback (#53)
+- **Analytics OAuth silent network error**: JavaScript `.catch()` block in the Google Analytics panel silently reset the button on network errors without showing any message to the user (#53)
+
 ## [2.15.1] - 2026-04-01
 
 ### Fixed

--- a/includes/admin/apps/panels/AnalyticsPanel.php
+++ b/includes/admin/apps/panels/AnalyticsPanel.php
@@ -398,7 +398,8 @@ class ContaiAnalyticsPanel
                             });
                         }, 15000);
                     })
-                    .catch(function() {
+                    .catch(function(err) {
+                        alert(err.message || '<?php echo esc_js(__('Network error. Please check your connection and try again.', '1platform-content-ai')); ?>');
                         oauthBtn.disabled = false;
                         oauthBtn.innerHTML = '<span class="dashicons dashicons-google"></span> <?php echo esc_js(__('Connect with Google', '1platform-content-ai')); ?>';
                     });

--- a/includes/services/api/OnePlatformClient.php
+++ b/includes/services/api/OnePlatformClient.php
@@ -261,7 +261,7 @@ class ContaiOnePlatformClient {
     }
 
     private function createErrorResponse(?array $json, ContaiHTTPResponse $http_response, ?string $trace_id = null): ContaiOnePlatformResponse {
-        $error_message = $json['msg'] ?? $http_response->getError() ?? self::ERROR_REQUEST_FAILED;
+        $error_message = $json['msg'] ?? $json['detail'] ?? $http_response->getError() ?? self::ERROR_REQUEST_FAILED;
 
         return new ContaiOnePlatformResponse(
             false,

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai content, seo, content generation, internal links, table of contents
 Requires at least: 5.9
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.15.2
+Stable tag: 2.15.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -159,6 +159,10 @@ The plugin sends your site URL, API key, and content generation parameters (keyw
 7. Tools — Google Analytics, Google Search Console, Publisuites, and Ads Manager integrations.
 
 == Changelog ==
+
+= 2.15.3 =
+* Fixed API error messages being lost — "Request failed" now shows the actual error from the API
+* Fixed Google Analytics OAuth button silently failing on network errors
 
 = 2.15.1 =
 * Fixed Site Wizard not generating complete navigation (menu, breadcrumbs, comments)


### PR DESCRIPTION
## Summary
- Fixed generic "Request failed" error on Google Analytics OAuth (and all API error responses) by adding `$json['detail']` fallback in `OnePlatformClient::createErrorResponse()`
- Added user-facing error message in Analytics OAuth JS `.catch()` block for network errors

## Changes
- **`includes/services/api/OnePlatformClient.php:264`** — Added `$json['detail']` in the error message fallback chain. FastAPI dependency errors (missing OAuth config, auth failures, validation) return `{"detail": "..."}` not `{"msg": "..."}`, so the actual error was being swallowed.
- **`includes/admin/apps/panels/AnalyticsPanel.php:401`** — JS `.catch()` now shows `alert()` with the error message instead of silently resetting the button.

## Root Cause
`OnePlatformClient::createErrorResponse()` only checked `$json['msg']`, but FastAPI uses `{"detail": "..."}` for dependency injection errors (e.g., `HTTPException(503, "OAuth not configured")`). Since `$json['msg']` was null, the fallback `"Request failed"` constant was always used.

## Audit Results
- PHP lint: CLEAN
- Provider name scan: CLEAN  
- PHPUnit: 480 tests, 754 assertions — all passing

## Test Plan
- [ ] Trigger Google Analytics OAuth on a site without OAuth keys configured — verify error says "OAuth not configured" instead of "Request failed"
- [ ] Trigger with valid OAuth keys — verify OAuth popup opens
- [ ] Disconnect network and click Authorize — verify "Network error" message appears
- [ ] All 480 tests pass (754 assertions)

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)