### PR TITLE
feat(post): deduplicate featured images across generated posts

### DIFF
--- a/1platform-content-ai.php
+++ b/1platform-content-ai.php
@@ -4,7 +4,7 @@
  * Plugin Name: 1Platform Content AI
  * Plugin URI: https://1platform.pro/
  * Description: SaaS client for AI-powered content generation, SEO optimization, and site management. All AI processing happens on 1Platform external servers. Includes free local tools: Table of Contents and Internal Links.
- * Version: 2.15.6
+ * Version: 2.16.0
  * Author: 1Platform
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Content AI are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.16.0] - 2026-04-01
+
+### Added
+- **Featured image deduplication**: Post generation now avoids reusing the same featured image across posts. The orchestrator queries `_contai_featured_image_source` post meta to find which candidate URLs are already in use and selects the first unused one, falling back to the first image only when all candidates are exhausted
+- **Optimized dedup query**: Uses a scoped `IN` clause limited to candidate URLs instead of fetching all used URLs site-wide, keeping the query performant regardless of site size
+- **Unit tests**: 4 new tests covering featured image selection (skip used, fallback, fresh site, empty images)
+
 ## [2.15.5] - 2026-04-01
 
 ### Fixed

--- a/includes/services/post/PostGenerationOrchestrator.php
+++ b/includes/services/post/PostGenerationOrchestrator.php
@@ -53,6 +53,8 @@ class ContaiContentGenerationException extends RuntimeException {
 
 class ContaiPostGenerationOrchestrator {
 
+    private const META_FEATURED_IMAGE_SOURCE = '_contai_featured_image_source';
+
     private ContaiContentGeneratorService $content_generator;
     private ContaiCategoryService $category_service;
     private ContaiWordPressPostCreator $post_creator;
@@ -188,17 +190,53 @@ class ContaiPostGenerationOrchestrator {
             return;
         }
 
-        $first_image_url = $images[0]['url'] ?? null;
+        $candidate_urls = array_filter(array_column($images, 'url'));
+        $used_urls = $this->getUsedFeaturedImageUrls($candidate_urls);
+        $selected_url = $this->selectUniqueImageUrl($images, $used_urls);
 
-        if (empty($first_image_url)) {
+        if ($selected_url === null) {
             return;
         }
 
-        $attachment_id = $this->image_uploader->uploadFromUrl($first_image_url);
+        $attachment_id = $this->image_uploader->uploadFromUrl($selected_url);
 
         if ($attachment_id !== null) {
             $this->post_creator->setFeaturedImage($post_id, $attachment_id);
+            update_post_meta($post_id, self::META_FEATURED_IMAGE_SOURCE, $selected_url);
         }
+    }
+
+    private function selectUniqueImageUrl(array $images, array $used_urls): ?string {
+        foreach ($images as $image) {
+            $url = $image['url'] ?? null;
+            if (!empty($url) && !in_array($url, $used_urls, true)) {
+                return $url;
+            }
+        }
+
+        contai_log('All candidate featured images already used on this site, falling back to first image');
+        return $images[0]['url'] ?? null;
+    }
+
+    private function getUsedFeaturedImageUrls(array $candidate_urls): array {
+        if (empty($candidate_urls)) {
+            return [];
+        }
+
+        global $wpdb;
+
+        $placeholders = implode(', ', array_fill(0, count($candidate_urls), '%s'));
+
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- One-time dedup lookup scoped to candidate URLs only.
+        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $placeholders is generated from array_fill, not user input.
+        $results = $wpdb->get_col(
+            $wpdb->prepare(
+                "SELECT meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s AND meta_value IN ($placeholders)",
+                array_merge([self::META_FEATURED_IMAGE_SOURCE], array_values($candidate_urls))
+            )
+        );
+
+        return is_array($results) ? $results : [];
     }
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai content, seo, content generation, internal links, table of contents
 Requires at least: 5.9
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.15.6
+Stable tag: 2.16.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -159,6 +159,10 @@ The plugin sends your site URL, API key, and content generation parameters (keyw
 7. Tools — Google Analytics, Google Search Console, Publisuites, and Ads Manager integrations.
 
 == Changelog ==
+
+= 2.16.0 =
+* Added: Featured image deduplication — post generation avoids reusing the same featured image across posts
+* Added: Optimized dedup query scoped to candidate URLs for performance at scale
 
 = 2.15.5 =
 * Fix: Site Wizard "Launch Site Generation" silently refreshing without action (#54)

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -101,6 +101,15 @@ require_once __DIR__ . '/../includes/admin/licenses/WPContentAILicensePanel.php'
 // ── Category API ────────────────────────────────────────────────
 require_once __DIR__ . '/../includes/services/category-api/CategoryAPIService.php';
 
+// ── Post Generation ────────────────────────────────────────────
+require_once __DIR__ . '/../includes/services/post/WordPressPostCreator.php';
+require_once __DIR__ . '/../includes/services/post/ImageUploader.php';
+require_once __DIR__ . '/../includes/services/post/ContentImageProcessor.php';
+require_once __DIR__ . '/../includes/services/post/PostMetadataBuilder.php';
+require_once __DIR__ . '/../includes/services/category/CategoryService.php';
+require_once __DIR__ . '/../includes/services/content/ContentGeneratorService.php';
+require_once __DIR__ . '/../includes/services/post/PostGenerationOrchestrator.php';
+
 // ── Cron ────────────────────────────────────────────────────────
 require_once __DIR__ . '/../includes/cron/job-processor-cron.php';
 require_once __DIR__ . '/../includes/cron/agent-actions-cron.php';

--- a/tests/unit/services/post/PostGenerationOrchestratorTest.php
+++ b/tests/unit/services/post/PostGenerationOrchestratorTest.php
@@ -1,0 +1,244 @@
+<?php
+
+namespace ContAI\Tests\Unit\Services\Post;
+
+use WP_Mock;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use ContaiPostGenerationOrchestrator;
+use ContaiContentGeneratorService;
+use ContaiCategoryService;
+use ContaiWordPressPostCreator;
+use ContaiContentImageProcessor;
+use ContaiImageUploader;
+use ContaiPostMetadataBuilder;
+
+class PostGenerationOrchestratorTest extends TestCase
+{
+    private ContaiContentGeneratorService $content_generator;
+    private ContaiCategoryService $category_service;
+    private ContaiWordPressPostCreator $post_creator;
+    private ContaiContentImageProcessor $image_processor;
+    private ContaiImageUploader $image_uploader;
+    private ContaiPostMetadataBuilder $metadata_builder;
+    private ContaiPostGenerationOrchestrator $orchestrator;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        WP_Mock::setUp();
+
+        $this->content_generator = Mockery::mock(ContaiContentGeneratorService::class);
+        $this->category_service = Mockery::mock(ContaiCategoryService::class);
+        $this->post_creator = Mockery::mock(ContaiWordPressPostCreator::class);
+        $this->image_processor = Mockery::mock(ContaiContentImageProcessor::class);
+        $this->image_uploader = Mockery::mock(ContaiImageUploader::class);
+        $this->metadata_builder = Mockery::mock(ContaiPostMetadataBuilder::class);
+
+        $this->orchestrator = new ContaiPostGenerationOrchestrator(
+            $this->content_generator,
+            $this->category_service,
+            $this->post_creator,
+            $this->image_processor,
+            $this->image_uploader,
+            $this->metadata_builder
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->addToAssertionCount(Mockery::getContainer()->mockery_getExpectationCount());
+        WP_Mock::tearDown();
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    // ── Featured Image Deduplication Tests ─────────────────────────
+
+    public function test_featured_image_skips_already_used_url_and_picks_next(): void
+    {
+        $images = [
+            ['url' => 'https://images.example.com/image-already-used.jpg'],
+            ['url' => 'https://images.example.com/image-unique.jpg'],
+            ['url' => 'https://images.example.com/image-third.jpg'],
+        ];
+
+        $this->setupPostCreation();
+
+        // Simulate that first image is already used as featured image
+        $this->mockUsedFeaturedImageUrls(['https://images.example.com/image-already-used.jpg']);
+
+        // Expect the unique (second) image to be uploaded
+        $this->image_uploader
+            ->shouldReceive('uploadFromUrl')
+            ->once()
+            ->with('https://images.example.com/image-unique.jpg')
+            ->andReturn(42);
+
+        $this->post_creator
+            ->shouldReceive('setFeaturedImage')
+            ->once()
+            ->with(1, 42);
+
+        WP_Mock::userFunction('update_post_meta')
+            ->once()
+            ->with(1, '_contai_featured_image_source', 'https://images.example.com/image-unique.jpg');
+
+        $this->executeCreatePostFromApiResult($images);
+    }
+
+    public function test_featured_image_falls_back_to_first_when_all_already_used(): void
+    {
+        $images = [
+            ['url' => 'https://images.example.com/image-a.jpg'],
+            ['url' => 'https://images.example.com/image-b.jpg'],
+        ];
+
+        $this->setupPostCreation();
+
+        // Both images already used
+        $this->mockUsedFeaturedImageUrls([
+            'https://images.example.com/image-a.jpg',
+            'https://images.example.com/image-b.jpg',
+        ]);
+
+        // Falls back to first image
+        $this->image_uploader
+            ->shouldReceive('uploadFromUrl')
+            ->once()
+            ->with('https://images.example.com/image-a.jpg')
+            ->andReturn(10);
+
+        $this->post_creator
+            ->shouldReceive('setFeaturedImage')
+            ->once()
+            ->with(1, 10);
+
+        WP_Mock::userFunction('update_post_meta')
+            ->once()
+            ->with(1, '_contai_featured_image_source', 'https://images.example.com/image-a.jpg');
+
+        $this->executeCreatePostFromApiResult($images);
+    }
+
+    public function test_featured_image_uses_first_when_none_previously_used(): void
+    {
+        $images = [
+            ['url' => 'https://images.example.com/fresh-image.jpg'],
+            ['url' => 'https://images.example.com/another-image.jpg'],
+        ];
+
+        $this->setupPostCreation();
+
+        // No images used yet
+        $this->mockUsedFeaturedImageUrls([]);
+
+        $this->image_uploader
+            ->shouldReceive('uploadFromUrl')
+            ->once()
+            ->with('https://images.example.com/fresh-image.jpg')
+            ->andReturn(5);
+
+        $this->post_creator
+            ->shouldReceive('setFeaturedImage')
+            ->once()
+            ->with(1, 5);
+
+        WP_Mock::userFunction('update_post_meta')
+            ->once()
+            ->with(1, '_contai_featured_image_source', 'https://images.example.com/fresh-image.jpg');
+
+        $this->executeCreatePostFromApiResult($images);
+    }
+
+    public function test_featured_image_handles_empty_images_array(): void
+    {
+        $images = [];
+
+        $this->setupPostCreation();
+
+        // Should not attempt upload or DB query
+        $this->image_uploader->shouldNotReceive('uploadFromUrl');
+        $this->post_creator->shouldNotReceive('setFeaturedImage');
+
+        $this->executeCreatePostFromApiResult($images);
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────
+
+    private function setupPostCreation(): void
+    {
+        $this->image_processor
+            ->shouldReceive('process')
+            ->once()
+            ->andReturn('<p>Content</p>');
+
+        $this->post_creator
+            ->shouldReceive('create')
+            ->once()
+            ->andReturn(1);
+
+        $this->category_service
+            ->shouldReceive('findOrCreateCategoryId')
+            ->andReturn(1);
+
+        $this->post_creator
+            ->shouldReceive('assignCategory')
+            ->andReturn(null);
+
+        $this->metadata_builder
+            ->shouldReceive('buildFromKeyword')
+            ->once()
+            ->andReturn([]);
+
+        $this->post_creator
+            ->shouldReceive('saveMetadata')
+            ->once();
+
+        $this->post_creator
+            ->shouldReceive('getPermalink')
+            ->once()
+            ->andReturn('https://example.com/test-post');
+    }
+
+    private function mockUsedFeaturedImageUrls(array $urls): void
+    {
+        global $wpdb;
+        $wpdb = Mockery::mock(\stdClass::class);
+        $wpdb->postmeta = 'wp_postmeta';
+        $wpdb->shouldReceive('prepare')
+            ->once()
+            ->andReturnUsing(function () { return 'prepared_query'; });
+        $wpdb->shouldReceive('get_col')
+            ->once()
+            ->with('prepared_query')
+            ->andReturn($urls);
+    }
+
+    private function executeCreatePostFromApiResult(array $images): void
+    {
+        $keyword = Mockery::mock(\ContaiKeyword::class);
+        $keyword->shouldReceive('getId')->andReturn(1);
+        $keyword->shouldReceive('getKeyword')->andReturn('test keyword');
+        $keyword->shouldReceive('getTitle')->andReturn('Test Title');
+        $keyword->shouldReceive('getVolume')->andReturn(100);
+
+        $api_result = [
+            'title' => 'Test Article Title',
+            'content' => '<p>Test content</p>',
+            'images' => $images,
+            'category' => 'Finance',
+            'url' => 'test-article',
+            'seo_metadata' => [
+                'metatitle' => 'Test Meta Title',
+                'post_date' => '2026-01-15T10:00:00',
+            ],
+        ];
+
+        $this->orchestrator->createPostFromApiResult(
+            $keyword,
+            ['lang' => 'en', 'country' => 'us', 'image_provider' => 'stock'],
+            $api_result
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- **Featured image deduplication**: Post generation now avoids reusing the same featured image URL across posts by querying `_contai_featured_image_source` post meta and selecting the first unused candidate
- **Optimized query**: Uses scoped `IN` clause with candidate URLs only (not a full table scan), keeping performance constant regardless of site size
- **Meta key constant**: Extracted `_contai_featured_image_source` to `META_FEATURED_IMAGE_SOURCE` private const

## Changes
- `PostGenerationOrchestrator::setFeaturedImageIfExists()` — now calls `getUsedFeaturedImageUrls()` + `selectUniqueImageUrl()` instead of always using `$images[0]`
- `PostGenerationOrchestrator::selectUniqueImageUrl()` — iterates candidates, skips used URLs, falls back to first if all exhausted
- `PostGenerationOrchestrator::getUsedFeaturedImageUrls()` — queries `wp_postmeta` with `IN` clause scoped to candidate URLs
- `tests/bootstrap.php` — added `require_once` for post generation classes
- `tests/unit/services/post/PostGenerationOrchestratorTest.php` — 4 new unit tests

## Audit Results
- Code review: 2 issues found and fixed (unbounded query → scoped IN clause; repeated string literal → private const)
- Provider name scan: clean (test URLs changed from pixabay.com to example.com)
- Security scan: clean (SQL injection, XSS, credentials all OK)
- Known limitation: theoretical race condition under concurrent job execution; mitigated by MySQL `GET_LOCK()` in the job processor

## Test Plan
- [x] All 491 tests pass (801 assertions)
- [x] No regressions in existing test suites
- [x] Version sync validated (plugin header = readme.txt = 2.16.0)
- [x] Provider name scan clean on all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)