### PR TITLE
feat(seo): add alt text, meta description, and title tag SEO basics (#49)

### DIFF
--- a/1platform-content-ai.php
+++ b/1platform-content-ai.php
@@ -4,7 +4,7 @@
  * Plugin Name: 1Platform Content AI
  * Plugin URI: https://1platform.pro/
  * Description: SaaS client for AI-powered content generation, SEO optimization, and site management. All AI processing happens on 1Platform external servers. Includes free local tools: Table of Contents and Internal Links.
- * Version: 2.15.6
+ * Version: 2.16.0
  * Author: 1Platform
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -60,6 +60,11 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/services/agents/ContaiAgent
 require_once plugin_dir_path( __FILE__ ) . 'includes/services/agents/ContaiAgentRestController.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/admin/agents/ContaiAgentsAdminPage.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/cron/agent-actions-cron.php';
+
+// SEO domain
+require_once plugin_dir_path(__FILE__) . 'includes/services/seo/SeoHeadService.php';
+$contai_seo_head = new ContaiSeoHeadService();
+$contai_seo_head->register();
 
 // Analytics domain
 require_once plugin_dir_path(__FILE__) . 'includes/analytics/class-analytics-tag.php';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Content AI are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.16.0] - 2026-04-01
+
+### Added
+- **SEO alt text on images** (#49): All images uploaded via the content pipeline now receive descriptive alt text. Uses per-image AI-generated alt text from the API when available, falls back to the keyword. Sets `_wp_attachment_image_alt` post meta and fixes empty/missing `alt` attributes in HTML content
+- **SEO meta description output** (#49): New `ContaiSeoHeadService` outputs `<meta name="description">` tag on singular posts via `wp_head` hook. Uses AI-generated meta description from the API when available, falls back to auto-generated 155-char excerpt from content
+- **SEO title tag override** (#49): Hooks `document_title_parts` to use the API-generated `metatitle` (stored in `_contai_metatitle`) for the document `<title>` tag on singular posts
+- **Auto-generated post excerpts**: `WordPressPostCreator` now sets `post_excerpt` on all generated posts for meta description and WordPress excerpt support
+- **14 new tests**: ImageUploader (2), ContentImageProcessor (4), WordPressPostCreator (2), SeoHeadService (6)
+
 ## [2.15.5] - 2026-04-01
 
 ### Fixed

--- a/includes/services/content/ContentGeneratorService.php
+++ b/includes/services/content/ContentGeneratorService.php
@@ -166,6 +166,7 @@ class ContaiContentGeneratorService {
             $data['category'] ?? null,
             $data['url'] ?? null,
             $seo_metadata['metatitle'] ?? null,
+            $seo_metadata['meta_description'] ?? null,
             $seo_metadata['post_date'] ?? null
         );
     }
@@ -188,6 +189,7 @@ class ContaiContentGenerationResult {
     private ?string $category;
     private ?string $slug;
     private ?string $metatitle;
+    private ?string $meta_description;
     private ?string $post_date;
 
     private function __construct(
@@ -198,6 +200,7 @@ class ContaiContentGenerationResult {
         ?string $category = null,
         ?string $slug = null,
         ?string $metatitle = null,
+        ?string $meta_description = null,
         ?string $post_date = null,
         ?string $error_message = null,
         ?int $status_code = null
@@ -209,6 +212,7 @@ class ContaiContentGenerationResult {
         $this->category = $category;
         $this->slug = $slug;
         $this->metatitle = $metatitle;
+        $this->meta_description = $meta_description;
         $this->post_date = $post_date;
         $this->error_message = $error_message;
         $this->status_code = $status_code;
@@ -221,13 +225,14 @@ class ContaiContentGenerationResult {
         ?string $category = null,
         ?string $slug = null,
         ?string $metatitle = null,
+        ?string $meta_description = null,
         ?string $post_date = null
     ): self {
-        return new self(true, $title, $content, $images, $category, $slug, $metatitle, $post_date, null, 200);
+        return new self(true, $title, $content, $images, $category, $slug, $metatitle, $meta_description, $post_date, null, 200);
     }
 
     public static function failure(string $error_message, ?int $status_code = null): self {
-        return new self(false, '', '', [], null, null, null, null, $error_message, $status_code);
+        return new self(false, '', '', [], null, null, null, null, null, $error_message, $status_code);
     }
 
     public function isSuccess(): bool {
@@ -262,6 +267,10 @@ class ContaiContentGenerationResult {
         return $this->metatitle;
     }
 
+    public function getMetaDescription(): ?string {
+        return $this->meta_description;
+    }
+
     public function getPostDate(): ?string {
         return $this->post_date;
     }
@@ -279,6 +288,7 @@ class ContaiContentGenerationResult {
             'category' => $this->category,
             'slug' => $this->slug,
             'metatitle' => $this->metatitle,
+            'meta_description' => $this->meta_description,
             'post_date' => $this->post_date,
             'error_message' => $this->error_message,
             'status_code' => $this->status_code,

--- a/includes/services/post/ContentImageProcessor.php
+++ b/includes/services/post/ContentImageProcessor.php
@@ -12,17 +12,20 @@ class ContaiContentImageProcessor {
         $this->uploader = $uploader;
     }
 
-    public function process(string $content, array $images): string {
-        if (empty($images)) {
-            return $content;
+    public function process(string $content, array $images, string $alt_text = ''): string {
+        if (!empty($images)) {
+            $url_map = $this->buildUrlMap($content, $images, $alt_text);
+            $content = $this->replaceUrls($content, $url_map);
         }
 
-        $url_map = $this->buildUrlMap($content, $images);
+        if ($alt_text !== '') {
+            $content = $this->ensureImgAltAttributes($content, $alt_text);
+        }
 
-        return $this->replaceUrls($content, $url_map);
+        return $content;
     }
 
-    private function buildUrlMap(string $content, array $images): array {
+    private function buildUrlMap(string $content, array $images, string $alt_text): array {
         $url_map = [];
 
         foreach ($images as $image) {
@@ -32,7 +35,8 @@ class ContaiContentImageProcessor {
                 continue;
             }
 
-            $attachment_id = $this->uploader->uploadFromUrl($external_url);
+            $image_alt = !empty($image['alt_text']) ? $image['alt_text'] : $alt_text;
+            $attachment_id = $this->uploader->uploadFromUrl($external_url, $image_alt);
 
             if ($attachment_id === null) {
                 continue;
@@ -56,6 +60,26 @@ class ContaiContentImageProcessor {
         foreach ($url_map as $external_url => $local_url) {
             $content = str_replace($external_url, $local_url, $content);
         }
+
+        return $content;
+    }
+
+    private function ensureImgAltAttributes(string $content, string $alt_text): string {
+        $escaped_alt = esc_attr($alt_text);
+
+        // Replace empty alt attributes with the keyword-based alt text
+        $content = preg_replace(
+            '/<img([^>]*)\salt=["\']["\']/',
+            '<img$1 alt="' . $escaped_alt . '"',
+            $content
+        );
+
+        // Add alt attribute to <img> tags missing it entirely
+        $content = preg_replace(
+            '/<img((?![^>]*\salt=)[^>]*)\s*\/?>/',
+            '<img$1 alt="' . $escaped_alt . '">',
+            $content
+        );
 
         return $content;
     }

--- a/includes/services/post/ImageUploader.php
+++ b/includes/services/post/ImageUploader.php
@@ -8,7 +8,7 @@ class ContaiImageUploader {
         $this->ensureMediaFunctionsLoaded();
     }
 
-    public function uploadFromUrl(string $image_url): ?int {
+    public function uploadFromUrl(string $image_url, string $alt_text = ''): ?int {
         $temp_file = download_url($image_url);
 
         if (is_wp_error($temp_file)) {
@@ -19,6 +19,10 @@ class ContaiImageUploader {
         $attachment_id = $this->createAttachment($temp_file, $image_url);
 
         $this->cleanupTempFile($temp_file);
+
+        if ($attachment_id !== null && $alt_text !== '') {
+            update_post_meta($attachment_id, '_wp_attachment_image_alt', sanitize_text_field($alt_text));
+        }
 
         return $attachment_id;
     }

--- a/includes/services/post/PostGenerationOrchestrator.php
+++ b/includes/services/post/PostGenerationOrchestrator.php
@@ -114,6 +114,7 @@ class ContaiPostGenerationOrchestrator {
             $api_result['category'] ?? null,
             $api_result['url'] ?? null,
             $seo_metadata['metatitle'] ?? null,
+            $seo_metadata['meta_description'] ?? null,
             $seo_metadata['post_date'] ?? null
         );
 
@@ -125,9 +126,12 @@ class ContaiPostGenerationOrchestrator {
     }
 
     private function buildPost(ContaiKeyword $keyword, array $params, ContaiContentGenerationResult $content_result): ContaiPostGenerationResult {
+        $alt_text = $keyword->getTitle() ?: $keyword->getKeyword();
+
         $processed_content = $this->image_processor->process(
             $content_result->getContent(),
-            $content_result->getImages()
+            $content_result->getImages(),
+            $alt_text
         );
 
         $title = $content_result->getTitle() ?: $keyword->getKeyword();
@@ -136,14 +140,15 @@ class ContaiPostGenerationOrchestrator {
             $processed_content,
             $content_result->getSlug(),
             $content_result->getPostDate(),
-            $content_result->getMetatitle()
+            $content_result->getMetatitle(),
+            $content_result->getMetaDescription()
         );
 
         $category_id = $this->assignCategoryIfExists($post_id, $content_result->getCategory());
 
         $this->saveMetadata($post_id, $keyword, $params);
 
-        $this->setFeaturedImageIfExists($post_id, $content_result->getImages());
+        $this->setFeaturedImageIfExists($post_id, $content_result->getImages(), $alt_text);
 
         return new ContaiPostGenerationResult(
             $post_id,
@@ -183,7 +188,7 @@ class ContaiPostGenerationOrchestrator {
         $this->post_creator->saveMetadata($post_id, $metadata);
     }
 
-    private function setFeaturedImageIfExists(int $post_id, array $images): void {
+    private function setFeaturedImageIfExists(int $post_id, array $images, string $alt_text = ''): void {
         if (empty($images)) {
             return;
         }
@@ -194,7 +199,7 @@ class ContaiPostGenerationOrchestrator {
             return;
         }
 
-        $attachment_id = $this->image_uploader->uploadFromUrl($first_image_url);
+        $attachment_id = $this->image_uploader->uploadFromUrl($first_image_url, $alt_text);
 
         if ($attachment_id !== null) {
             $this->post_creator->setFeaturedImage($post_id, $attachment_id);

--- a/includes/services/post/WordPressPostCreator.php
+++ b/includes/services/post/WordPressPostCreator.php
@@ -5,13 +5,17 @@ if (!defined('ABSPATH')) exit;
 class ContaiWordPressPostCreator {
 
     private const CUSTOM_FIELD_METATITLE = '_contai_metatitle';
+    private const META_DESCRIPTION_LENGTH = 155;
 
-    public function create(string $title, string $content, ?string $slug = null, ?string $post_date = null, ?string $metatitle = null): int {
+    public function create(string $title, string $content, ?string $slug = null, ?string $post_date = null, ?string $metatitle = null, ?string $meta_description = null): int {
+        $excerpt = !empty($meta_description) ? $meta_description : $this->generateExcerpt($content);
+
         $post_data = [
             'post_title' => sanitize_text_field($title),
             'post_content' => $content,
             'post_status' => 'publish',
-            'post_type' => 'post'
+            'post_type' => 'post',
+            'post_excerpt' => sanitize_text_field($excerpt),
         ];
 
         if ($slug !== null) {
@@ -49,6 +53,24 @@ class ContaiWordPressPostCreator {
 
     private function saveMetatitle(int $post_id, string $metatitle): void {
         update_post_meta($post_id, self::CUSTOM_FIELD_METATITLE, sanitize_text_field($metatitle));
+    }
+
+    private function generateExcerpt(string $content): string {
+        $text = wp_strip_all_tags($content);
+        $text = preg_replace('/\s+/', ' ', trim($text));
+
+        if (mb_strlen($text) <= self::META_DESCRIPTION_LENGTH) {
+            return $text;
+        }
+
+        $truncated = mb_substr($text, 0, self::META_DESCRIPTION_LENGTH);
+        $last_space = mb_strrpos($truncated, ' ');
+
+        if ($last_space !== false) {
+            $truncated = mb_substr($truncated, 0, $last_space);
+        }
+
+        return $truncated . '...';
     }
 
     public function assignCategory(int $post_id, int $category_id): void {

--- a/includes/services/seo/SeoHeadService.php
+++ b/includes/services/seo/SeoHeadService.php
@@ -1,0 +1,55 @@
+<?php
+
+if (!defined('ABSPATH')) exit;
+
+class ContaiSeoHeadService {
+
+    private const METATITLE_META_KEY = '_contai_metatitle';
+
+    public function register(): void {
+        add_filter('document_title_parts', [$this, 'overrideTitleParts']);
+        add_action('wp_head', [$this, 'outputMetaDescription'], 2);
+    }
+
+    public function overrideTitleParts(array $title_parts): array {
+        if (!is_singular('post')) {
+            return $title_parts;
+        }
+
+        $post = get_queried_object();
+
+        if (!$post instanceof WP_Post) {
+            return $title_parts;
+        }
+
+        $metatitle = get_post_meta($post->ID, self::METATITLE_META_KEY, true);
+
+        if (!empty($metatitle)) {
+            $title_parts['title'] = $metatitle;
+        }
+
+        return $title_parts;
+    }
+
+    public function outputMetaDescription(): void {
+        if (!is_singular('post')) {
+            return;
+        }
+
+        $post = get_queried_object();
+
+        if (!$post instanceof WP_Post) {
+            return;
+        }
+
+        $description = $post->post_excerpt;
+
+        if (empty($description)) {
+            return;
+        }
+
+        $description = esc_attr(wp_strip_all_tags($description));
+
+        echo '<meta name="description" content="' . $description . '" />' . "\n";
+    }
+}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai content, seo, content generation, internal links, table of contents
 Requires at least: 5.9
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.15.6
+Stable tag: 2.16.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -159,6 +159,12 @@ The plugin sends your site URL, API key, and content generation parameters (keyw
 7. Tools — Google Analytics, Google Search Console, Publisuites, and Ads Manager integrations.
 
 == Changelog ==
+
+= 2.16.0 =
+* Added: SEO alt text on all images uploaded by the content pipeline (#49)
+* Added: Meta description output via wp_head for generated posts (#49)
+* Added: SEO title tag override using AI-generated metatitle (#49)
+* Added: Auto-generated post excerpts for meta description support
 
 = 2.15.5 =
 * Fix: Site Wizard "Launch Site Generation" silently refreshing without action (#54)

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -98,6 +98,14 @@ require_once __DIR__ . '/../includes/admin/content-generator/handlers/PostGenera
 require_once __DIR__ . '/../includes/services/user-profile/UserProfileService.php';
 require_once __DIR__ . '/../includes/admin/licenses/WPContentAILicensePanel.php';
 
+// ── Post Pipeline ──────────────────────────────────────────────
+require_once __DIR__ . '/../includes/services/post/ImageUploader.php';
+require_once __DIR__ . '/../includes/services/post/ContentImageProcessor.php';
+require_once __DIR__ . '/../includes/services/post/WordPressPostCreator.php';
+
+// ── SEO ────────────────────────────────────────────────────────
+require_once __DIR__ . '/../includes/services/seo/SeoHeadService.php';
+
 // ── Category API ────────────────────────────────────────────────
 require_once __DIR__ . '/../includes/services/category-api/CategoryAPIService.php';
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,6 +6,18 @@ define('ARRAY_A', 'ARRAY_A');
 define('DAY_IN_SECONDS', 86400);
 define('HOUR_IN_SECONDS', 3600);
 
+// Create dummy WP admin files so ImageUploader::ensureMediaFunctionsLoaded() doesn't fatal
+$wp_admin_includes = ABSPATH . 'wp-admin/includes/';
+if (!is_dir($wp_admin_includes)) {
+    mkdir($wp_admin_includes, 0777, true);
+}
+foreach (['file.php', 'media.php', 'image.php'] as $stub) {
+    $path = $wp_admin_includes . $stub;
+    if (!file_exists($path)) {
+        file_put_contents($path, "<?php\n");
+    }
+}
+
 require_once __DIR__ . '/../vendor/autoload.php';
 
 WP_Mock::bootstrap();

--- a/tests/unit/services/post/ContentImageProcessorTest.php
+++ b/tests/unit/services/post/ContentImageProcessorTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace ContAI\Tests\Unit\Services\Post;
+
+use WP_Mock;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use ContaiContentImageProcessor;
+use ContaiImageUploader;
+
+class ContentImageProcessorTest extends TestCase
+{
+    private $mockUploader;
+    private ContaiContentImageProcessor $processor;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        WP_Mock::setUp();
+
+        $this->mockUploader = Mockery::mock(ContaiImageUploader::class);
+        $this->processor = new ContaiContentImageProcessor($this->mockUploader);
+    }
+
+    public function tearDown(): void
+    {
+        WP_Mock::tearDown();
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_process_passes_alt_text_to_uploader(): void
+    {
+        $external_url = 'https://images.pexels.com/photos/123/shoe.jpg';
+        $local_url = 'https://example.com/wp-content/uploads/shoe.jpg';
+        $content = '<p>Text</p><img src="' . $external_url . '" alt="" />';
+
+        WP_Mock::userFunction('esc_attr')->andReturnArg(0);
+
+        $this->mockUploader
+            ->shouldReceive('uploadFromUrl')
+            ->once()
+            ->with($external_url, 'running shoes')
+            ->andReturn(42);
+
+        $this->mockUploader
+            ->shouldReceive('getAttachmentUrl')
+            ->once()
+            ->with(42)
+            ->andReturn($local_url);
+
+        $result = $this->processor->process($content, [['url' => $external_url]], 'running shoes');
+
+        $this->assertStringContainsString($local_url, $result);
+        $this->assertStringContainsString('alt="running shoes"', $result);
+        $this->assertStringNotContainsString('alt=""', $result);
+    }
+
+    public function test_process_adds_alt_to_img_without_alt_attribute(): void
+    {
+        $content = '<img src="https://example.com/local.jpg">';
+
+        WP_Mock::userFunction('esc_attr')->andReturnArg(0);
+
+        $result = $this->processor->process($content, [], 'keyword alt');
+
+        $this->assertStringContainsString('alt="keyword alt"', $result);
+    }
+
+    public function test_process_preserves_existing_alt_text(): void
+    {
+        $content = '<img src="https://example.com/local.jpg" alt="original alt">';
+
+        WP_Mock::userFunction('esc_attr')->andReturnArg(0);
+
+        $result = $this->processor->process($content, [], 'keyword alt');
+
+        $this->assertStringContainsString('alt="original alt"', $result);
+        $this->assertStringNotContainsString('alt="keyword alt"', $result);
+    }
+
+    public function test_process_without_alt_text_does_not_modify_img_tags(): void
+    {
+        $content = '<img src="https://example.com/local.jpg" alt="">';
+
+        $result = $this->processor->process($content, [], '');
+
+        $this->assertStringContainsString('alt=""', $result);
+    }
+}

--- a/tests/unit/services/post/ImageUploaderTest.php
+++ b/tests/unit/services/post/ImageUploaderTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace ContAI\Tests\Unit\Services\Post;
+
+use WP_Mock;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use ContaiImageUploader;
+
+class ImageUploaderTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        WP_Mock::setUp();
+
+        WP_Mock::userFunction('contai_log')->andReturn(null);
+    }
+
+    public function tearDown(): void
+    {
+        WP_Mock::tearDown();
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    private function mockSuccessfulUpload(): void
+    {
+        WP_Mock::userFunction('download_url')->andReturn('/tmp/test-image.jpg');
+        WP_Mock::userFunction('wp_parse_url')->andReturnUsing(function ($url, $component) {
+            return parse_url($url, $component);
+        });
+        WP_Mock::userFunction('media_handle_sideload')->andReturn(42);
+        WP_Mock::userFunction('wp_delete_file')->andReturn(true);
+        WP_Mock::userFunction('is_wp_error')->andReturn(false);
+    }
+
+    public function test_upload_sets_alt_text_when_provided(): void
+    {
+        $this->mockSuccessfulUpload();
+        WP_Mock::userFunction('sanitize_text_field')->andReturnArg(0);
+        WP_Mock::userFunction('update_post_meta')
+            ->once()
+            ->with(42, '_wp_attachment_image_alt', 'Best running shoes 2025')
+            ->andReturn(true);
+
+        $uploader = new ContaiImageUploader();
+        $result = $uploader->uploadFromUrl('https://example.com/shoe.jpg', 'Best running shoes 2025');
+
+        $this->assertSame(42, $result);
+    }
+
+    public function test_upload_skips_alt_text_when_empty(): void
+    {
+        $this->mockSuccessfulUpload();
+        WP_Mock::userFunction('update_post_meta')->never();
+
+        $uploader = new ContaiImageUploader();
+        $result = $uploader->uploadFromUrl('https://example.com/shoe.jpg');
+
+        $this->assertSame(42, $result);
+    }
+}

--- a/tests/unit/services/post/WordPressPostCreatorTest.php
+++ b/tests/unit/services/post/WordPressPostCreatorTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace ContAI\Tests\Unit\Services\Post;
+
+use WP_Mock;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use ContaiWordPressPostCreator;
+
+class WordPressPostCreatorTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        WP_Mock::setUp();
+    }
+
+    public function tearDown(): void
+    {
+        WP_Mock::tearDown();
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_create_sets_post_excerpt_from_content(): void
+    {
+        $content = '<p>This is a test article about running shoes that covers everything you need to know.</p>';
+
+        WP_Mock::userFunction('sanitize_text_field')->andReturnArg(0);
+        WP_Mock::userFunction('wp_strip_all_tags')->andReturnUsing(function ($str) {
+            return strip_tags($str);
+        });
+
+        $captured_data = null;
+        WP_Mock::userFunction('wp_insert_post')
+            ->once()
+            ->andReturnUsing(function ($data) use (&$captured_data) {
+                $captured_data = $data;
+                return 1;
+            });
+
+        $creator = new ContaiWordPressPostCreator();
+        $post_id = $creator->create('Test Title', $content);
+
+        $this->assertSame(1, $post_id);
+        $this->assertNotEmpty($captured_data['post_excerpt']);
+        $this->assertStringContainsString('running shoes', $captured_data['post_excerpt']);
+    }
+
+    public function test_create_truncates_long_excerpt_at_word_boundary(): void
+    {
+        $content = '<p>' . str_repeat('Word ', 100) . '</p>';
+
+        WP_Mock::userFunction('sanitize_text_field')->andReturnArg(0);
+        WP_Mock::userFunction('wp_strip_all_tags')->andReturnUsing(function ($str) {
+            return strip_tags($str);
+        });
+
+        $captured_data = null;
+        WP_Mock::userFunction('wp_insert_post')
+            ->once()
+            ->andReturnUsing(function ($data) use (&$captured_data) {
+                $captured_data = $data;
+                return 1;
+            });
+
+        $creator = new ContaiWordPressPostCreator();
+        $creator->create('Long content', $content);
+
+        $this->assertLessThanOrEqual(160, mb_strlen($captured_data['post_excerpt']));
+        $this->assertStringEndsWith('...', $captured_data['post_excerpt']);
+    }
+}

--- a/tests/unit/services/seo/SeoHeadServiceTest.php
+++ b/tests/unit/services/seo/SeoHeadServiceTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace ContAI\Tests\Unit\Services\Seo;
+
+use WP_Mock;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use ContaiSeoHeadService;
+
+class SeoHeadServiceTest extends TestCase
+{
+    private ContaiSeoHeadService $service;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        WP_Mock::setUp();
+
+        $this->service = new ContaiSeoHeadService();
+    }
+
+    public function tearDown(): void
+    {
+        WP_Mock::tearDown();
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_override_title_uses_metatitle_on_singular_post(): void
+    {
+        $post = Mockery::mock('WP_Post');
+        $post->ID = 42;
+
+        WP_Mock::userFunction('is_singular')->with('post')->andReturn(true);
+        WP_Mock::userFunction('get_queried_object')->andReturn($post);
+        WP_Mock::userFunction('get_post_meta')
+            ->with(42, '_contai_metatitle', true)
+            ->andReturn('BEST Running Shoes for BEGINNERS 2025');
+
+        $result = $this->service->overrideTitleParts(['title' => 'Original Title', 'site' => 'My Site']);
+
+        $this->assertSame('BEST Running Shoes for BEGINNERS 2025', $result['title']);
+        $this->assertSame('My Site', $result['site']);
+    }
+
+    public function test_override_title_skips_non_singular_pages(): void
+    {
+        WP_Mock::userFunction('is_singular')->with('post')->andReturn(false);
+
+        $result = $this->service->overrideTitleParts(['title' => 'Original Title']);
+
+        $this->assertSame('Original Title', $result['title']);
+    }
+
+    public function test_override_title_skips_when_no_metatitle(): void
+    {
+        $post = Mockery::mock('WP_Post');
+        $post->ID = 42;
+
+        WP_Mock::userFunction('is_singular')->with('post')->andReturn(true);
+        WP_Mock::userFunction('get_queried_object')->andReturn($post);
+        WP_Mock::userFunction('get_post_meta')
+            ->with(42, '_contai_metatitle', true)
+            ->andReturn('');
+
+        $result = $this->service->overrideTitleParts(['title' => 'Original Title']);
+
+        $this->assertSame('Original Title', $result['title']);
+    }
+
+    public function test_output_meta_description_on_singular_post(): void
+    {
+        $post = Mockery::mock('WP_Post');
+        $post->ID = 42;
+        $post->post_excerpt = 'This is a test excerpt for SEO.';
+
+        WP_Mock::userFunction('is_singular')->with('post')->andReturn(true);
+        WP_Mock::userFunction('get_queried_object')->andReturn($post);
+        WP_Mock::userFunction('wp_strip_all_tags')->andReturnArg(0);
+        WP_Mock::userFunction('esc_attr')->andReturnArg(0);
+
+        ob_start();
+        $this->service->outputMetaDescription();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('<meta name="description"', $output);
+        $this->assertStringContainsString('This is a test excerpt for SEO.', $output);
+    }
+
+    public function test_output_meta_description_skips_empty_excerpt(): void
+    {
+        $post = Mockery::mock('WP_Post');
+        $post->ID = 42;
+        $post->post_excerpt = '';
+
+        WP_Mock::userFunction('is_singular')->with('post')->andReturn(true);
+        WP_Mock::userFunction('get_queried_object')->andReturn($post);
+
+        ob_start();
+        $this->service->outputMetaDescription();
+        $output = ob_get_clean();
+
+        $this->assertEmpty($output);
+    }
+
+    public function test_output_meta_description_skips_non_singular(): void
+    {
+        WP_Mock::userFunction('is_singular')->with('post')->andReturn(false);
+
+        ob_start();
+        $this->service->outputMetaDescription();
+        $output = ob_get_clean();
+
+        $this->assertEmpty($output);
+    }
+}


### PR DESCRIPTION
## Summary
- Add image alt text to all images uploaded via the content pipeline (keyword fallback + API-generated per-image alt text)
- Output `<meta name="description">` tag on singular posts via `wp_head` hook
- Override document `<title>` tag using API-generated metatitle via `document_title_parts` filter

## Changes

### Image Alt Text (0/7 sites → all sites)
- `ImageUploader::uploadFromUrl()` now accepts `$alt_text` and sets `_wp_attachment_image_alt` post meta
- `ContentImageProcessor::process()` passes keyword as alt text, fixes empty/missing `alt` attrs in HTML
- Prefers per-image `$image['alt_text']` from API when available
- `PostGenerationOrchestrator` passes keyword through the entire image pipeline (content images + featured image)

### Meta Description (3/7 missing → all sites)
- `WordPressPostCreator` auto-generates `post_excerpt` from content (155 chars, word-boundary truncated)
- Prefers API-generated `meta_description` when available
- New `ContaiSeoHeadService` outputs `<meta name="description">` tag via `wp_head`

### Title Tags (5/7 generic → all sites)
- New `ContaiSeoHeadService` hooks `document_title_parts` to use `_contai_metatitle` when available
- Existing `metatitle` already stored by `WordPressPostCreator` — now actually used for the `<title>` tag

### New Files
- `includes/services/seo/SeoHeadService.php` — SEO head output service
- 4 new test files (14 tests, 23 assertions)

## Audit Results
- Code review: PASS (1 regex edge case auto-fixed for self-closing `<img />` tags)
- Provider name scan: CLEAN
- Security: All outputs properly escaped (esc_attr, sanitize_text_field, wp_strip_all_tags)

## Test Plan
- [x] All 501 tests pass (787 assertions)
- [x] 14 new tests covering: ImageUploader alt text, ContentImageProcessor alt injection, WordPressPostCreator excerpt generation, SeoHeadService title override + meta description output
- [x] No regressions in existing test suite
- [x] Backward compatible — all new fields/params have defaults

**Companion PR:** 1platformlabs/1platform-api — adds AI-generated alt text and meta description to the content generation API response

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)