### PR TITLE
feat(site-generation): re-execution cleanup, legal page resilience, and menu management

### DIFF
--- a/1platform-content-ai.php
+++ b/1platform-content-ai.php
@@ -4,7 +4,7 @@
  * Plugin Name: 1Platform Content AI
  * Plugin URI: https://1platform.pro/
  * Description: SaaS client for AI-powered content generation, SEO optimization, and site management. All AI processing happens on 1Platform external servers. Includes free local tools: Table of Contents and Internal Links.
- * Version: 2.25.0
+ * Version: 2.26.0
  * Author: 1Platform
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -18,7 +18,7 @@
 
 if (!defined('ABSPATH')) exit;
 
-define('CONTAI_VERSION', '2.24.0');
+define('CONTAI_VERSION', '2.26.0');
 
 require_once plugin_dir_path(__FILE__) . 'includes/helpers/security.php';
 require_once plugin_dir_path(__FILE__) . 'includes/helpers/crypto.php';

--- a/1platform-content-ai.php
+++ b/1platform-content-ai.php
@@ -4,11 +4,7 @@
  * Plugin Name: 1Platform Content AI
  * Plugin URI: https://1platform.pro/
  * Description: SaaS client for AI-powered content generation, SEO optimization, and site management. All AI processing happens on 1Platform external servers. Includes free local tools: Table of Contents and Internal Links.
-<<<<<<< Updated upstream
  * Version: 2.26.0
-=======
- * Version: 2.10.2
->>>>>>> Stashed changes
  * Author: 1Platform
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/1platform-content-ai.php
+++ b/1platform-content-ai.php
@@ -4,7 +4,11 @@
  * Plugin Name: 1Platform Content AI
  * Plugin URI: https://1platform.pro/
  * Description: SaaS client for AI-powered content generation, SEO optimization, and site management. All AI processing happens on 1Platform external servers. Includes free local tools: Table of Contents and Internal Links.
+<<<<<<< Updated upstream
  * Version: 2.26.0
+=======
+ * Version: 2.10.2
+>>>>>>> Stashed changes
  * Author: 1Platform
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to Content AI are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.26.0] - 2026-04-07
+
+### Added
+- **Site generation re-execution**: Detect re-execution via `contai_site_generation_completed` option flag, clean previous AI-generated categories and orphaned batch options before re-extracting keywords
+- **Legal page resilience**: Restore trashed legal pages automatically, ensure all 5 required pages (privacy, cookies, legal, about, contact) exist with fallback content if the API omits them
+- **Menu management**: New `MainMenuManager` service to clean orphaned page and category menu items during re-execution
+- **Image deduplication**: Exclude already-used featured image URLs from content generation requests to avoid repeated images across posts
+- **Site generator form refactor**: Inline notice pattern replaces URL-based error messages, form values preserved on error via transient, explicit action attribute and nonce field
+
+### Changed
+- **QueueManager**: Skip keywords that already have generated posts to avoid duplicates on re-execution, mark them as `done`
+- **Cookie notice**: Resolve privacy policy link dynamically from `_contai_legal_key` meta instead of hardcoded slug
+- **Footer menu assignment**: Pattern-match footer location across themes instead of checking a fixed list of location slugs
+
 ## [2.24.0] - 2026-04-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ All notable changes to Content AI are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-<<<<<<< Updated upstream
 ## [2.26.0] - 2026-04-07
 
 ### Added
@@ -311,8 +310,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`CategoryAPIServiceGetActiveCategoriesTest`**: 9 unit tests for `getActiveCategories()` covering API success, auth failure, cache hit, force refresh, inactive categories, non-array data, reindexing, and no-cache-on-failure
 - **`SiteGeneratorPayloadNoLicenseKeyTest`**: 3 unit tests verifying the job payload contains no sensitive data
 
-=======
->>>>>>> Stashed changes
 ## [2.10.2] - 2026-03-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to Content AI are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+<<<<<<< Updated upstream
 ## [2.26.0] - 2026-04-07
 
 ### Added
@@ -310,6 +311,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`CategoryAPIServiceGetActiveCategoriesTest`**: 9 unit tests for `getActiveCategories()` covering API success, auth failure, cache hit, force refresh, inactive categories, non-array data, reindexing, and no-cache-on-failure
 - **`SiteGeneratorPayloadNoLicenseKeyTest`**: 3 unit tests verifying the job payload contains no sensitive data
 
+=======
+>>>>>>> Stashed changes
 ## [2.10.2] - 2026-03-25
 
 ### Fixed

--- a/includes/admin/admin-ai-site-generator.php
+++ b/includes/admin/admin-ai-site-generator.php
@@ -38,20 +38,17 @@ function contai_handle_ai_site_generator_submission() {
 		return;
 	}
 
-	$redirect_url = admin_url( 'admin.php?page=contai-ai-site-generator' );
-
-	// Verify nonce — redirect with error instead of wp_die() to avoid silent refresh (#54)
+	// Verify nonce — show inline error instead of redirecting to avoid silent refresh (#54)
 	$nonce_value = isset( $_POST['contai_site_generator_nonce'] )
 		? sanitize_key( wp_unslash( $_POST['contai_site_generator_nonce'] ) )
 		: '';
 
 	if ( ! wp_verify_nonce( $nonce_value, 'contai_site_generator_nonce' ) ) {
-		set_transient( 'contai_site_gen_notice', array(
+		$GLOBALS['contai_site_gen_inline_notice'] = array(
 			'type'    => 'error',
 			'message' => __( 'Your session has expired. Please reload the page and try again.', '1platform-content-ai' ),
-		), 30 );
-		wp_safe_redirect( $redirect_url );
-		exit;
+		);
+		return;
 	}
 
 	if ( ! current_user_can( 'manage_options' ) ) {
@@ -59,36 +56,38 @@ function contai_handle_ai_site_generator_submission() {
 	}
 
 	try {
-		contai_process_site_generation_submission( $redirect_url );
+		$error = contai_process_site_generation_submission();
+		if ( $error ) {
+			$GLOBALS['contai_site_gen_inline_notice'] = $error;
+			return;
+		}
 	} catch ( \Throwable $e ) {
 		contai_log( 'Site generation submission failed: ' . $e->getMessage() ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
-		set_transient( 'contai_site_gen_notice', array(
+		$GLOBALS['contai_site_gen_inline_notice'] = array(
 			'type'    => 'error',
 			'message' => __( 'An unexpected error occurred while starting site generation. Please try again.', '1platform-content-ai' ),
-		), 30 );
-		wp_safe_redirect( $redirect_url );
-		exit;
+		);
+		return;
 	}
 }
 
 /**
  * Process the site generation form submission.
  *
- * Extracted from the handler to enable try/catch wrapping.
- * All validation errors redirect with a transient notice (#54).
+ * Returns an error array on validation failure (displayed inline without
+ * redirect so the user keeps their form data). Returns null on success
+ * and redirects to show the progress panel (#54).
  *
- * @param string $redirect_url The URL to redirect to after processing.
+ * @return array|null Error notice array on failure, null on success (redirects).
  */
-function contai_process_site_generation_submission( string $redirect_url ) {
+function contai_process_site_generation_submission() {
 	// Validate that category is configured
 	$site_category = sanitize_text_field( wp_unslash( $_POST['contai_site_category'] ?? '' ) );
 	if ( empty( $site_category ) ) {
-		set_transient( 'contai_site_gen_notice', array(
+		return array(
 			'type'    => 'error',
 			'message' => __( 'Please select a category before starting the site generation process.', '1platform-content-ai' ),
-		), 30 );
-		wp_safe_redirect( $redirect_url );
-		exit;
+		);
 	}
 
 	// Validate credits before starting site generation
@@ -97,24 +96,20 @@ function contai_process_site_generation_submission( string $redirect_url ) {
 	$creditCheck = $creditGuard->validateCredits();
 
 	if ( ! $creditCheck['has_credits'] ) {
-		set_transient( 'contai_site_gen_notice', array(
+		return array(
 			'type'    => 'error',
 			'message' => $creditCheck['message'],
-		), 30 );
-		wp_safe_redirect( $redirect_url );
-		exit;
+		);
 	}
 
 	$jobRepository = new ContaiJobRepository();
 	$activeJob = $jobRepository->findActiveSiteGenerationJob();
 
 	if ( $activeJob ) {
-		set_transient( 'contai_site_gen_notice', array(
+		return array(
 			'type'    => 'error',
 			'message' => __( 'There is already an active site generation process running.', '1platform-content-ai' ),
-		), 30 );
-		wp_safe_redirect( $redirect_url );
-		exit;
+		);
 	}
 
 	$site_language = sanitize_text_field( wp_unslash( $_POST['contai_site_language'] ?? 'english' ) );
@@ -166,12 +161,10 @@ function contai_process_site_generation_submission( string $redirect_url ) {
 	$created = $jobRepository->create( $job );
 
 	if ( ! $created ) {
-		set_transient( 'contai_site_gen_notice', array(
+		return array(
 			'type'    => 'error',
 			'message' => __( 'Failed to start site generation process.', '1platform-content-ai' ),
-		), 30 );
-		wp_safe_redirect( $redirect_url );
-		exit;
+		);
 	}
 
 	// Save site configuration to options for use by other services
@@ -190,6 +183,8 @@ function contai_process_site_generation_submission( string $redirect_url ) {
 		}
 	}
 
+	// Success — redirect to show the progress panel
+	$redirect_url = admin_url( 'admin.php?page=contai-ai-site-generator' );
 	set_transient( 'contai_site_gen_notice', array(
 		'type'    => 'success',
 		'message' => __( 'Site generation process has been started successfully!', '1platform-content-ai' ),
@@ -208,10 +203,20 @@ function contai_ai_site_generator_page() {
 	$activeJob = $jobRepository->findActiveSiteGenerationJob();
 	$hasActiveJob = ! empty( $activeJob );
 
-	// Display transient-based notices (primary — survives redirects reliably)
-	$notice = get_transient( 'contai_site_gen_notice' );
-	if ( ! empty( $notice ) && is_array( $notice ) ) {
-		delete_transient( 'contai_site_gen_notice' );
+	// Display inline notice from current POST (no redirect needed — form data preserved)
+	$notice = $GLOBALS['contai_site_gen_inline_notice'] ?? null;
+
+	// Fallback: check transient (from success redirect)
+	if ( ! $notice ) {
+		$notice = get_transient( 'contai_site_gen_notice' );
+		if ( ! empty( $notice ) && is_array( $notice ) ) {
+			delete_transient( 'contai_site_gen_notice' );
+		} else {
+			$notice = null;
+		}
+	}
+
+	if ( $notice ) {
 		$type = in_array( $notice['type'], array( 'success', 'error', 'warning', 'info' ), true ) ? $notice['type'] : 'info';
 		$msg  = $notice['message'] ?? '';
 		if ( ! empty( $msg ) ) {

--- a/includes/admin/ai-site-generator/site-generator-form.php
+++ b/includes/admin/ai-site-generator/site-generator-form.php
@@ -15,6 +15,17 @@ function contai_render_full_site_generator_form() {
 	$site_domain    = wp_parse_url( home_url(), PHP_URL_HOST );
 	$default_email  = 'info@' . preg_replace( '/^www\./', '', $site_domain );
 
+	// Preserve form data on validation error (inline notice = POST was rejected)
+	// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Values are only used for re-display, not processing.
+	$has_post_data = ! empty( $GLOBALS['contai_site_gen_inline_notice'] ) && isset( $_POST['contai_start_site_generation'] );
+	$post = static function ( $key, $default = '' ) use ( $has_post_data ) {
+		if ( ! $has_post_data || ! isset( $_POST[ $key ] ) ) {
+			return $default;
+		}
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		return sanitize_text_field( wp_unslash( $_POST[ $key ] ) );
+	};
+
 	// Check credit balance for UI feedback
 	$creditGuard = new ContaiCreditGuard();
 	$creditCheck = $creditGuard->validateCredits();
@@ -92,7 +103,7 @@ function contai_render_full_site_generator_form() {
 						</label>
 						<div class="contai-input-wrap contai-input-icon">
 							<span class="dashicons dashicons-edit"></span>
-							<input type="text" id="contai_site_topic" name="contai_site_topic" class="contai-input" placeholder="<?php esc_attr_e( 'e.g., Indoor gardening, Personal finance, Pet care...', '1platform-content-ai' ); ?>" autocomplete="off" required>
+							<input type="text" id="contai_site_topic" name="contai_site_topic" class="contai-input" value="<?php echo esc_attr( $post( 'contai_site_topic' ) ); ?>" placeholder="<?php esc_attr_e( 'e.g., Indoor gardening, Personal finance, Pet care...', '1platform-content-ai' ); ?>" autocomplete="off" required>
 						</div>
 						<span class="contai-help-text"><?php esc_html_e( 'The main subject of your website', '1platform-content-ai' ); ?></span>
 					</div>
@@ -103,6 +114,10 @@ function contai_render_full_site_generator_form() {
 							<span class="contai-required">*</span>
 						</label>
 						<select id="contai_site_category" name="contai_site_category" class="contai-select" autocomplete="off" required data-lang-select="#contai_site_language">
+							<?php
+								$post_category = $post( 'contai_site_category' );
+								$selected_category = $post_category ?: $saved_category;
+								?>
 							<?php if ( empty( $categories ) ) : ?>
 								<option value=""><?php esc_html_e( 'No categories available', '1platform-content-ai' ); ?></option>
 							<?php else : ?>
@@ -113,7 +128,7 @@ function contai_render_full_site_generator_form() {
 									$title_en = esc_html( $category['title']['en'] ?? 'Unnamed Category' );
 									$title_es = esc_html( $category['title']['es'] ?? $title_en );
 									$category_theme = esc_attr( $category['recommended_theme'] ?? 'astra' );
-									$is_selected = ( $saved_category === $category_id );
+									$is_selected = ( $selected_category === $category_id );
 									?>
 									<option value="<?php echo esc_attr( $category_id ); ?>"<?php selected( $is_selected ); ?> data-title-en="<?php echo esc_attr( $title_en ); ?>" data-title-es="<?php echo esc_attr( $title_es ); ?>" data-theme="<?php echo esc_attr( $category_theme ); ?>">
 										<?php echo esc_html( $title_en ); ?>
@@ -129,9 +144,10 @@ function contai_render_full_site_generator_form() {
 							<?php esc_html_e( 'Language', '1platform-content-ai' ); ?>
 							<span class="contai-required">*</span>
 						</label>
+						<?php $post_language = $post( 'contai_site_language', 'english' ); ?>
 						<select id="contai_site_language" name="contai_site_language" class="contai-select" autocomplete="language" required data-category-select="#contai_site_category">
-							<option value="english" selected><?php esc_html_e( 'English', '1platform-content-ai' ); ?></option>
-							<option value="spanish"><?php esc_html_e( 'Spanish', '1platform-content-ai' ); ?></option>
+							<option value="english" <?php selected( $post_language, 'english' ); ?>><?php esc_html_e( 'English', '1platform-content-ai' ); ?></option>
+							<option value="spanish" <?php selected( $post_language, 'spanish' ); ?>><?php esc_html_e( 'Spanish', '1platform-content-ai' ); ?></option>
 						</select>
 					</div>
 
@@ -140,9 +156,10 @@ function contai_render_full_site_generator_form() {
 							<?php esc_html_e( 'Target Country', '1platform-content-ai' ); ?>
 							<span class="contai-required">*</span>
 						</label>
+						<?php $post_country = $post( 'contai_target_country', 'us' ); ?>
 						<select id="contai_target_country" name="contai_target_country" class="contai-select" autocomplete="country" required>
-							<option value="us" selected><?php esc_html_e( 'United States', '1platform-content-ai' ); ?></option>
-							<option value="es"><?php esc_html_e( 'Spain', '1platform-content-ai' ); ?></option>
+							<option value="us" <?php selected( $post_country, 'us' ); ?>><?php esc_html_e( 'United States', '1platform-content-ai' ); ?></option>
+							<option value="es" <?php selected( $post_country, 'es' ); ?>><?php esc_html_e( 'Spain', '1platform-content-ai' ); ?></option>
 						</select>
 					</div>
 
@@ -153,7 +170,7 @@ function contai_render_full_site_generator_form() {
 						</label>
 						<div class="contai-input-wrap contai-input-icon">
 							<span class="dashicons dashicons-money-alt"></span>
-							<input type="text" id="contai_adsense_publisher" name="contai_adsense_publisher" class="contai-input" placeholder="pub-1234567890123456" autocomplete="off" spellcheck="false" required>
+							<input type="text" id="contai_adsense_publisher" name="contai_adsense_publisher" class="contai-input" value="<?php echo esc_attr( $post( 'contai_adsense_publisher' ) ); ?>" placeholder="pub-1234567890123456" autocomplete="off" spellcheck="false" required>
 						</div>
 						<span class="contai-help-text"><?php esc_html_e( 'Account > Account information in AdSense', '1platform-content-ai' ); ?></span>
 					</div>
@@ -185,7 +202,7 @@ function contai_render_full_site_generator_form() {
 						</label>
 						<div class="contai-input-wrap contai-input-icon">
 							<span class="dashicons dashicons-businessperson"></span>
-							<input type="text" id="contai_legal_owner" name="contai_legal_owner" class="contai-input" placeholder="<?php esc_attr_e( 'John Doe', '1platform-content-ai' ); ?>" autocomplete="name" required>
+							<input type="text" id="contai_legal_owner" name="contai_legal_owner" class="contai-input" value="<?php echo esc_attr( $post( 'contai_legal_owner' ) ); ?>" placeholder="<?php esc_attr_e( 'John Doe', '1platform-content-ai' ); ?>" autocomplete="name" required>
 						</div>
 					</div>
 
@@ -196,7 +213,7 @@ function contai_render_full_site_generator_form() {
 						</label>
 						<div class="contai-input-wrap contai-input-icon">
 							<span class="dashicons dashicons-email"></span>
-							<input type="email" id="contai_legal_email" name="contai_legal_email" class="contai-input" value="<?php echo esc_attr( $default_email ); ?>" placeholder="<?php esc_attr_e( 'info@domain.com', '1platform-content-ai' ); ?>" autocomplete="email" spellcheck="false" required>
+							<input type="email" id="contai_legal_email" name="contai_legal_email" class="contai-input" value="<?php echo esc_attr( $post( 'contai_legal_email', $default_email ) ); ?>" placeholder="<?php esc_attr_e( 'info@domain.com', '1platform-content-ai' ); ?>" autocomplete="email" spellcheck="false" required>
 						</div>
 					</div>
 
@@ -207,7 +224,7 @@ function contai_render_full_site_generator_form() {
 						</label>
 						<div class="contai-input-wrap contai-input-icon">
 							<span class="dashicons dashicons-building"></span>
-							<input type="text" id="contai_legal_activity" name="contai_legal_activity" class="contai-input" placeholder="<?php esc_attr_e( 'e.g., Digital publishing', '1platform-content-ai' ); ?>" autocomplete="organization-title" required>
+							<input type="text" id="contai_legal_activity" name="contai_legal_activity" class="contai-input" value="<?php echo esc_attr( $post( 'contai_legal_activity' ) ); ?>" placeholder="<?php esc_attr_e( 'e.g., Digital publishing', '1platform-content-ai' ); ?>" autocomplete="organization-title" required>
 						</div>
 					</div>
 
@@ -218,7 +235,7 @@ function contai_render_full_site_generator_form() {
 						</label>
 						<div class="contai-input-wrap contai-input-icon">
 							<span class="dashicons dashicons-location"></span>
-							<input type="text" id="contai_legal_address" name="contai_legal_address" class="contai-input" placeholder="<?php esc_attr_e( '123 Main St, City, Country', '1platform-content-ai' ); ?>" autocomplete="street-address" required>
+							<input type="text" id="contai_legal_address" name="contai_legal_address" class="contai-input" value="<?php echo esc_attr( $post( 'contai_legal_address' ) ); ?>" placeholder="<?php esc_attr_e( '123 Main St, City, Country', '1platform-content-ai' ); ?>" autocomplete="street-address" required>
 						</div>
 					</div>
 				</div>
@@ -248,7 +265,7 @@ function contai_render_full_site_generator_form() {
 						</label>
 						<div class="contai-input-wrap contai-input-icon">
 							<span class="dashicons dashicons-search"></span>
-							<input type="text" id="contai_source_topic" name="contai_source_topic" class="contai-input" placeholder="<?php esc_attr_e( 'e.g., indoor plants care, home workout routines...', '1platform-content-ai' ); ?>" autocomplete="off" spellcheck="false" required>
+							<input type="text" id="contai_source_topic" name="contai_source_topic" class="contai-input" value="<?php echo esc_attr( $post( 'contai_source_topic' ) ); ?>" placeholder="<?php esc_attr_e( 'e.g., indoor plants care, home workout routines...', '1platform-content-ai' ); ?>" autocomplete="off" spellcheck="false" required>
 						</div>
 						<span class="contai-help-text"><?php esc_html_e( 'We\'ll research this topic to extract relevant keywords for your content.', '1platform-content-ai' ); ?></span>
 					</div>
@@ -258,7 +275,7 @@ function contai_render_full_site_generator_form() {
 							<?php esc_html_e( 'Number of Posts', '1platform-content-ai' ); ?>
 							<span class="contai-required">*</span>
 						</label>
-						<input type="number" id="contai_num_posts" name="contai_num_posts" class="contai-input" value="100" min="1" max="1000" autocomplete="off" required>
+						<input type="number" id="contai_num_posts" name="contai_num_posts" class="contai-input" value="<?php echo esc_attr( $post( 'contai_num_posts', '100' ) ); ?>" min="1" max="1000" autocomplete="off" required>
 					</div>
 
 					<div class="contai-form-group">
@@ -266,7 +283,7 @@ function contai_render_full_site_generator_form() {
 							<?php esc_html_e( 'Comments per Post', '1platform-content-ai' ); ?>
 							<span class="contai-required">*</span>
 						</label>
-						<input type="number" id="contai_comments_per_post" name="contai_comments_per_post" class="contai-input" value="1" min="1" max="10" autocomplete="off" required>
+						<input type="number" id="contai_comments_per_post" name="contai_comments_per_post" class="contai-input" value="<?php echo esc_attr( $post( 'contai_comments_per_post', '1' ) ); ?>" min="1" max="10" autocomplete="off" required>
 					</div>
 
 					<div class="contai-form-group">
@@ -274,9 +291,10 @@ function contai_render_full_site_generator_form() {
 							<?php esc_html_e( 'Image Source', '1platform-content-ai' ); ?>
 							<span class="contai-required">*</span>
 						</label>
+						<?php $post_image = $post( 'contai_image_provider', 'pexels' ); ?>
 						<select id="contai_image_provider" name="contai_image_provider" class="contai-select" autocomplete="off" required>
-							<option value="pexels" selected>Pexels</option>
-							<option value="pixabay">Pixabay</option>
+							<option value="pexels" <?php selected( $post_image, 'pexels' ); ?>><?php esc_html_e( 'Stock Photos (Free)', '1platform-content-ai' ); ?></option>
+							<option value="pixabay" <?php selected( $post_image, 'pixabay' ); ?>><?php esc_html_e( 'Stock Images (Free)', '1platform-content-ai' ); ?></option>
 						</select>
 					</div>
 				</div>

--- a/includes/admin/content-generator/helpers/cookie-notice-helper.php
+++ b/includes/admin/content-generator/helpers/cookie-notice-helper.php
@@ -38,7 +38,14 @@ class ContaiCookieNoticeHelper {
 
 		$language = get_option( 'contai_site_language', 'spanish' );
 		$text = get_option( 'contai_cookie_notice_text' );
-		$link = $language === 'english' ? '/privacy-policy/' : '/politica-de-privacidad/';
+		$privacy_page = get_posts( array(
+			'post_type'   => 'page',
+			'meta_key'    => '_contai_legal_key',
+			'meta_value'  => 'privacy-policy',
+			'post_status' => 'publish',
+			'numberposts' => 1,
+		) );
+		$link = ! empty( $privacy_page ) ? get_permalink( $privacy_page[0]->ID ) : ( $language === 'english' ? '/privacy-policy/' : '/politica-de-privacidad/' );
 		$accept_label = $language === 'english' ? 'Accept' : 'Estoy de acuerdo';
 		$reject_label = $language === 'english' ? 'Reject' : 'Rechazar';
 		$privacy_label = $language === 'english' ? 'Privacy Policy' : 'Política de privacidad';

--- a/includes/helpers/site-generation.php
+++ b/includes/helpers/site-generation.php
@@ -426,15 +426,39 @@ function contai_create_footer_menu_with_legal_pages(): void {
 		return;
 	}
 
-	// Fallback: try runtime-registered footer locations
-	$registered = get_registered_nav_menus();
-	foreach ( $footer_locations as $loc ) {
-		if ( isset( $registered[ $loc ] ) ) {
-			$locations[ $loc ] = $menu_id;
-			set_theme_mod( 'nav_menu_locations', $locations );
-			return;
+	// Fallback: pattern-match footer location from registered nav menus
+	$registered       = get_registered_nav_menus();
+	$footer_patterns  = array( 'footer', 'bottom', 'secondary' );
+	$exclude_patterns = array( 'primary', 'main', 'header', 'top', 'mobile', 'social' );
+
+	foreach ( $registered as $location => $description ) {
+		$loc_lower  = strtolower( $location );
+		$desc_lower = strtolower( $description );
+
+		// Skip primary navigation locations
+		$is_excluded = false;
+		foreach ( $exclude_patterns as $exclude ) {
+			if ( strpos( $loc_lower, $exclude ) !== false || strpos( $desc_lower, $exclude ) !== false ) {
+				$is_excluded = true;
+				break;
+			}
+		}
+		if ( $is_excluded ) {
+			continue;
+		}
+
+		// Match footer patterns
+		foreach ( $footer_patterns as $pattern ) {
+			if ( strpos( $loc_lower, $pattern ) !== false || strpos( $desc_lower, $pattern ) !== false ) {
+				$locations[ $location ] = $menu_id;
+				set_theme_mod( 'nav_menu_locations', $locations );
+				error_log( "[ContAI] Footer menu assigned to '{$location}' via pattern match for theme '{$theme}'" );
+				return;
+			}
 		}
 	}
+
+	error_log( "[ContAI] WARNING: No footer location found for theme '{$theme}'. Registered menus: " . implode( ', ', array_keys( $registered ) ) );
 }
 
 /**

--- a/includes/services/content/ContentGeneratorService.php
+++ b/includes/services/content/ContentGeneratorService.php
@@ -135,6 +135,11 @@ class ContaiContentGeneratorService {
             $request_data['categories'] = array_map('sanitize_text_field', $categories);
         }
 
+        $used_urls = $this->getUsedFeaturedImageUrls();
+        if (!empty($used_urls)) {
+            $request_data['exclude_image_urls'] = array_values($used_urls);
+        }
+
         return $request_data;
     }
 
@@ -175,6 +180,17 @@ class ContaiContentGeneratorService {
         return is_array($data)
             && isset($data['title'])
             && isset($data['content']);
+    }
+
+    private function getUsedFeaturedImageUrls(): array {
+        global $wpdb;
+
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+        $results = $wpdb->get_col(
+            "SELECT DISTINCT meta_value FROM {$wpdb->postmeta} WHERE meta_key = '_contai_featured_image_source' AND meta_value != ''"
+        );
+
+        return is_array($results) ? $results : [];
     }
 }
 

--- a/includes/services/jobs/QueueManager.php
+++ b/includes/services/jobs/QueueManager.php
@@ -134,6 +134,25 @@ class ContaiQueueManager
             return $b->getVolume() - $a->getVolume();
         });
 
-        return $availableKeywords[0];
+        // Skip keywords that already have generated posts (re-execution deduplication)
+        foreach ($availableKeywords as $keyword) {
+            $existing_post = get_posts([
+                'meta_key'    => '_1platform_keyword',
+                'meta_value'  => $keyword->getKeyword(),
+                'post_type'   => 'post',
+                'post_status' => ['publish', 'draft'],
+                'numberposts' => 1,
+            ]);
+
+            if (empty($existing_post)) {
+                return $keyword;
+            }
+
+            // Mark keyword as done so it's not re-checked
+            $this->keywordRepository->updateStatus($keyword->getId(), 'done');
+            error_log("[ContAI] Keyword '{$keyword->getKeyword()}' already has a post — marked as done");
+        }
+
+        return null;
     }
 }

--- a/includes/services/jobs/SiteGenerationJob.php
+++ b/includes/services/jobs/SiteGenerationJob.php
@@ -126,6 +126,7 @@ class ContaiSiteGenerationJob implements ContaiJobInterface
                 break;
 
             case 'extractKeywords':
+                $this->cleanPreviousDataIfReExecution();
                 $this->extractKeywords($config['keyword_extraction']);
                 break;
 
@@ -168,6 +169,7 @@ class ContaiSiteGenerationJob implements ContaiJobInterface
                 } catch (Exception $e) {
                     contai_log("Optional step 'setupNavigation' failed: " . $e->getMessage()); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
                 }
+                update_option('contai_site_generation_completed', true);
                 break;
         }
         return $payload;
@@ -252,6 +254,55 @@ class ContaiSiteGenerationJob implements ContaiJobInterface
             // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
             throw new Exception('Website generation failed: ' . implode(', ', $result['errors']));
         }
+    }
+
+    private function isReExecution(): bool
+    {
+        return (bool) get_option('contai_site_generation_completed', false);
+    }
+
+    private function cleanPreviousDataIfReExecution(): void
+    {
+        if (!$this->isReExecution()) {
+            return;
+        }
+
+        error_log('[ContAI] Re-execution detected — cleaning previous data');
+
+        // Clean categories where ALL posts are wizard-generated
+        $categories = get_categories([
+            'hide_empty' => false,
+            'exclude'    => [get_option('default_category')],
+        ]);
+
+        foreach ($categories as $category) {
+            $total_posts = $category->count;
+            if ($total_posts === 0) {
+                wp_delete_term($category->term_id, 'category');
+                continue;
+            }
+
+            $contai_posts = get_posts([
+                'category'    => $category->term_id,
+                'meta_key'    => '_1platform_ai_generated',
+                'meta_value'  => '1',
+                'numberposts' => -1,
+                'fields'      => 'ids',
+            ]);
+
+            if (count($contai_posts) === $total_posts) {
+                wp_delete_term($category->term_id, 'category');
+            }
+        }
+
+        // Clean orphaned batch options
+        global $wpdb;
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+        $wpdb->query(
+            "DELETE FROM {$wpdb->options} WHERE option_name LIKE 'contai\_batch\_%'"
+        );
+
+        error_log('[ContAI] Re-execution cleanup completed');
     }
 
     private function extractKeywords(array $extractionConfig): void

--- a/includes/services/legal/LegalPagesGenerator.php
+++ b/includes/services/legal/LegalPagesGenerator.php
@@ -13,6 +13,15 @@ class ContaiLegalPagesGenerator
     private const META_GENERATED_AT = '_contai_legal_generated_at';
     private const SOURCE_VALUE = 'contai_api';
 
+    // Keys match API response from legal_page_service.py / legal_pages.py
+    private const REQUIRED_LEGAL_KEYS = [
+        'privacy-policy' => ['es' => 'Politica de Privacidad', 'en' => 'Privacy Policy'],
+        'cookie-policy'  => ['es' => 'Politica de Cookies',    'en' => 'Cookie Policy'],
+        'legal-policy'   => ['es' => 'Aviso Legal',            'en' => 'Legal Notice'],
+        'about-me'       => ['es' => 'Sobre mi',               'en' => 'About Me'],
+        'contact'        => ['es' => 'Contacto',               'en' => 'Contact'],
+    ];
+
     private ContaiLegalPagesAPIClient $apiClient;
     private ContaiLegalInfoService $legalInfoService;
 
@@ -73,6 +82,8 @@ class ContaiLegalPagesGenerator
             $this->processPage($key, $pageData, $slugMap, $lang, $result);
         }
 
+        $this->ensureRequiredLegalPages($lang, $result);
+
         $result['success'] = ($result['created'] > 0 && empty($result['errors']));
 
         return $result;
@@ -100,6 +111,20 @@ class ContaiLegalPagesGenerator
         }
 
         $existingPage = get_page_by_path($slug);
+        if (!$existingPage) {
+            // Check if page exists in trash
+            $trashed = get_posts([
+                'post_type'   => 'page',
+                'name'        => $slug,
+                'post_status' => 'trash',
+                'numberposts' => 1,
+            ]);
+            if (!empty($trashed)) {
+                wp_untrash_post($trashed[0]->ID);
+                $existingPage = $trashed[0];
+                error_log("[ContAI] Legal page '{$key}' restored from trash (slug: {$slug})");
+            }
+        }
         if ($existingPage) {
             $result['warnings'][] = sprintf(
                 /* translators: %1$s: page title, %2$s: page slug */
@@ -140,5 +165,101 @@ class ContaiLegalPagesGenerator
             __('Page "%s" created successfully.', '1platform-content-ai'),
             esc_html($title)
         );
+    }
+
+    private function ensureRequiredLegalPages(string $lang, array &$result): void
+    {
+        $lang_key = ($lang === 'es' || $lang === 'spanish') ? 'es' : 'en';
+
+        foreach (self::REQUIRED_LEGAL_KEYS as $key => $titles) {
+            // Look up by meta key (reliable regardless of slug)
+            $existing = get_posts([
+                'post_type'   => 'page',
+                'meta_key'    => self::META_KEY,
+                'meta_value'  => $key,
+                'post_status' => ['publish', 'draft', 'trash'],
+                'numberposts' => 1,
+            ]);
+
+            if (!empty($existing)) {
+                if ($existing[0]->post_status === 'trash') {
+                    wp_untrash_post($existing[0]->ID);
+                    error_log("[ContAI] Legal page '{$key}' was in trash — restored");
+                }
+                continue;
+            }
+
+            $title = $titles[$lang_key];
+            $slug = sanitize_title($title);
+
+            $post_id = wp_insert_post([
+                'post_title'   => sanitize_text_field($title),
+                'post_name'    => $slug,
+                'post_content' => $this->generateFallbackContent($key, $title),
+                'post_status'  => 'publish',
+                'post_type'    => 'page',
+            ]);
+
+            if ($post_id && !is_wp_error($post_id)) {
+                update_post_meta($post_id, self::META_SOURCE, self::SOURCE_VALUE);
+                update_post_meta($post_id, self::META_KEY, sanitize_text_field($key));
+                update_post_meta($post_id, self::META_LANG, sanitize_text_field($lang));
+                update_post_meta($post_id, self::META_GENERATED_AT, current_time('mysql'));
+
+                $result['created']++;
+                $result['messages'][] = sprintf(
+                    __('Legal page "%s" was missing — created fallback.', '1platform-content-ai'),
+                    esc_html($title)
+                );
+                error_log("[ContAI] Legal page '{$key}' was missing — created fallback (post_id: {$post_id})");
+            }
+        }
+    }
+
+    private function generateFallbackContent(string $key, string $title): string
+    {
+        $owner = sanitize_text_field(get_option('contai_legal_owner', ''));
+        $email = sanitize_email(get_option('contai_legal_email', ''));
+
+        $content = '<h1>' . esc_html($title) . '</h1>';
+
+        switch ($key) {
+            case 'cookie-policy':
+                $content .= '<p>' . esc_html__('This website uses cookies to ensure the best user experience.', '1platform-content-ai') . '</p>';
+                $content .= '<h2>' . esc_html__('What are cookies?', '1platform-content-ai') . '</h2>';
+                $content .= '<p>' . esc_html__('Cookies are small text files stored on your device when you visit a website.', '1platform-content-ai') . '</p>';
+                $content .= '<h2>' . esc_html__('Types of cookies we use', '1platform-content-ai') . '</h2>';
+                $content .= '<p>' . esc_html__('Necessary cookies: required for the website to function properly.', '1platform-content-ai') . '</p>';
+                $content .= '<p>' . esc_html__('Analytics cookies: help us understand how visitors interact with the website.', '1platform-content-ai') . '</p>';
+                $content .= '<h2>' . esc_html__('How to disable cookies', '1platform-content-ai') . '</h2>';
+                $content .= '<p>' . esc_html__('You can configure your browser to reject cookies. Please note that some features may not work correctly.', '1platform-content-ai') . '</p>';
+                break;
+
+            case 'privacy-policy':
+                $content .= '<p>' . sprintf(esc_html__('The owner of this website, %s, is committed to protecting your privacy.', '1platform-content-ai'), esc_html($owner)) . '</p>';
+                if ($email) {
+                    $content .= '<p>' . sprintf(esc_html__('Contact: %s', '1platform-content-ai'), esc_html($email)) . '</p>';
+                }
+                break;
+
+            case 'legal-policy':
+                $content .= '<p>' . sprintf(esc_html__('This website is owned by %s.', '1platform-content-ai'), esc_html($owner)) . '</p>';
+                if ($email) {
+                    $content .= '<p>' . sprintf(esc_html__('Contact: %s', '1platform-content-ai'), esc_html($email)) . '</p>';
+                }
+                break;
+
+            case 'contact':
+                if ($email) {
+                    $content .= '<p>' . sprintf(esc_html__('Email: %s', '1platform-content-ai'), esc_html($email)) . '</p>';
+                }
+                break;
+
+            case 'about-me':
+                $content .= '<p>' . sprintf(esc_html__('Welcome! This site is managed by %s.', '1platform-content-ai'), esc_html($owner)) . '</p>';
+                break;
+        }
+
+        return $content;
     }
 }

--- a/includes/services/menu/MainMenuManager.php
+++ b/includes/services/menu/MainMenuManager.php
@@ -19,6 +19,8 @@ class ContaiMainMenuManager {
         $menu_id = $this->getOrCreateMenu();
         $site_language = get_option('contai_site_language', 'spanish');
 
+        $this->removePageItems($menu_id);
+        $this->removeOrphanedCategoryItems($menu_id);
         $this->ensureHomeMenuItem($menu_id, $site_language);
         $this->addCategoryMenuItems($menu_id, $category_names);
     }
@@ -176,6 +178,35 @@ class ContaiMainMenuManager {
         }
 
         return false;
+    }
+
+    private function removePageItems(int $menu_id): void {
+        $menu_items = wp_get_nav_menu_items($menu_id);
+        if (!$menu_items) {
+            return;
+        }
+
+        foreach ($menu_items as $item) {
+            if ($item->type === 'post_type' && $item->object === 'page') {
+                wp_delete_post($item->ID, true);
+            }
+        }
+    }
+
+    private function removeOrphanedCategoryItems(int $menu_id): void {
+        $menu_items = wp_get_nav_menu_items($menu_id);
+        if (!$menu_items) {
+            return;
+        }
+
+        foreach ($menu_items as $item) {
+            if ($item->type === 'taxonomy' && $item->object === 'category') {
+                $category = get_category($item->object_id);
+                if (!$category || is_wp_error($category)) {
+                    wp_delete_post($item->ID, true);
+                }
+            }
+        }
     }
 
     private function addCategoryMenuItems(int $menu_id, array $category_names): void {

--- a/includes/services/post/PostGenerationOrchestrator.php
+++ b/includes/services/post/PostGenerationOrchestrator.php
@@ -224,6 +224,7 @@ class ContaiPostGenerationOrchestrator {
         }
 
         contai_log('All candidate featured images already used on this site, skipping featured image to avoid duplication');
+        error_log('[ContAI] All candidate featured images already used — post created without featured image');
         return null;
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai content, seo, content generation, internal links, table of contents
 Requires at least: 5.9
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.25.0
+Stable tag: 2.26.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,11 @@ Tags: ai content, seo, content generation, internal links, table of contents
 Requires at least: 5.9
 Tested up to: 6.9
 Requires PHP: 7.4
+<<<<<<< Updated upstream
 Stable tag: 2.26.0
+=======
+Stable tag: 2.10.2
+>>>>>>> Stashed changes
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,11 +4,7 @@ Tags: ai content, seo, content generation, internal links, table of contents
 Requires at least: 5.9
 Tested up to: 6.9
 Requires PHP: 7.4
-<<<<<<< Updated upstream
 Stable tag: 2.26.0
-=======
-Stable tag: 2.10.2
->>>>>>> Stashed changes
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -119,6 +119,7 @@ require_once __DIR__ . '/../includes/admin/content-generator/panels/post-mainten
 require_once __DIR__ . '/../includes/services/user-profile/UserProfileService.php';
 require_once __DIR__ . '/../includes/admin/licenses/WPContentAILicensePanel.php';
 
+<<<<<<< Updated upstream
 // ── Post Pipeline & Generation ─────────────────────────────────
 require_once __DIR__ . '/../includes/services/post/ImageUploader.php';
 require_once __DIR__ . '/../includes/services/post/ContentImageProcessor.php';
@@ -219,3 +220,7 @@ if (!function_exists('contai_activate_plugin')) {
         update_option('contai_plugin_version', CONTAI_VERSION, false);
     }
 }
+=======
+// ── Category API ────────────────────────────────────────────────
+require_once __DIR__ . '/../includes/services/category-api/CategoryAPIService.php';
+>>>>>>> Stashed changes

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -119,7 +119,6 @@ require_once __DIR__ . '/../includes/admin/content-generator/panels/post-mainten
 require_once __DIR__ . '/../includes/services/user-profile/UserProfileService.php';
 require_once __DIR__ . '/../includes/admin/licenses/WPContentAILicensePanel.php';
 
-<<<<<<< Updated upstream
 // ── Post Pipeline & Generation ─────────────────────────────────
 require_once __DIR__ . '/../includes/services/post/ImageUploader.php';
 require_once __DIR__ . '/../includes/services/post/ContentImageProcessor.php';
@@ -220,7 +219,3 @@ if (!function_exists('contai_activate_plugin')) {
         update_option('contai_plugin_version', CONTAI_VERSION, false);
     }
 }
-=======
-// ── Category API ────────────────────────────────────────────────
-require_once __DIR__ . '/../includes/services/category-api/CategoryAPIService.php';
->>>>>>> Stashed changes

--- a/tests/unit/admin/site-generator/SiteGeneratorSubmissionTest.php
+++ b/tests/unit/admin/site-generator/SiteGeneratorSubmissionTest.php
@@ -5,122 +5,580 @@ namespace ContAI\Tests\Unit\Admin\SiteGenerator;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Regression tests for the Site Wizard form submission handler.
+ * Tests for the Site Wizard form submission handler and form rendering.
  *
- * Validates the fix for GitHub issue #54: "Launch Site Generation"
- * refreshed the page silently without executing any action or
- * showing error/success feedback.
+ * Covers GitHub issue #54: "Launch Site Generation" refreshed the page
+ * silently without executing any action or showing error/success feedback.
  *
- * Root cause: The handler had no try/catch, no error logging, used
- * wp_die() for nonce failures (which is swallowed on production sites
- * with display_errors off), and relied on URL parameters for error
- * messages (fragile when wp_safe_redirect fails due to headers already sent).
+ * The fix replaced redirect-on-error with inline error display via
+ * $GLOBALS['contai_site_gen_inline_notice'], preserving form data on
+ * validation failures. Only the success path redirects.
  *
- * Fix: Switched to transient-based notices, graceful nonce handling,
- * explicit form action, and try/catch around the processing logic.
+ * Tests are organized by branch coverage:
+ * - Handler branches (nonce fail, capability, error return, exception)
+ * - Processing branches (category, credits, active job, job creation, success)
+ * - Page renderer (inline notice priority, transient fallback)
+ * - Form (POST data preservation, provider masking, escaping)
  */
 class SiteGeneratorSubmissionTest extends TestCase
 {
     private string $handlerFile;
     private string $formFile;
+    private string $handlerContent;
+    private string $formContent;
 
     public function setUp(): void
     {
         parent::setUp();
         $this->handlerFile = dirname(__DIR__, 4) . '/includes/admin/admin-ai-site-generator.php';
         $this->formFile = dirname(__DIR__, 4) . '/includes/admin/ai-site-generator/site-generator-form.php';
+        $this->handlerContent = file_get_contents($this->handlerFile);
+        $this->formContent = file_get_contents($this->formFile);
     }
 
-    public function test_form_has_explicit_action_attribute(): void
+    // ── Handler: Entry Guard ───────────────────────────────────────
+
+    public function test_handler_returns_early_when_no_post_data(): void
     {
-        $this->assertFileExists($this->formFile);
-        $content = file_get_contents($this->formFile);
-
+        // Branch: line 37 — if ( ! isset( $_POST['contai_start_site_generation'] ) )
         $this->assertStringContainsString(
-            'action="<?php echo esc_url( admin_url(',
-            $content,
-            'Form must have an explicit action attribute with admin_url() to prevent URL resolution issues (#54)'
+            "if ( ! isset( \$_POST['contai_start_site_generation'] ) )",
+            $this->handlerContent,
+            'Handler must check for POST submission marker before processing'
         );
+
+        // Must return immediately — no GLOBALS, no redirect
+        $earlyReturn = $this->extractBlock($this->handlerContent, "isset( \$_POST['contai_start_site_generation']", 'return;');
+        $this->assertNotNull($earlyReturn, 'Early return must follow POST check');
+        $this->assertStringNotContainsString('GLOBALS', $earlyReturn, 'Early return must not set any GLOBALS');
+        $this->assertStringNotContainsString('wp_safe_redirect', $earlyReturn, 'Early return must not redirect');
     }
 
-    public function test_handler_uses_transient_notices_not_url_params(): void
-    {
-        $content = file_get_contents($this->handlerFile);
-
-        $this->assertStringContainsString(
-            "set_transient( 'contai_site_gen_notice'",
-            $content,
-            'Handler must use transient-based notices for reliable message delivery (#54)'
-        );
-    }
-
-    public function test_handler_has_try_catch_around_processing(): void
-    {
-        $content = file_get_contents($this->handlerFile);
-
-        $this->assertStringContainsString(
-            'catch ( \\Throwable $e )',
-            $content,
-            'Handler must catch Throwable to prevent silent failures on production (#54)'
-        );
-    }
+    // ── Handler: Nonce Verification ────────────────────────────────
 
     public function test_handler_uses_graceful_nonce_verification(): void
     {
-        $content = file_get_contents($this->handlerFile);
-
-        // Must use wp_verify_nonce (returns false) instead of check_admin_referer (calls wp_die)
         $this->assertStringContainsString(
             'wp_verify_nonce(',
-            $content,
+            $this->handlerContent,
             'Handler must use wp_verify_nonce() for graceful nonce verification (#54)'
         );
 
-        // check_admin_referer should NOT be used (it wp_die()s on failure)
         $this->assertStringNotContainsString(
             'check_admin_referer(',
-            $content,
+            $this->handlerContent,
             'Handler must NOT use check_admin_referer() which wp_die()s silently (#54)'
         );
     }
 
-    public function test_page_render_reads_transient_notices(): void
+    public function test_nonce_failure_sets_inline_notice_not_redirect(): void
     {
-        $content = file_get_contents($this->handlerFile);
+        // Branch: line 46 — if ( ! wp_verify_nonce(...) )
+        $nonceBlock = $this->extractBlock($this->handlerContent, '! wp_verify_nonce(', "return;\n\t}");
+        $this->assertNotNull($nonceBlock, 'Nonce failure block must exist');
 
         $this->assertStringContainsString(
-            "get_transient( 'contai_site_gen_notice' )",
-            $content,
-            'Page render must read transient notices for display (#54)'
+            "GLOBALS['contai_site_gen_inline_notice']",
+            $nonceBlock,
+            'Nonce failure must set inline notice (#54)'
+        );
+
+        $this->assertStringNotContainsString(
+            'wp_safe_redirect',
+            $nonceBlock,
+            'Nonce failure must NOT redirect — error shown inline (#54)'
+        );
+
+        $this->assertStringNotContainsString(
+            'set_transient',
+            $nonceBlock,
+            'Nonce failure must NOT use transient — inline notice only (#54)'
+        );
+    }
+
+    public function test_nonce_failure_notice_has_correct_type(): void
+    {
+        $nonceBlock = $this->extractBlock($this->handlerContent, '! wp_verify_nonce(', "return;\n\t}");
+        $this->assertNotNull($nonceBlock, 'Nonce failure block must exist');
+        $this->assertStringContainsString("'type'    => 'error'", $nonceBlock);
+        $this->assertStringContainsString('session has expired', $nonceBlock);
+    }
+
+    // ── Handler: Capability Check ──────────────────────────────────
+
+    public function test_handler_checks_manage_options_capability(): void
+    {
+        $this->assertStringContainsString(
+            "current_user_can( 'manage_options' )",
+            $this->handlerContent,
+            'Handler must verify manage_options capability'
         );
 
         $this->assertStringContainsString(
+            'wp_die(',
+            $this->handlerContent,
+            'Capability failure must use wp_die()'
+        );
+    }
+
+    // ── Handler: Try/Catch + Error Return ──────────────────────────
+
+    public function test_handler_has_try_catch_around_processing(): void
+    {
+        $this->assertStringContainsString(
+            'catch ( \\Throwable $e )',
+            $this->handlerContent,
+            'Handler must catch Throwable to prevent silent failures on production (#54)'
+        );
+    }
+
+    public function test_handler_stores_processing_error_in_inline_notice(): void
+    {
+        // Branch: line 60 — if ( $error ) { $GLOBALS[...] = $error; return; }
+        $this->assertStringContainsString(
+            '$error = contai_process_site_generation_submission()',
+            $this->handlerContent,
+            'Handler must capture return value from processing function'
+        );
+
+        $this->assertStringContainsString(
+            "if ( \$error ) {\n\t\t\t\$GLOBALS['contai_site_gen_inline_notice'] = \$error;",
+            $this->handlerContent,
+            'Handler must set inline notice when processing returns error (#54)'
+        );
+    }
+
+    public function test_exception_handler_logs_and_sets_inline_notice(): void
+    {
+        // Branch: line 64-71 — catch block
+        $catchBlock = $this->extractBlock($this->handlerContent, 'catch ( \\Throwable $e )', 'return;');
+        $this->assertNotNull($catchBlock, 'Catch block must exist');
+
+        $this->assertStringContainsString(
+            'contai_log(',
+            $catchBlock,
+            'Exception handler must log the error for debugging (#54)'
+        );
+
+        $this->assertStringContainsString(
+            "GLOBALS['contai_site_gen_inline_notice']",
+            $catchBlock,
+            'Exception handler must set inline notice (#54)'
+        );
+
+        $this->assertStringNotContainsString(
+            'wp_safe_redirect',
+            $catchBlock,
+            'Exception handler must NOT redirect (#54)'
+        );
+    }
+
+    // ── Handler: No Redirect on Errors ─────────────────────────────
+
+    public function test_handler_never_redirects_in_error_paths(): void
+    {
+        // The handler function should NOT contain wp_safe_redirect at all
+        // Only the processing function redirects on success
+        $handlerFunc = $this->extractFunction($this->handlerContent, 'contai_handle_ai_site_generator_submission');
+        $this->assertNotNull($handlerFunc, 'Handler function must exist');
+
+        $this->assertStringNotContainsString(
+            'wp_safe_redirect',
+            $handlerFunc,
+            'Handler must never redirect — only processing function redirects on success (#54)'
+        );
+    }
+
+    // ── Processing: Validation Returns ─────────────────────────────
+
+    public function test_processing_function_signature_has_no_redirect_param(): void
+    {
+        $this->assertStringContainsString(
+            'function contai_process_site_generation_submission()',
+            $this->handlerContent,
+            'Processing function must accept no redirect_url param — errors are returned inline (#54)'
+        );
+    }
+
+    public function test_processing_returns_error_on_empty_category(): void
+    {
+        // Branch: line 86 — if ( empty( $site_category ) )
+        $this->assertReturnErrorPattern(
+            'empty( $site_category )',
+            'Please select a category',
+            'Empty category must return error array (#54)'
+        );
+    }
+
+    public function test_processing_returns_error_on_no_credits(): void
+    {
+        // Branch: line 98 — if ( ! $creditCheck['has_credits'] )
+        $this->assertReturnErrorPattern(
+            "! \$creditCheck['has_credits']",
+            "\$creditCheck['message']",
+            'Insufficient credits must return error array (#54)'
+        );
+    }
+
+    public function test_processing_returns_error_on_active_job(): void
+    {
+        // Branch: line 108 — if ( $activeJob )
+        $this->assertReturnErrorPattern(
+            '$activeJob',
+            'already an active site generation',
+            'Active job must return error array (#54)'
+        );
+    }
+
+    public function test_processing_returns_error_on_job_creation_failure(): void
+    {
+        // Branch: line 163 — if ( ! $created )
+        $this->assertReturnErrorPattern(
+            '! $created',
+            'Failed to start site generation',
+            'Job creation failure must return error array (#54)'
+        );
+    }
+
+    public function test_processing_error_returns_use_return_not_redirect(): void
+    {
+        $processingFunc = $this->extractFunction($this->handlerContent, 'contai_process_site_generation_submission');
+        $this->assertNotNull($processingFunc, 'Processing function must exist');
+
+        // Count error paths: should use 'return array(' not 'wp_safe_redirect'
+        $returnArrayCount = substr_count($processingFunc, 'return array(');
+        $this->assertGreaterThanOrEqual(4, $returnArrayCount,
+            'Processing function must have at least 4 error return paths (category, credits, active job, job creation)'
+        );
+
+        // Only ONE redirect (success path)
+        $redirectCount = substr_count($processingFunc, 'wp_safe_redirect');
+        $this->assertEquals(1, $redirectCount,
+            'Processing function must have exactly 1 redirect (success path only)'
+        );
+    }
+
+    // ── Processing: Success Path ───────────────────────────────────
+
+    public function test_processing_success_uses_transient_and_redirect(): void
+    {
+        $this->assertStringContainsString(
+            "set_transient( 'contai_site_gen_notice'",
+            $this->handlerContent,
+            'Success path must use transient for notice delivery (#54)'
+        );
+
+        // Verify success transient contains success type
+        $successBlock = $this->extractBlock($this->handlerContent, "// Success — redirect", 'exit;');
+        $this->assertNotNull($successBlock, 'Success block must exist');
+
+        $this->assertStringContainsString("'type'    => 'success'", $successBlock);
+        $this->assertStringContainsString('wp_safe_redirect', $successBlock);
+        $this->assertStringContainsString('exit;', $successBlock);
+    }
+
+    public function test_processing_saves_adsense_publisher_on_success(): void
+    {
+        $processingFunc = $this->extractFunction($this->handlerContent, 'contai_process_site_generation_submission');
+        $this->assertStringContainsString(
+            "update_option( 'contai_adsense_publishers'",
+            $processingFunc,
+            'Success path must save AdSense publisher ID (fixes #12)'
+        );
+        $this->assertStringContainsString(
+            '/^pub-\\d+$/',
+            $processingFunc,
+            'AdSense publisher ID must be validated with regex before saving'
+        );
+    }
+
+    // ── Page Renderer: Notice Priority ─────────────────────────────
+
+    public function test_page_renderer_checks_inline_notice_first(): void
+    {
+        $rendererFunc = $this->extractFunction($this->handlerContent, 'contai_ai_site_generator_page');
+        $this->assertNotNull($rendererFunc, 'Page renderer function must exist');
+
+        $inlinePos = strpos($rendererFunc, "GLOBALS['contai_site_gen_inline_notice']");
+        $transientPos = strpos($rendererFunc, "get_transient( 'contai_site_gen_notice' )");
+
+        $this->assertNotFalse($inlinePos, 'Page renderer must check inline notice');
+        $this->assertNotFalse($transientPos, 'Page renderer must check transient as fallback');
+        $this->assertLessThan(
+            $transientPos,
+            $inlinePos,
+            'Inline notice must be checked before transient fallback in page renderer (#54)'
+        );
+    }
+
+    public function test_page_renderer_deletes_transient_after_reading(): void
+    {
+        $rendererFunc = $this->extractFunction($this->handlerContent, 'contai_ai_site_generator_page');
+
+        $this->assertStringContainsString(
             "delete_transient( 'contai_site_gen_notice' )",
-            $content,
+            $rendererFunc,
             'Page render must delete transient after display to prevent stale notices (#54)'
         );
     }
 
-    public function test_handler_logs_errors_on_failure(): void
+    public function test_page_renderer_validates_notice_type(): void
     {
-        $content = file_get_contents($this->handlerFile);
+        $rendererFunc = $this->extractFunction($this->handlerContent, 'contai_ai_site_generator_page');
 
         $this->assertStringContainsString(
-            'contai_log(',
-            $content,
-            'Handler must log errors when processing fails for debugging (#54)'
+            "in_array( \$notice['type'], array( 'success', 'error', 'warning', 'info' ), true )",
+            $rendererFunc,
+            'Notice type must be validated against allowed values'
+        );
+    }
+
+    public function test_page_renderer_escapes_notice_output(): void
+    {
+        $rendererFunc = $this->extractFunction($this->handlerContent, 'contai_ai_site_generator_page');
+
+        $this->assertStringContainsString('esc_attr( $type )', $rendererFunc, 'Notice type must be escaped with esc_attr');
+        $this->assertStringContainsString('esc_html( $msg )', $rendererFunc, 'Notice message must be escaped with esc_html');
+    }
+
+    // ── Form: POST Data Preservation ───────────────────────────────
+
+    public function test_form_detects_post_data_via_inline_notice(): void
+    {
+        $this->assertStringContainsString(
+            "! empty( \$GLOBALS['contai_site_gen_inline_notice'] ) && isset( \$_POST['contai_start_site_generation'] )",
+            $this->formContent,
+            'Form must detect POST data availability by checking inline notice AND POST marker (#54)'
+        );
+    }
+
+    public function test_form_post_closure_sanitizes_values(): void
+    {
+        $this->assertStringContainsString(
+            'sanitize_text_field( wp_unslash( $_POST[ $key ] ) )',
+            $this->formContent,
+            'POST data closure must sanitize all values with sanitize_text_field + wp_unslash'
+        );
+    }
+
+    public function test_form_post_closure_returns_default_when_no_post(): void
+    {
+        // When $has_post_data is false, closure must return default
+        $this->assertStringContainsString(
+            "if ( ! \$has_post_data || ! isset( \$_POST[ \$key ] ) )",
+            $this->formContent,
+            'POST closure must check both data availability and key existence'
+        );
+
+        $this->assertStringContainsString(
+            'return $default;',
+            $this->formContent,
+            'POST closure must return default value when no POST data'
+        );
+    }
+
+    public function test_form_preserves_all_text_inputs_on_error(): void
+    {
+        $fields = [
+            'contai_site_topic',
+            'contai_legal_owner',
+            'contai_legal_email',
+            'contai_legal_activity',
+            'contai_legal_address',
+            'contai_source_topic',
+            'contai_adsense_publisher',
+            'contai_num_posts',
+            'contai_comments_per_post',
+        ];
+
+        foreach ($fields as $field) {
+            $this->assertStringContainsString(
+                "\$post( '{$field}'",
+                $this->formContent,
+                "Form field {$field} must use \$post() for value preservation on error (#54)"
+            );
+        }
+    }
+
+    public function test_form_preserves_select_values_on_error(): void
+    {
+        $selects = [
+            'contai_site_category'   => 'selected_category',
+            'contai_site_language'   => 'post_language',
+            'contai_target_country'  => 'post_country',
+            'contai_image_provider'  => 'post_image',
+        ];
+
+        foreach ($selects as $field => $_var) {
+            $this->assertStringContainsString(
+                "\$post( '{$field}'",
+                $this->formContent,
+                "Select field {$field} must use \$post() for POST data retrieval (#54)"
+            );
+        }
+    }
+
+    public function test_form_text_inputs_escape_with_esc_attr(): void
+    {
+        // Every $post() call in a value attribute must be wrapped with esc_attr()
+        preg_match_all('/value="<\?php echo esc_attr\( \$post\(/', $this->formContent, $matches);
+
+        $this->assertGreaterThanOrEqual(7, count($matches[0]),
+            'At least 7 text inputs must use esc_attr( $post(...) ) pattern for XSS prevention'
+        );
+    }
+
+    // ── Form: Provider Name Masking ────────────────────────────────
+
+    public function test_form_does_not_expose_provider_names_as_visible_text(): void
+    {
+        $this->assertStringNotContainsString(
+            '>Pexels<',
+            $this->formContent,
+            'Form must not expose Pexels provider name in visible text (CRITICAL RULE)'
+        );
+        $this->assertStringNotContainsString(
+            '>Pixabay<',
+            $this->formContent,
+            'Form must not expose Pixabay provider name in visible text (CRITICAL RULE)'
+        );
+    }
+
+    public function test_form_uses_generic_labels_for_image_providers(): void
+    {
+        $this->assertStringContainsString(
+            'Stock Photos (Free)',
+            $this->formContent,
+            'Pexels option must use generic label "Stock Photos (Free)"'
+        );
+        $this->assertStringContainsString(
+            'Stock Images (Free)',
+            $this->formContent,
+            'Pixabay option must use generic label "Stock Images (Free)"'
+        );
+    }
+
+    public function test_form_image_labels_are_translatable(): void
+    {
+        $this->assertStringContainsString(
+            "esc_html_e( 'Stock Photos (Free)'",
+            $this->formContent,
+            'Stock Photos label must be translatable via esc_html_e()'
+        );
+        $this->assertStringContainsString(
+            "esc_html_e( 'Stock Images (Free)'",
+            $this->formContent,
+            'Stock Images label must be translatable via esc_html_e()'
+        );
+    }
+
+    // ── Form: Security ─────────────────────────────────────────────
+
+    public function test_form_has_nonce_field(): void
+    {
+        $this->assertStringContainsString(
+            "wp_nonce_field( 'contai_site_generator_nonce', 'contai_site_generator_nonce' )",
+            $this->formContent,
+            'Form must include nonce field for CSRF protection'
+        );
+    }
+
+    public function test_form_has_explicit_action_attribute(): void
+    {
+        $this->assertStringContainsString(
+            'action="<?php echo esc_url( admin_url(',
+            $this->formContent,
+            'Form must have an explicit action attribute with admin_url() to prevent URL resolution issues (#54)'
+        );
+    }
+
+    public function test_form_has_hidden_submission_marker(): void
+    {
+        $this->assertStringContainsString(
+            'name="contai_start_site_generation" value="1"',
+            $this->formContent,
+            'Form must include hidden field for handler detection'
+        );
+    }
+
+    // ── Structural Integrity ───────────────────────────────────────
+
+    public function test_handler_registered_on_admin_init(): void
+    {
+        $this->assertStringContainsString(
+            "add_action( 'admin_init', 'contai_handle_ai_site_generator_submission' )",
+            $this->handlerContent,
+            'Handler must be registered on admin_init hook'
         );
     }
 
     public function test_no_url_param_based_error_messages_in_handler(): void
     {
-        $content = file_get_contents($this->handlerFile);
-
-        // The old pattern of passing error messages via URL params is fragile
         $this->assertStringNotContainsString(
             "'error' => 1",
-            $content,
+            $this->handlerContent,
             'Handler should not use URL params for error messages — use transients (#54)'
         );
+    }
+
+    // ── Helper Methods ─────────────────────────────────────────────
+
+    /**
+     * Extract a code block between two markers.
+     */
+    private function extractBlock(string $content, string $startMarker, string $endMarker): ?string
+    {
+        $startPos = strpos($content, $startMarker);
+        if ($startPos === false) {
+            return null;
+        }
+        $endPos = strpos($content, $endMarker, $startPos);
+        if ($endPos === false) {
+            return null;
+        }
+        return substr($content, $startPos, $endPos - $startPos + strlen($endMarker));
+    }
+
+    /**
+     * Extract a function body from source code.
+     */
+    private function extractFunction(string $content, string $funcName): ?string
+    {
+        $pattern = '/function\s+' . preg_quote($funcName, '/') . '\s*\([^)]*\)\s*\{/';
+        if (!preg_match($pattern, $content, $matches, PREG_OFFSET_CAPTURE)) {
+            return null;
+        }
+        $startPos = $matches[0][1];
+        $braceCount = 0;
+        $len = strlen($content);
+        $started = false;
+
+        for ($i = $startPos; $i < $len; $i++) {
+            if ($content[$i] === '{') {
+                $braceCount++;
+                $started = true;
+            } elseif ($content[$i] === '}') {
+                $braceCount--;
+                if ($started && $braceCount === 0) {
+                    return substr($content, $startPos, $i - $startPos + 1);
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Assert that a condition triggers a return array('type' => 'error') pattern.
+     */
+    private function assertReturnErrorPattern(string $condition, string $_messageHint, string $description): void
+    {
+        $condPos = strpos($this->handlerContent, $condition);
+        $this->assertNotFalse($condPos, "Condition '{$condition}' must exist in handler");
+
+        $returnPos = strpos($this->handlerContent, 'return array(', $condPos);
+        $this->assertNotFalse($returnPos, "Return array must follow condition: {$description}");
+
+        $block = substr($this->handlerContent, $returnPos, 200);
+        $this->assertStringContainsString("'type'    => 'error'", $block, $description);
     }
 }

--- a/tests/unit/services/jobs/QueueManagerTest.php
+++ b/tests/unit/services/jobs/QueueManagerTest.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace ContAI\Tests\Unit\Services\Jobs;
+
+use WP_Mock;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use ContaiQueueManager;
+use ContaiJobRepository;
+use ContaiKeywordRepository;
+use ContaiKeyword;
+use ContaiJob;
+use ContaiDatabase;
+
+class QueueManagerTest extends TestCase
+{
+    private $jobRepository;
+    private $keywordRepository;
+    private ContaiQueueManager $queueManager;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        WP_Mock::setUp();
+
+        // Reset ContaiDatabase singleton so constructor can access $wpdb
+        $dbRef = new \ReflectionClass(ContaiDatabase::class);
+        $instanceProp = $dbRef->getProperty('instance');
+        $instanceProp->setAccessible(true);
+        $instanceProp->setValue(null, null);
+
+        // Set up global $wpdb mock to satisfy ContaiDatabase constructor
+        global $wpdb;
+        $wpdb = Mockery::mock('wpdb');
+        $wpdb->prefix = 'wp_';
+
+        $this->jobRepository = Mockery::mock(ContaiJobRepository::class);
+        $this->keywordRepository = Mockery::mock(ContaiKeywordRepository::class);
+
+        $this->queueManager = new ContaiQueueManager();
+
+        // Inject mocked repositories via reflection
+        $ref = new \ReflectionClass($this->queueManager);
+
+        $jobRepoProp = $ref->getProperty('jobRepository');
+        $jobRepoProp->setAccessible(true);
+        $jobRepoProp->setValue($this->queueManager, $this->jobRepository);
+
+        $kwRepoProp = $ref->getProperty('keywordRepository');
+        $kwRepoProp->setAccessible(true);
+        $kwRepoProp->setValue($this->queueManager, $this->keywordRepository);
+    }
+
+    public function tearDown(): void
+    {
+        $this->addToAssertionCount(Mockery::getContainer()->mockery_getExpectationCount());
+        WP_Mock::tearDown();
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    // ── Keyword dedup via enqueuePostGeneration ───────────────────
+
+    public function test_enqueue_skips_keyword_with_existing_post_and_marks_done(): void
+    {
+        $keyword1 = Mockery::mock(ContaiKeyword::class);
+        $keyword1->shouldReceive('getId')->andReturn(1);
+        $keyword1->shouldReceive('getKeyword')->andReturn('existing topic');
+        $keyword1->shouldReceive('getVolume')->andReturn(500);
+
+        $keyword2 = Mockery::mock(ContaiKeyword::class);
+        $keyword2->shouldReceive('getId')->andReturn(2);
+        $keyword2->shouldReceive('getKeyword')->andReturn('new topic');
+        $keyword2->shouldReceive('getVolume')->andReturn(300);
+
+        $this->jobRepository
+            ->shouldReceive('getActiveJobKeywordIds')
+            ->andReturn([]);
+
+        // First call returns both; second call returns empty (all consumed)
+        $this->keywordRepository
+            ->shouldReceive('findByStatus')
+            ->with('pending', 100)
+            ->andReturn([$keyword1, $keyword2], []);
+
+        // keyword1 has an existing post
+        WP_Mock::userFunction('get_posts')
+            ->andReturnUsing(function ($args) {
+                if ($args['meta_value'] === 'existing topic') {
+                    return [(object) ['ID' => 10]];
+                }
+                return [];
+            });
+
+        // keyword1 should be marked as done (dedup)
+        $this->keywordRepository
+            ->shouldReceive('updateStatus')
+            ->once()
+            ->with(1, 'done');
+
+        // ContaiJob::create needs current_time
+        WP_Mock::userFunction('current_time')
+            ->andReturn('2026-04-07 12:00:00');
+
+        // keyword2 has no existing post, so it gets enqueued
+        $this->jobRepository
+            ->shouldReceive('create')
+            ->once()
+            ->andReturn(true);
+
+        $this->keywordRepository
+            ->shouldReceive('updateStatus')
+            ->once()
+            ->with(2, 'active');
+
+        // contai_trigger_immediate_job_processing calls these WP functions
+        WP_Mock::userFunction('wp_next_scheduled')
+            ->andReturn(true);
+        WP_Mock::userFunction('spawn_cron');
+
+        $result = $this->queueManager->enqueuePostGeneration(2);
+
+        $this->assertEquals(1, $result);
+    }
+
+    public function test_enqueue_returns_zero_when_all_keywords_have_existing_posts(): void
+    {
+        $keyword1 = Mockery::mock(ContaiKeyword::class);
+        $keyword1->shouldReceive('getId')->andReturn(1);
+        $keyword1->shouldReceive('getKeyword')->andReturn('topic a');
+        $keyword1->shouldReceive('getVolume')->andReturn(100);
+
+        $keyword2 = Mockery::mock(ContaiKeyword::class);
+        $keyword2->shouldReceive('getId')->andReturn(2);
+        $keyword2->shouldReceive('getKeyword')->andReturn('topic b');
+        $keyword2->shouldReceive('getVolume')->andReturn(200);
+
+        $this->jobRepository
+            ->shouldReceive('getActiveJobKeywordIds')
+            ->andReturn([]);
+
+        $this->keywordRepository
+            ->shouldReceive('findByStatus')
+            ->with('pending', 100)
+            ->andReturn([$keyword1, $keyword2]);
+
+        // Both keywords have existing posts
+        WP_Mock::userFunction('get_posts')
+            ->andReturn([(object) ['ID' => 99]]);
+
+        // Both should be marked done
+        $this->keywordRepository
+            ->shouldReceive('updateStatus')
+            ->with(Mockery::anyOf(1, 2), 'done')
+            ->twice();
+
+        $result = $this->queueManager->enqueuePostGeneration(2);
+
+        $this->assertEquals(0, $result);
+    }
+
+    public function test_enqueue_returns_zero_when_no_pending_keywords(): void
+    {
+        $this->jobRepository
+            ->shouldReceive('getActiveJobKeywordIds')
+            ->andReturn([]);
+
+        $this->keywordRepository
+            ->shouldReceive('findByStatus')
+            ->with('pending', 100)
+            ->andReturn([]);
+
+        $result = $this->queueManager->enqueuePostGeneration(1);
+
+        $this->assertEquals(0, $result);
+    }
+
+    public function test_enqueue_skips_keywords_with_active_jobs(): void
+    {
+        $keyword1 = Mockery::mock(ContaiKeyword::class);
+        $keyword1->shouldReceive('getId')->andReturn(1);
+
+        $keyword2 = Mockery::mock(ContaiKeyword::class);
+        $keyword2->shouldReceive('getId')->andReturn(2);
+        $keyword2->shouldReceive('getKeyword')->andReturn('available topic');
+        $keyword2->shouldReceive('getVolume')->andReturn(100);
+
+        $this->jobRepository
+            ->shouldReceive('getActiveJobKeywordIds')
+            ->andReturn([1]); // keyword1 already has an active job
+
+        // First call returns both; second call returns empty (all consumed)
+        $this->keywordRepository
+            ->shouldReceive('findByStatus')
+            ->with('pending', 100)
+            ->andReturn([$keyword1, $keyword2], []);
+
+        // keyword2 has no existing post
+        WP_Mock::userFunction('get_posts')
+            ->andReturn([]);
+
+        WP_Mock::userFunction('current_time')
+            ->andReturn('2026-04-07 12:00:00');
+
+        $this->jobRepository
+            ->shouldReceive('create')
+            ->once()
+            ->andReturn(true);
+
+        $this->keywordRepository
+            ->shouldReceive('updateStatus')
+            ->once()
+            ->with(2, 'active');
+
+        WP_Mock::userFunction('wp_next_scheduled')
+            ->andReturn(true);
+        WP_Mock::userFunction('spawn_cron');
+
+        $result = $this->queueManager->enqueuePostGeneration(2);
+
+        $this->assertEquals(1, $result);
+    }
+
+    public function test_enqueue_throws_on_invalid_count(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->queueManager->enqueuePostGeneration(0);
+    }
+}

--- a/tests/unit/services/jobs/SiteGenerationJobTest.php
+++ b/tests/unit/services/jobs/SiteGenerationJobTest.php
@@ -1,0 +1,244 @@
+<?php
+
+namespace ContAI\Tests\Unit\Services\Jobs;
+
+use WP_Mock;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use ContaiSiteGenerationJob;
+use ContaiJobRepository;
+use ContaiDatabase;
+
+class SiteGenerationJobTest extends TestCase
+{
+    private ContaiSiteGenerationJob $job;
+    private $jobRepository;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        WP_Mock::setUp();
+
+        // Reset ContaiDatabase singleton so constructor can access $wpdb
+        $dbRef = new \ReflectionClass(ContaiDatabase::class);
+        $instanceProp = $dbRef->getProperty('instance');
+        $instanceProp->setAccessible(true);
+        $instanceProp->setValue(null, null);
+
+        // Set up global $wpdb mock to satisfy ContaiDatabase constructor
+        global $wpdb;
+        $wpdb = Mockery::mock('wpdb');
+        $wpdb->prefix = 'wp_';
+        $wpdb->options = 'wp_options';
+
+        $this->job = new ContaiSiteGenerationJob();
+
+        // Inject mock repository via reflection
+        $this->jobRepository = Mockery::mock(ContaiJobRepository::class);
+        $ref = new \ReflectionClass($this->job);
+        $prop = $ref->getProperty('jobRepository');
+        $prop->setAccessible(true);
+        $prop->setValue($this->job, $this->jobRepository);
+    }
+
+    public function tearDown(): void
+    {
+        $this->addToAssertionCount(Mockery::getContainer()->mockery_getExpectationCount());
+        WP_Mock::tearDown();
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    // ── isReExecution direct tests ────────────────────────────────
+
+    public function test_isReExecution_returns_true_when_option_is_set(): void
+    {
+        WP_Mock::userFunction('get_option')
+            ->with('contai_site_generation_completed', false)
+            ->andReturn(true);
+
+        $ref = new \ReflectionClass($this->job);
+        $method = $ref->getMethod('isReExecution');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke($this->job));
+    }
+
+    public function test_isReExecution_returns_false_when_option_is_not_set(): void
+    {
+        WP_Mock::userFunction('get_option')
+            ->with('contai_site_generation_completed', false)
+            ->andReturn(false);
+
+        $ref = new \ReflectionClass($this->job);
+        $method = $ref->getMethod('isReExecution');
+        $method->setAccessible(true);
+
+        $this->assertFalse($method->invoke($this->job));
+    }
+
+    // ── cleanPreviousDataIfReExecution tests ──────────────────────
+
+    public function test_first_execution_does_not_clean_data(): void
+    {
+        WP_Mock::userFunction('get_option')
+            ->with('contai_site_generation_completed', false)
+            ->andReturn(false);
+
+        // get_categories should NOT be called since we return early
+        WP_Mock::userFunction('get_categories')
+            ->never();
+
+        $ref = new \ReflectionClass($this->job);
+        $method = $ref->getMethod('cleanPreviousDataIfReExecution');
+        $method->setAccessible(true);
+        $method->invoke($this->job);
+    }
+
+    public function test_re_execution_deletes_empty_categories(): void
+    {
+        WP_Mock::userFunction('get_option')
+            ->with('contai_site_generation_completed', false)
+            ->andReturn(true);
+
+        WP_Mock::userFunction('get_option')
+            ->with('default_category')
+            ->andReturn(1);
+
+        $emptyCategory = (object) [
+            'term_id' => 10,
+            'count' => 0,
+            'name' => 'Empty Cat',
+        ];
+
+        WP_Mock::userFunction('get_categories')
+            ->once()
+            ->andReturn([$emptyCategory]);
+
+        WP_Mock::userFunction('wp_delete_term')
+            ->once()
+            ->with(10, 'category');
+
+        // Batch options cleanup
+        global $wpdb;
+        $wpdb->shouldReceive('query')
+            ->once()
+            ->andReturn(0);
+
+        $ref = new \ReflectionClass($this->job);
+        $method = $ref->getMethod('cleanPreviousDataIfReExecution');
+        $method->setAccessible(true);
+        $method->invoke($this->job);
+    }
+
+    public function test_re_execution_deletes_category_when_all_posts_ai_generated(): void
+    {
+        WP_Mock::userFunction('get_option')
+            ->with('contai_site_generation_completed', false)
+            ->andReturn(true);
+
+        WP_Mock::userFunction('get_option')
+            ->with('default_category')
+            ->andReturn(1);
+
+        $aiCategory = (object) [
+            'term_id' => 20,
+            'count' => 3,
+            'name' => 'AI Category',
+        ];
+
+        WP_Mock::userFunction('get_categories')
+            ->once()
+            ->andReturn([$aiCategory]);
+
+        // All 3 posts are AI-generated
+        WP_Mock::userFunction('get_posts')
+            ->once()
+            ->andReturn([1, 2, 3]);
+
+        WP_Mock::userFunction('wp_delete_term')
+            ->once()
+            ->with(20, 'category');
+
+        global $wpdb;
+        $wpdb->shouldReceive('query')
+            ->once()
+            ->andReturn(0);
+
+        $ref = new \ReflectionClass($this->job);
+        $method = $ref->getMethod('cleanPreviousDataIfReExecution');
+        $method->setAccessible(true);
+        $method->invoke($this->job);
+    }
+
+    public function test_re_execution_keeps_category_with_mixed_posts(): void
+    {
+        WP_Mock::userFunction('get_option')
+            ->with('contai_site_generation_completed', false)
+            ->andReturn(true);
+
+        WP_Mock::userFunction('get_option')
+            ->with('default_category')
+            ->andReturn(1);
+
+        $mixedCategory = (object) [
+            'term_id' => 30,
+            'count' => 5,
+            'name' => 'Mixed Category',
+        ];
+
+        WP_Mock::userFunction('get_categories')
+            ->once()
+            ->andReturn([$mixedCategory]);
+
+        // Only 2 of 5 posts are AI-generated
+        WP_Mock::userFunction('get_posts')
+            ->once()
+            ->andReturn([1, 2]);
+
+        // Category should NOT be deleted
+        WP_Mock::userFunction('wp_delete_term')
+            ->never();
+
+        global $wpdb;
+        $wpdb->shouldReceive('query')
+            ->once()
+            ->andReturn(0);
+
+        $ref = new \ReflectionClass($this->job);
+        $method = $ref->getMethod('cleanPreviousDataIfReExecution');
+        $method->setAccessible(true);
+        $method->invoke($this->job);
+    }
+
+    public function test_re_execution_cleans_batch_options_via_wpdb(): void
+    {
+        WP_Mock::userFunction('get_option')
+            ->with('contai_site_generation_completed', false)
+            ->andReturn(true);
+
+        WP_Mock::userFunction('get_option')
+            ->with('default_category')
+            ->andReturn(1);
+
+        WP_Mock::userFunction('get_categories')
+            ->once()
+            ->andReturn([]);
+
+        // Verify batch options are cleaned via wpdb DELETE query
+        global $wpdb;
+        $wpdb->shouldReceive('query')
+            ->once()
+            ->with(Mockery::on(function ($query) {
+                return strpos($query, 'DELETE') !== false
+                    && strpos($query, 'contai') !== false
+                    && strpos($query, 'batch') !== false;
+            }))
+            ->andReturn(3);
+
+        $ref = new \ReflectionClass($this->job);
+        $method = $ref->getMethod('cleanPreviousDataIfReExecution');
+        $method->setAccessible(true);
+        $method->invoke($this->job);
+    }
+}

--- a/tests/unit/services/legal/LegalPagesGeneratorTest.php
+++ b/tests/unit/services/legal/LegalPagesGeneratorTest.php
@@ -1,0 +1,296 @@
+<?php
+
+namespace ContAI\Tests\Unit\Services\Legal;
+
+use WP_Mock;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use ContaiLegalPagesGenerator;
+use ContaiLegalPagesAPIClient;
+use ContaiLegalInfoService;
+
+class LegalPagesGeneratorTest extends TestCase
+{
+    private $apiClient;
+    private $legalInfoService;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        WP_Mock::setUp();
+
+        $this->apiClient = Mockery::mock(ContaiLegalPagesAPIClient::class);
+        $this->legalInfoService = Mockery::mock(ContaiLegalInfoService::class);
+    }
+
+    public function tearDown(): void
+    {
+        $this->addToAssertionCount(Mockery::getContainer()->mockery_getExpectationCount());
+        WP_Mock::tearDown();
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    // ── ensureRequiredLegalPages: creates fallback for missing page ──
+
+    public function test_generate_creates_fallback_for_missing_legal_page(): void
+    {
+        $this->setupValidLegalInfo();
+
+        // API returns 4 pages but NOT cookie-policy
+        $response = Mockery::mock(\ContaiOnePlatformResponse::class);
+        $response->shouldReceive('isSuccess')->andReturn(true);
+        $response->shouldReceive('getData')->andReturn([
+            'pages' => [
+                'privacy-policy' => ['title' => 'Privacy Policy', 'content' => '<p>Privacy content</p>'],
+                'legal-policy' => ['title' => 'Legal Notice', 'content' => '<p>Legal content</p>'],
+                'about-me' => ['title' => 'About Me', 'content' => '<p>About content</p>'],
+                'contact' => ['title' => 'Contact', 'content' => '<p>Contact content</p>'],
+            ],
+            'meta' => ['slug_map' => [
+                'privacy-policy' => 'privacy-policy',
+                'legal-policy' => 'legal-notice',
+                'about-me' => 'about-me',
+                'contact' => 'contact',
+            ]],
+            'lang' => 'en',
+        ]);
+
+        $this->apiClient
+            ->shouldReceive('generateLegalPages')
+            ->once()
+            ->andReturn($response);
+
+        // processPage: each page already exists (skipped)
+        WP_Mock::userFunction('get_page_by_path')
+            ->andReturn((object) ['ID' => 1, 'post_status' => 'publish']);
+
+        WP_Mock::userFunction('sanitize_text_field')
+            ->andReturnUsing(function ($v) { return $v; });
+        WP_Mock::userFunction('sanitize_email')
+            ->andReturnUsing(function ($v) { return $v; });
+        WP_Mock::userFunction('sanitize_title')
+            ->andReturnUsing(function ($v) { return strtolower(str_replace(' ', '-', $v)); });
+        WP_Mock::userFunction('esc_html')
+            ->andReturnUsing(function ($v) { return $v; });
+        WP_Mock::userFunction('esc_html__')
+            ->andReturnUsing(function ($v) { return $v; });
+        WP_Mock::userFunction('wp_kses_post')
+            ->andReturnUsing(function ($v) { return $v; });
+
+        WP_Mock::userFunction('get_option')
+            ->with('contai_site_theme', '')
+            ->andReturn('Tech Blog');
+        WP_Mock::userFunction('get_option')
+            ->with('contai_legal_owner', '')
+            ->andReturn('John Doe');
+        WP_Mock::userFunction('get_option')
+            ->with('contai_legal_email', '')
+            ->andReturn('john@example.com');
+
+        // ensureRequiredLegalPages: 4 already exist by meta, cookie-policy does not
+        $callCount = 0;
+        WP_Mock::userFunction('get_posts')
+            ->andReturnUsing(function ($args) use (&$callCount) {
+                // processPage trash checks return empty
+                if (isset($args['post_status']) && $args['post_status'] === 'trash') {
+                    return [];
+                }
+                // ensureRequiredLegalPages meta lookups
+                if (isset($args['meta_key']) && $args['meta_key'] === '_contai_legal_key') {
+                    if ($args['meta_value'] === 'cookie-policy') {
+                        return []; // missing
+                    }
+                    return [(object) ['ID' => 10, 'post_status' => 'publish']];
+                }
+                return [];
+            });
+
+        // Fallback creation for cookie-policy
+        WP_Mock::userFunction('wp_insert_post')
+            ->once()
+            ->andReturn(99);
+
+        WP_Mock::userFunction('update_post_meta')
+            ->times(4); // source, key, lang, generated_at
+
+        WP_Mock::userFunction('current_time')
+            ->andReturn('2026-04-07 12:00:00');
+
+        WP_Mock::userFunction('is_wp_error')
+            ->andReturn(false);
+
+        WP_Mock::userFunction('__')
+            ->andReturnUsing(function ($text) { return $text; });
+
+        $generator = new ContaiLegalPagesGenerator($this->apiClient, $this->legalInfoService);
+        $result = $generator->generate();
+
+        $this->assertTrue($result['success']);
+        $this->assertGreaterThanOrEqual(1, $result['created']);
+    }
+
+    public function test_generate_restores_trashed_page_in_ensure_step(): void
+    {
+        $this->setupValidLegalInfo();
+
+        // Must return at least one page to avoid the "API returned no pages" early return
+        $response = Mockery::mock(\ContaiOnePlatformResponse::class);
+        $response->shouldReceive('isSuccess')->andReturn(true);
+        $response->shouldReceive('getData')->andReturn([
+            'pages' => [
+                'legal-policy' => ['title' => 'Legal Notice', 'content' => '<p>Legal</p>'],
+            ],
+            'meta' => ['slug_map' => ['legal-policy' => 'legal-notice']],
+            'lang' => 'en',
+        ]);
+
+        $this->apiClient
+            ->shouldReceive('generateLegalPages')
+            ->once()
+            ->andReturn($response);
+
+        WP_Mock::userFunction('sanitize_text_field')
+            ->andReturnUsing(function ($v) { return $v; });
+        WP_Mock::userFunction('sanitize_email')
+            ->andReturnUsing(function ($v) { return $v; });
+        WP_Mock::userFunction('sanitize_title')
+            ->andReturnUsing(function ($v) { return strtolower(str_replace(' ', '-', $v)); });
+        WP_Mock::userFunction('esc_html')
+            ->andReturnUsing(function ($v) { return $v; });
+        WP_Mock::userFunction('esc_html__')
+            ->andReturnUsing(function ($v) { return $v; });
+
+        WP_Mock::userFunction('get_option')
+            ->with('contai_site_theme', '')
+            ->andReturn('Blog');
+        WP_Mock::userFunction('get_option')
+            ->with('contai_legal_owner', '')
+            ->andReturn('Owner');
+        WP_Mock::userFunction('get_option')
+            ->with('contai_legal_email', '')
+            ->andReturn('owner@test.com');
+
+        // processPage: legal-notice already exists (skipped)
+        WP_Mock::userFunction('get_page_by_path')
+            ->andReturn((object) ['ID' => 1, 'post_status' => 'publish']);
+
+        WP_Mock::userFunction('wp_kses_post')
+            ->andReturnUsing(function ($v) { return $v; });
+
+        // ensureRequiredLegalPages: privacy-policy is in trash, rest missing
+        WP_Mock::userFunction('get_posts')
+            ->andReturnUsing(function ($args) {
+                if (isset($args['meta_key']) && $args['meta_key'] === '_contai_legal_key') {
+                    if ($args['meta_value'] === 'privacy-policy') {
+                        return [(object) ['ID' => 55, 'post_status' => 'trash']];
+                    }
+                    // legal-policy already exists from API
+                    if ($args['meta_value'] === 'legal-policy') {
+                        return [(object) ['ID' => 1, 'post_status' => 'publish']];
+                    }
+                    return []; // missing pages
+                }
+                return [];
+            });
+
+        // Trashed page should be restored
+        WP_Mock::userFunction('wp_untrash_post')
+            ->once()
+            ->with(55);
+
+        // Missing pages: cookie-policy, about-me, contact (3 missing)
+        WP_Mock::userFunction('wp_insert_post')
+            ->times(3)
+            ->andReturn(100);
+
+        WP_Mock::userFunction('update_post_meta');
+
+        WP_Mock::userFunction('current_time')
+            ->andReturn('2026-04-07 12:00:00');
+
+        WP_Mock::userFunction('is_wp_error')
+            ->andReturn(false);
+
+        WP_Mock::userFunction('__')
+            ->andReturnUsing(function ($text) { return $text; });
+
+        $generator = new ContaiLegalPagesGenerator($this->apiClient, $this->legalInfoService);
+        $result = $generator->generate();
+
+        // 3 fallback pages created; privacy-policy restored from trash, legal-policy already exists
+        // wp_untrash_post called once verifies the trash restore
+        $this->assertEquals(3, $result['created']);
+    }
+
+    public function test_generate_returns_error_when_api_fails(): void
+    {
+        $this->setupValidLegalInfo();
+
+        $response = Mockery::mock(\ContaiOnePlatformResponse::class);
+        $response->shouldReceive('isSuccess')->andReturn(false);
+        $response->shouldReceive('getMessage')->andReturn('API error');
+
+        $this->apiClient
+            ->shouldReceive('generateLegalPages')
+            ->once()
+            ->andReturn($response);
+
+        WP_Mock::userFunction('sanitize_text_field')
+            ->andReturnUsing(function ($v) { return $v; });
+        WP_Mock::userFunction('sanitize_email')
+            ->andReturnUsing(function ($v) { return $v; });
+
+        WP_Mock::userFunction('get_option')
+            ->with('contai_site_theme', '')
+            ->andReturn('Blog');
+
+        WP_Mock::userFunction('__')
+            ->andReturnUsing(function ($text) { return $text; });
+
+        $generator = new ContaiLegalPagesGenerator($this->apiClient, $this->legalInfoService);
+        $result = $generator->generate();
+
+        $this->assertFalse($result['success']);
+        $this->assertNotEmpty($result['errors']);
+    }
+
+    public function test_generate_returns_error_on_validation_failure(): void
+    {
+        $this->legalInfoService
+            ->shouldReceive('getLegalInfo')
+            ->once()
+            ->andReturn([]);
+
+        $this->legalInfoService
+            ->shouldReceive('validateLegalInfo')
+            ->once()
+            ->andReturn(['Owner is required']);
+
+        $generator = new ContaiLegalPagesGenerator($this->apiClient, $this->legalInfoService);
+        $result = $generator->generate();
+
+        $this->assertFalse($result['success']);
+        $this->assertEquals(['Owner is required'], $result['errors']);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────
+
+    private function setupValidLegalInfo(): void
+    {
+        $this->legalInfoService
+            ->shouldReceive('getLegalInfo')
+            ->once()
+            ->andReturn([
+                'owner' => 'John Doe',
+                'email' => 'john@example.com',
+                'address' => '123 Main St',
+                'activity' => 'Technology Blog',
+            ]);
+
+        $this->legalInfoService
+            ->shouldReceive('validateLegalInfo')
+            ->once()
+            ->andReturn([]);
+    }
+}

--- a/tests/unit/services/menu/MainMenuManagerTest.php
+++ b/tests/unit/services/menu/MainMenuManagerTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace ContAI\Tests\Unit\Services\Menu;
+
+use WP_Mock;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use ContaiMainMenuManager;
+use ContaiConfig;
+use ReflectionMethod;
+
+class MainMenuManagerTest extends TestCase
+{
+    private $config;
+    private ContaiMainMenuManager $manager;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        WP_Mock::setUp();
+
+        $this->config = Mockery::mock(ContaiConfig::class);
+        $this->config->shouldReceive('getMaxMenuCategories')->andReturn(10)->byDefault();
+
+        $this->manager = new ContaiMainMenuManager($this->config);
+    }
+
+    public function tearDown(): void
+    {
+        $this->addToAssertionCount(Mockery::getContainer()->mockery_getExpectationCount());
+        WP_Mock::tearDown();
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    private function invokePrivate(string $method, array $args = [])
+    {
+        $ref = new ReflectionMethod(ContaiMainMenuManager::class, $method);
+        $ref->setAccessible(true);
+        return $ref->invoke($this->manager, ...$args);
+    }
+
+    // ── removePageItems ──
+
+    public function test_removePageItems_deletes_page_type_items(): void
+    {
+        $pageItem = (object) ['ID' => 101, 'type' => 'post_type', 'object' => 'page'];
+        $catItem = (object) ['ID' => 102, 'type' => 'taxonomy', 'object' => 'category'];
+        $customItem = (object) ['ID' => 103, 'type' => 'custom', 'object' => 'custom'];
+
+        WP_Mock::userFunction('wp_get_nav_menu_items')
+            ->once()
+            ->with(5)
+            ->andReturn([$pageItem, $catItem, $customItem]);
+
+        WP_Mock::userFunction('wp_delete_post')
+            ->once()
+            ->with(101, true);
+
+        $this->invokePrivate('removePageItems', [5]);
+    }
+
+    public function test_removePageItems_does_nothing_when_no_items(): void
+    {
+        WP_Mock::userFunction('wp_get_nav_menu_items')
+            ->once()
+            ->with(7)
+            ->andReturn(false);
+
+        WP_Mock::userFunction('wp_delete_post')->never();
+
+        $this->invokePrivate('removePageItems', [7]);
+    }
+
+    // ── removeOrphanedCategoryItems ──
+
+    public function test_removeOrphanedCategoryItems_deletes_when_category_missing(): void
+    {
+        $orphanItem = (object) ['ID' => 201, 'type' => 'taxonomy', 'object' => 'category', 'object_id' => 99];
+
+        WP_Mock::userFunction('wp_get_nav_menu_items')
+            ->once()
+            ->with(9)
+            ->andReturn([$orphanItem]);
+
+        WP_Mock::userFunction('get_category')
+            ->once()
+            ->with(99)
+            ->andReturn(false);
+
+        WP_Mock::userFunction('wp_delete_post')
+            ->once()
+            ->with(201, true);
+
+        $this->invokePrivate('removeOrphanedCategoryItems', [9]);
+    }
+
+    public function test_removeOrphanedCategoryItems_deletes_when_wp_error(): void
+    {
+        $errorItem = (object) ['ID' => 301, 'type' => 'taxonomy', 'object' => 'category', 'object_id' => 77];
+
+        WP_Mock::userFunction('wp_get_nav_menu_items')
+            ->once()
+            ->with(11)
+            ->andReturn([$errorItem]);
+
+        $wpError = Mockery::mock('WP_Error');
+        WP_Mock::userFunction('get_category')
+            ->once()
+            ->with(77)
+            ->andReturn($wpError);
+
+        WP_Mock::userFunction('is_wp_error')
+            ->with($wpError)
+            ->andReturn(true);
+
+        WP_Mock::userFunction('wp_delete_post')
+            ->once()
+            ->with(301, true);
+
+        $this->invokePrivate('removeOrphanedCategoryItems', [11]);
+    }
+
+    public function test_removeOrphanedCategoryItems_keeps_valid_categories(): void
+    {
+        $validItem = (object) ['ID' => 401, 'type' => 'taxonomy', 'object' => 'category', 'object_id' => 5];
+
+        WP_Mock::userFunction('wp_get_nav_menu_items')
+            ->once()
+            ->with(13)
+            ->andReturn([$validItem]);
+
+        $validCat = (object) ['term_id' => 5, 'slug' => 'tech'];
+        WP_Mock::userFunction('get_category')
+            ->once()
+            ->with(5)
+            ->andReturn($validCat);
+
+        WP_Mock::userFunction('is_wp_error')
+            ->andReturn(false);
+
+        WP_Mock::userFunction('wp_delete_post')->never();
+
+        $this->invokePrivate('removeOrphanedCategoryItems', [13]);
+    }
+}


### PR DESCRIPTION
## Summary
- Site generation re-execution support: clean previous AI data, deduplicate keywords, restore trashed legal pages
- Legal page resilience: ensure all 5 required pages exist with fallback content
- Site generator form refactor: inline notices, preserved form values, secure nonce handling

## Changes
- **SiteGenerationJob**: re-execution detection + cleanup (categories, batch options)
- **LegalPagesGenerator**: restore trashed pages, `ensureRequiredLegalPages()` with fallback content
- **QueueManager**: skip keywords with existing posts, mark as `done`
- **MainMenuManager**: new service to clean orphaned menu items
- **ContentGeneratorService**: exclude used featured image URLs
- **CookieNoticeHelper**: dynamic privacy policy link via `_contai_legal_key` meta
- **site-generation helper**: pattern-match footer menu location across themes
- **admin-ai-site-generator + site-generator-form**: inline notice pattern, form value preservation
- **Tests**: 56 new tests (QueueManager, SiteGenerationJob, LegalPagesGenerator, MainMenuManager, SiteGeneratorSubmission)
- **Version**: 2.25.0 → 2.26.0 (minor)

## Test Plan
- [x] 56 new tests pass (QueueManagerTest, SiteGenerationJobTest, LegalPagesGeneratorTest, MainMenuManagerTest, SiteGeneratorSubmissionTest)
- [x] Full test suite passes (589+ existing tests)
- [x] PHP syntax validation on all modified files
- [x] No provider name exposure

🤖 Generated with [Claude Code](https://claude.com/claude-code)