### PR TITLE
chore(publisuites): remove unused renderEmptyState method

### DIFF
--- a/1platform-content-ai.php
+++ b/1platform-content-ai.php
@@ -4,7 +4,7 @@
  * Plugin Name: 1Platform Content AI
  * Plugin URI: https://1platform.pro/
  * Description: SaaS client for AI-powered content generation, SEO optimization, and site management. All AI processing happens on 1Platform external servers. Includes free local tools: Table of Contents and Internal Links.
- * Version: 2.23.0
+ * Version: 2.23.1
  * Author: 1Platform
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -18,7 +18,7 @@
 
 if (!defined('ABSPATH')) exit;
 
-define('CONTAI_VERSION', '2.22.0');
+define('CONTAI_VERSION', '2.23.1');
 
 require_once plugin_dir_path(__FILE__) . 'includes/helpers/security.php';
 require_once plugin_dir_path(__FILE__) . 'includes/helpers/crypto.php';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Content AI are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.23.1] - 2026-04-07
+
+### Changed
+- **Dead code cleanup**: Removed unused `renderEmptyState()` method from OrdersSection — each tab already renders its own empty state inline
+
 ## [2.22.0] - 2026-04-07
 
 ### Added

--- a/includes/admin/apps/panels/publisuites/OrdersSection.php
+++ b/includes/admin/apps/panels/publisuites/OrdersSection.php
@@ -621,22 +621,6 @@ class ContaiPublisuitesOrdersSection
     }
 
     /* ------------------------------------------------------------------
-       Empty state (global — when no orders at all)
-       ------------------------------------------------------------------ */
-
-    private function renderEmptyState(): void
-    {
-        ?>
-        <div class="contai-ps-orders__empty">
-            <span class="dashicons dashicons-format-aside contai-ps-orders__empty-icon" aria-hidden="true"></span>
-            <p class="contai-ps-orders__empty-text">
-                <?php esc_html_e('No sponsored post orders yet. Orders will appear here once they are available in the marketplace.', '1platform-content-ai'); ?>
-            </p>
-        </div>
-        <?php
-    }
-
-    /* ------------------------------------------------------------------
        Helpers
        ------------------------------------------------------------------ */
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai content, seo, content generation, internal links, table of contents
 Requires at least: 5.9
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.23.0
+Stable tag: 2.23.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Summary
- Remove dead code: `renderEmptyState()` method in OrdersSection was defined but never called
- Fix version constant mismatch: CONTAI_VERSION was 2.22.0 while plugin header and readme were at 2.23.0

## Changes
- **OrdersSection.php**: Removed unused `renderEmptyState()` method (16 lines). Each tab already renders its own empty state inline
- **Version bump**: 2.23.0 → 2.23.1 (patch) across all 3 locations, fixing the CONTAI_VERSION mismatch

## Test Plan
- [x] PHP syntax check passes
- [x] All 3 version locations synced (2.23.1)
- [x] No functional changes — dead code removal only

🤖 Generated with [Claude Code](https://claude.com/claude-code)