### PR TITLE
fix(post): stop featured image dedup fallback from duplicating (#47)

### DIFF
--- a/1platform-content-ai.php
+++ b/1platform-content-ai.php
@@ -4,7 +4,7 @@
  * Plugin Name: 1Platform Content AI
  * Plugin URI: https://1platform.pro/
  * Description: SaaS client for AI-powered content generation, SEO optimization, and site management. All AI processing happens on 1Platform external servers. Includes free local tools: Table of Contents and Internal Links.
- * Version: 2.17.2
+ * Version: 2.17.3
  * Author: 1Platform
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Content AI are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.17.3] - 2026-04-01
+
+### Fixed
+- **Featured image dedup fallback guarantees duplication** (#47): When all candidate images from the API were already used as featured images, `selectUniqueImageUrl()` fell back to `$images[0]['url']` — always the same first image. In batch generation with similar keywords, this caused every post beyond the initial set to share the same cover image. Now returns `null` (no featured image) instead of duplicating
+- **Featured image dedup race window**: `_contai_featured_image_source` meta was saved after the (potentially slow) image upload, leaving a window where concurrent jobs could select the same URL. Meta is now claimed before upload and cleaned up on failure
+
+### Added
+- **Upload failure cleanup test**: New regression test verifying that the meta claim is removed when image upload fails
+
 ## [2.17.1] - 2026-04-01
 
 ### Fixed

--- a/includes/services/post/PostGenerationOrchestrator.php
+++ b/includes/services/post/PostGenerationOrchestrator.php
@@ -198,11 +198,15 @@ class ContaiPostGenerationOrchestrator {
             return;
         }
 
+        // Claim the URL before uploading to prevent concurrent jobs from selecting the same image.
+        update_post_meta($post_id, self::META_FEATURED_IMAGE_SOURCE, $selected_url);
+
         $attachment_id = $this->image_uploader->uploadFromUrl($selected_url);
 
         if ($attachment_id !== null) {
             $this->post_creator->setFeaturedImage($post_id, $attachment_id);
-            update_post_meta($post_id, self::META_FEATURED_IMAGE_SOURCE, $selected_url);
+        } else {
+            delete_post_meta($post_id, self::META_FEATURED_IMAGE_SOURCE);
         }
     }
 
@@ -214,8 +218,8 @@ class ContaiPostGenerationOrchestrator {
             }
         }
 
-        contai_log('All candidate featured images already used on this site, falling back to first image');
-        return $images[0]['url'] ?? null;
+        contai_log('All candidate featured images already used on this site, skipping featured image to avoid duplication');
+        return null;
     }
 
     private function getUsedFeaturedImageUrls(array $candidate_urls): array {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai content, seo, content generation, internal links, table of contents
 Requires at least: 5.9
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.17.2
+Stable tag: 2.17.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -159,6 +159,11 @@ The plugin sends your site URL, API key, and content generation parameters (keyw
 7. Tools — Google Analytics, Google Search Console, Publisuites, and Ads Manager integrations.
 
 == Changelog ==
+
+= 2.17.3 =
+* Fix: Featured image dedup no longer falls back to first image when all candidates are used — skips featured image to avoid duplication (#47)
+* Fix: Featured image source URL claimed before upload to prevent race conditions in concurrent jobs
+* Added: Regression test for upload failure cleanup
 
 = 2.17.1 =
 * Fix: Site Wizard re-execution now shows failed job error details instead of silently returning to form (#55)

--- a/tests/unit/services/post/PostGenerationOrchestratorTest.php
+++ b/tests/unit/services/post/PostGenerationOrchestratorTest.php
@@ -68,6 +68,11 @@ class PostGenerationOrchestratorTest extends TestCase
         // Simulate that first image is already used as featured image
         $this->mockUsedFeaturedImageUrls(['https://images.example.com/image-already-used.jpg']);
 
+        // Claim the URL before uploading
+        WP_Mock::userFunction('update_post_meta')
+            ->once()
+            ->with(1, '_contai_featured_image_source', 'https://images.example.com/image-unique.jpg');
+
         // Expect the unique (second) image to be uploaded
         $this->image_uploader
             ->shouldReceive('uploadFromUrl')
@@ -80,14 +85,10 @@ class PostGenerationOrchestratorTest extends TestCase
             ->once()
             ->with(1, 42);
 
-        WP_Mock::userFunction('update_post_meta')
-            ->once()
-            ->with(1, '_contai_featured_image_source', 'https://images.example.com/image-unique.jpg');
-
         $this->executeCreatePostFromApiResult($images);
     }
 
-    public function test_featured_image_falls_back_to_first_when_all_already_used(): void
+    public function test_featured_image_skipped_when_all_candidates_already_used(): void
     {
         $images = [
             ['url' => 'https://images.example.com/image-a.jpg'],
@@ -102,21 +103,9 @@ class PostGenerationOrchestratorTest extends TestCase
             'https://images.example.com/image-b.jpg',
         ]);
 
-        // Falls back to first image
-        $this->image_uploader
-            ->shouldReceive('uploadFromUrl')
-            ->once()
-            ->with('https://images.example.com/image-a.jpg')
-            ->andReturn(10);
-
-        $this->post_creator
-            ->shouldReceive('setFeaturedImage')
-            ->once()
-            ->with(1, 10);
-
-        WP_Mock::userFunction('update_post_meta')
-            ->once()
-            ->with(1, '_contai_featured_image_source', 'https://images.example.com/image-a.jpg');
+        // Should NOT attempt upload or set featured image — avoids duplication
+        $this->image_uploader->shouldNotReceive('uploadFromUrl');
+        $this->post_creator->shouldNotReceive('setFeaturedImage');
 
         $this->executeCreatePostFromApiResult($images);
     }
@@ -133,6 +122,11 @@ class PostGenerationOrchestratorTest extends TestCase
         // No images used yet
         $this->mockUsedFeaturedImageUrls([]);
 
+        // Claim the URL before uploading
+        WP_Mock::userFunction('update_post_meta')
+            ->once()
+            ->with(1, '_contai_featured_image_source', 'https://images.example.com/fresh-image.jpg');
+
         $this->image_uploader
             ->shouldReceive('uploadFromUrl')
             ->once()
@@ -144,9 +138,40 @@ class PostGenerationOrchestratorTest extends TestCase
             ->once()
             ->with(1, 5);
 
+        $this->executeCreatePostFromApiResult($images);
+    }
+
+    public function test_featured_image_claim_cleaned_up_on_upload_failure(): void
+    {
+        $images = [
+            ['url' => 'https://images.example.com/will-fail.jpg'],
+            ['url' => 'https://images.example.com/another.jpg'],
+        ];
+
+        $this->setupPostCreation();
+
+        // First image is unused
+        $this->mockUsedFeaturedImageUrls([]);
+
+        // Claim the URL before uploading
         WP_Mock::userFunction('update_post_meta')
             ->once()
-            ->with(1, '_contai_featured_image_source', 'https://images.example.com/fresh-image.jpg');
+            ->with(1, '_contai_featured_image_source', 'https://images.example.com/will-fail.jpg');
+
+        // Upload fails
+        $this->image_uploader
+            ->shouldReceive('uploadFromUrl')
+            ->once()
+            ->with('https://images.example.com/will-fail.jpg')
+            ->andReturn(null);
+
+        // Should NOT set featured image
+        $this->post_creator->shouldNotReceive('setFeaturedImage');
+
+        // Should clean up the claim
+        WP_Mock::userFunction('delete_post_meta')
+            ->once()
+            ->with(1, '_contai_featured_image_source');
 
         $this->executeCreatePostFromApiResult($images);
     }


### PR DESCRIPTION
## Summary
- Fixes featured image deduplication that still caused duplicates when all candidate images were already used
- Eliminates race condition window between dedup check and meta claim
- Adds regression test for upload failure cleanup

## Changes
- **`PostGenerationOrchestrator::selectUniqueImageUrl()`**: Returns `null` instead of falling back to `$images[0]['url']` when all candidates are exhausted — no featured image is better than a duplicate
- **`PostGenerationOrchestrator::setFeaturedImageIfExists()`**: Claims `_contai_featured_image_source` meta **before** the image upload (instead of after), closing the TOCTOU race window. Cleans up the claim if upload fails.
- **Tests**: Updated 3 existing tests for new claim-before-upload ordering. Added `test_featured_image_claim_cleaned_up_on_upload_failure` regression test.

## Root Cause
The v2.16.0 dedup implementation (commit 3fe342f) had a fallback in `selectUniqueImageUrl()` that returned `$images[0]['url']` when all candidate images were already used. In batch site generation, the API returns overlapping image sets for similar keywords. Once all ~3-5 candidate images were used, every subsequent post got image #1 — guaranteeing the exact duplication the feature was supposed to prevent.

## Audit Results
- Provider name scan: PASS (no exposure in diff)
- Security: PASS (uses WordPress core `update_post_meta`/`delete_post_meta`)
- Tests: 500 tests, 826 assertions — all passing

## Test Plan
- [x] All 500 tests pass (826 assertions)
- [x] 5 featured image dedup tests cover: skip used, all-used skip, fresh site, empty images, upload failure cleanup
- [x] No regressions in existing test suites

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)