### PR TITLE
feat(publisuites): marketplace pending state + delete action

### DIFF
--- a/includes/admin/apps/handlers/PublisuitesFormHandler.php
+++ b/includes/admin/apps/handlers/PublisuitesFormHandler.php
@@ -77,6 +77,11 @@ class ContaiPublisuitesFormHandler
             $this->handleSendUrl();
             return;
         }
+
+        if (isset($_POST['contai_delete_from_marketplace'])) {
+            $this->handleDeleteFromMarketplace();
+            return;
+        }
     }
 
     private function handleSetup(): void
@@ -259,6 +264,18 @@ class ContaiPublisuitesFormHandler
         }
 
         $this->redirectWithMessage('success', __('URL submitted successfully', '1platform-content-ai'));
+    }
+
+    private function handleDeleteFromMarketplace(): void
+    {
+        $response = $this->service->deleteWebsiteFromMarketplace();
+
+        if ($response->isSuccess()) {
+            $this->redirectWithMessage('success', __('Website removed from the marketplace. You can re-add it at any time.', '1platform-content-ai'));
+            return;
+        }
+
+        $this->redirectWithMessage('error', wp_kses_post($response->getMessage()), $response->getTraceId());
     }
 
     private function redirectWithMessage(string $type, string $message, ?string $trace_id = null): void

--- a/includes/admin/apps/panels/PublisuitesPanel.php
+++ b/includes/admin/apps/panels/PublisuitesPanel.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/../../../helpers/license-helper.php';
 require_once __DIR__ . '/publisuites/ConnectSection.php';
 require_once __DIR__ . '/publisuites/VerificationSection.php';
 require_once __DIR__ . '/publisuites/ConnectedSection.php';
+require_once __DIR__ . '/publisuites/MarketplacePendingSection.php';
 require_once __DIR__ . '/publisuites/OrdersSection.php';
 
 /**
@@ -100,6 +101,20 @@ class ContaiPublisuitesPanel
 
             case 'configured':
                 if ($this->service->isVerified($config)) {
+                    $marketplaceStatus = $config['marketplace_status'] ?? null;
+
+                    if ($marketplaceStatus !== 'active') {
+                        return array_merge($base, [
+                            'status_key'           => 'marketplace_pending',
+                            'status_label'         => __('Pending Approval', '1platform-content-ai'),
+                            'status_class'         => 'contai-badge--warning',
+                            'primary_cta_label'    => null,
+                            'primary_cta_action'   => null,
+                            'secondary_cta_label'  => __('Remove from Marketplace', '1platform-content-ai'),
+                            'secondary_cta_action' => 'contai_delete_from_marketplace',
+                        ]);
+                    }
+
                     $view_data = array_merge($base, [
                         'status_key'           => 'connected',
                         'status_label'         => __('Connected', '1platform-content-ai'),
@@ -186,6 +201,11 @@ class ContaiPublisuitesPanel
 
             case 'pending_verification':
                 $section = new ContaiPublisuitesVerificationSection($view_data);
+                $section->render();
+                break;
+
+            case 'marketplace_pending':
+                $section = new ContaiPublisuitesMarketplacePendingSection($view_data);
                 $section->render();
                 break;
 

--- a/includes/admin/apps/panels/publisuites/ConnectedSection.php
+++ b/includes/admin/apps/panels/publisuites/ConnectedSection.php
@@ -49,24 +49,46 @@ class ContaiPublisuitesConnectedSection
                         </div>
                     <?php endif; ?>
                     <div class="contai-ps-info-list__row">
+                        <dt><?php esc_html_e('Marketplace Status', '1platform-content-ai'); ?></dt>
+                        <dd>
+                            <span class="contai-badge contai-badge--success">
+                                &#10003; <?php esc_html_e('Approved', '1platform-content-ai'); ?>
+                            </span>
+                        </dd>
+                    </div>
+                    <div class="contai-ps-info-list__row">
                         <dt><?php esc_html_e('Site URL', '1platform-content-ai'); ?></dt>
                         <dd class="contai-ps-mono"><?php echo esc_html($this->view_data['site_url']); ?></dd>
                     </div>
                 </dl>
-                <?php if (!empty($this->view_data['secondary_cta_action'])) : ?>
-                    <form method="post" class="contai-ps-form" data-confirm="<?php echo esc_attr($confirm_message); ?>">
+                <div style="display: flex; gap: 8px; flex-wrap: wrap;">
+                    <?php if (!empty($this->view_data['secondary_cta_action'])) : ?>
+                        <form method="post" class="contai-ps-form" data-confirm="<?php echo esc_attr($confirm_message); ?>">
+                            <?php wp_nonce_field($this->view_data['nonce_action'], $this->view_data['nonce_field']); ?>
+                            <button
+                                type="submit"
+                                name="<?php echo esc_attr($this->view_data['secondary_cta_action']); ?>"
+                                class="button button-secondary contai-ps-btn--danger"
+                                aria-label="<?php esc_attr_e('Disconnect from the marketplace', '1platform-content-ai'); ?>"
+                            >
+                                <span class="dashicons dashicons-dismiss" aria-hidden="true"></span>
+                                <?php echo esc_html($this->view_data['secondary_cta_label']); ?>
+                            </button>
+                        </form>
+                    <?php endif; ?>
+                    <form method="post" class="contai-ps-form">
                         <?php wp_nonce_field($this->view_data['nonce_action'], $this->view_data['nonce_field']); ?>
                         <button
                             type="submit"
-                            name="<?php echo esc_attr($this->view_data['secondary_cta_action']); ?>"
+                            name="contai_delete_from_marketplace"
                             class="button button-secondary contai-ps-btn--danger"
-                            aria-label="<?php esc_attr_e('Disconnect from the marketplace', '1platform-content-ai'); ?>"
+                            onclick="return confirm('<?php echo esc_js(__('Are you sure? This will remove the website from the marketplace and delete all synced orders.', '1platform-content-ai')); ?>');"
                         >
-                            <span class="dashicons dashicons-dismiss" aria-hidden="true"></span>
-                            <?php echo esc_html($this->view_data['secondary_cta_label']); ?>
+                            <span class="dashicons dashicons-trash" aria-hidden="true"></span>
+                            <?php esc_html_e('Remove from Marketplace', '1platform-content-ai'); ?>
                         </button>
                     </form>
-                <?php endif; ?>
+                </div>
             </div>
         </details>
         <?php

--- a/includes/admin/apps/panels/publisuites/MarketplacePendingSection.php
+++ b/includes/admin/apps/panels/publisuites/MarketplacePendingSection.php
@@ -1,0 +1,115 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+/**
+ * Publisuites "Marketplace Pending" state — website verified but awaiting marketplace approval.
+ *
+ * Shows status info, Sync Now button (to check approval), and Remove from Marketplace button.
+ */
+class ContaiPublisuitesMarketplacePendingSection
+{
+    private array $view_data;
+
+    public function __construct(array $view_data)
+    {
+        $this->view_data = $view_data;
+    }
+
+    public function render(): void
+    {
+        $config = $this->view_data['config'];
+        $publisuites_id = esc_html($config['publisuitesId'] ?? '—');
+        $site_url = esc_html($this->view_data['site_url']);
+        $verified_at = !empty($config['verifiedAt']) ? esc_html($this->formatDate($config['verifiedAt'])) : '—';
+        $confirm_remove = esc_js(
+            __('Are you sure? This will remove the website from the marketplace and delete all synced orders.', '1platform-content-ai')
+        );
+        ?>
+        <div class="contai-ps-marketplace-pending" style="margin-top: 16px;">
+            <div class="contai-ps-notice contai-ps-notice--warning" style="margin-bottom: 20px; padding: 16px; border-left: 4px solid #dba617; background: #fff8e1; border-radius: 4px;">
+                <p style="margin: 0 0 8px 0; font-weight: 600;">
+                    &#9203; <?php esc_html_e('Marketplace Status: Pending Approval', '1platform-content-ai'); ?>
+                </p>
+                <p style="margin: 0; color: #555;">
+                    <?php esc_html_e('Your website has been submitted and is under review by the marketplace administrators. This usually takes 24-48 hours.', '1platform-content-ai'); ?>
+                </p>
+            </div>
+
+            <details class="contai-ps-settings" open>
+                <summary class="contai-ps-settings__summary">
+                    <span class="dashicons dashicons-admin-generic" aria-hidden="true"></span>
+                    <?php esc_html_e('Connection Settings', '1platform-content-ai'); ?>
+                    <span class="contai-ps-inline-badge contai-ps-inline-badge--active" style="margin-left: 8px; font-size: 11px;">
+                        <?php esc_html_e('Active', '1platform-content-ai'); ?>
+                    </span>
+                </summary>
+                <div class="contai-ps-settings__body">
+                    <dl class="contai-ps-info-list" style="margin-bottom: 16px;">
+                        <div class="contai-ps-info-list__row">
+                            <dt><?php esc_html_e('Marketplace ID', '1platform-content-ai'); ?></dt>
+                            <dd class="contai-ps-mono"><?php echo $publisuites_id; ?></dd>
+                        </div>
+                        <div class="contai-ps-info-list__row">
+                            <dt><?php esc_html_e('Site URL', '1platform-content-ai'); ?></dt>
+                            <dd class="contai-ps-mono"><?php echo $site_url; ?></dd>
+                        </div>
+                        <div class="contai-ps-info-list__row">
+                            <dt><?php esc_html_e('Status', '1platform-content-ai'); ?></dt>
+                            <dd>
+                                <span class="contai-badge contai-badge--warning">
+                                    &#9203; <?php esc_html_e('Pending Approval', '1platform-content-ai'); ?>
+                                </span>
+                            </dd>
+                        </div>
+                        <div class="contai-ps-info-list__row">
+                            <dt><?php esc_html_e('Submitted', '1platform-content-ai'); ?></dt>
+                            <dd><?php echo $verified_at; ?></dd>
+                        </div>
+                    </dl>
+
+                    <div style="display: flex; gap: 8px; flex-wrap: wrap;">
+                        <form method="post" class="contai-ps-form">
+                            <?php wp_nonce_field($this->view_data['nonce_action'], $this->view_data['nonce_field']); ?>
+                            <button
+                                type="submit"
+                                name="contai_sync_publisuites"
+                                class="button button-primary"
+                            >
+                                <span class="dashicons dashicons-update" aria-hidden="true" style="margin-top: 3px;"></span>
+                                <?php esc_html_e('Sync Now', '1platform-content-ai'); ?>
+                            </button>
+                        </form>
+                        <form method="post" class="contai-ps-form">
+                            <?php wp_nonce_field($this->view_data['nonce_action'], $this->view_data['nonce_field']); ?>
+                            <button
+                                type="submit"
+                                name="contai_delete_from_marketplace"
+                                class="button button-secondary contai-ps-btn--danger"
+                                onclick="return confirm('<?php echo $confirm_remove; ?>');"
+                            >
+                                <span class="dashicons dashicons-trash" aria-hidden="true" style="margin-top: 3px;"></span>
+                                <?php esc_html_e('Remove from Marketplace', '1platform-content-ai'); ?>
+                            </button>
+                        </form>
+                    </div>
+                </div>
+            </details>
+
+            <p class="description" style="margin-top: 12px; color: #666;">
+                <?php esc_html_e('Once approved, your website will start receiving sponsored post orders from the marketplace.', '1platform-content-ai'); ?>
+            </p>
+        </div>
+        <?php
+    }
+
+    private function formatDate(string $dateString): string
+    {
+        try {
+            $date = new DateTime($dateString);
+            return $date->format(get_option('date_format'));
+        } catch (Exception $e) {
+            return $dateString;
+        }
+    }
+}

--- a/includes/admin/apps/panels/publisuites/MarketplacePendingSection.php
+++ b/includes/admin/apps/panels/publisuites/MarketplacePendingSection.php
@@ -80,13 +80,12 @@ class ContaiPublisuitesMarketplacePendingSection
                                 <?php esc_html_e('Sync Now', '1platform-content-ai'); ?>
                             </button>
                         </form>
-                        <form method="post" class="contai-ps-form">
+                        <form method="post" class="contai-ps-form" data-confirm="<?php echo esc_attr($confirm_remove); ?>">
                             <?php wp_nonce_field($this->view_data['nonce_action'], $this->view_data['nonce_field']); ?>
                             <button
                                 type="submit"
                                 name="contai_delete_from_marketplace"
                                 class="button button-secondary contai-ps-btn--danger"
-                                onclick="return confirm('<?php echo $confirm_remove; ?>');"
                             >
                                 <span class="dashicons dashicons-trash" aria-hidden="true" style="margin-top: 3px;"></span>
                                 <?php esc_html_e('Remove from Marketplace', '1platform-content-ai'); ?>

--- a/includes/admin/apps/panels/publisuites/MarketplacePendingSection.php
+++ b/includes/admin/apps/panels/publisuites/MarketplacePendingSection.php
@@ -19,9 +19,9 @@ class ContaiPublisuitesMarketplacePendingSection
     public function render(): void
     {
         $config = $this->view_data['config'];
-        $publisuites_id = esc_html($config['publisuitesId'] ?? '—');
-        $site_url = esc_html($this->view_data['site_url']);
-        $verified_at = !empty($config['verifiedAt']) ? esc_html($this->formatDate($config['verifiedAt'])) : '—';
+        $publisuites_id = $config['publisuitesId'] ?? '—';
+        $site_url = $this->view_data['site_url'];
+        $verified_at = !empty($config['verifiedAt']) ? $this->formatDate($config['verifiedAt']) : '—';
         $confirm_remove = esc_js(
             __('Are you sure? This will remove the website from the marketplace and delete all synced orders.', '1platform-content-ai')
         );
@@ -48,11 +48,11 @@ class ContaiPublisuitesMarketplacePendingSection
                     <dl class="contai-ps-info-list" style="margin-bottom: 16px;">
                         <div class="contai-ps-info-list__row">
                             <dt><?php esc_html_e('Marketplace ID', '1platform-content-ai'); ?></dt>
-                            <dd class="contai-ps-mono"><?php echo $publisuites_id; ?></dd>
+                            <dd class="contai-ps-mono"><?php echo esc_html($publisuites_id); ?></dd>
                         </div>
                         <div class="contai-ps-info-list__row">
                             <dt><?php esc_html_e('Site URL', '1platform-content-ai'); ?></dt>
-                            <dd class="contai-ps-mono"><?php echo $site_url; ?></dd>
+                            <dd class="contai-ps-mono"><?php echo esc_html($site_url); ?></dd>
                         </div>
                         <div class="contai-ps-info-list__row">
                             <dt><?php esc_html_e('Status', '1platform-content-ai'); ?></dt>
@@ -64,7 +64,7 @@ class ContaiPublisuitesMarketplacePendingSection
                         </div>
                         <div class="contai-ps-info-list__row">
                             <dt><?php esc_html_e('Submitted', '1platform-content-ai'); ?></dt>
-                            <dd><?php echo $verified_at; ?></dd>
+                            <dd><?php echo esc_html($verified_at); ?></dd>
                         </div>
                     </dl>
 

--- a/includes/services/publisuites/PublisuitesService.php
+++ b/includes/services/publisuites/PublisuitesService.php
@@ -42,16 +42,23 @@ class ContaiPublisuitesService
     public function savePublisuitesConfig(array $data): bool
     {
         $config = [
-            'userId' => $data['user_id'] ?? $this->userProvider->getUserId() ?? '',
-            'websiteId' => $data['website_id'] ?? $this->websiteProvider->getWebsiteId() ?? '',
-            'publisuitesId' => $data['publisuites_id'] ?? '',
+            'userId' => $data['user_id'] ?? $data['userId'] ?? $this->userProvider->getUserId() ?? '',
+            'websiteId' => $data['website_id'] ?? $data['websiteId'] ?? $this->websiteProvider->getWebsiteId() ?? '',
+            'publisuitesId' => $data['publisuites_id'] ?? $data['publisuitesId'] ?? '',
             'status' => $data['status'] ?? 'pending_verification',
-            'verificationFileName' => $data['verification_file_name'] ?? '',
-            'verificationFileContent' => $data['verification_file_content'] ?? '',
+            'verificationFileName' => $data['verification_file_name'] ?? $data['verificationFileName'] ?? '',
+            'verificationFileContent' => $data['verification_file_content'] ?? $data['verificationFileContent'] ?? '',
             'verified' => $data['verified'] ?? false,
-            'verifiedAt' => $data['verified_at'] ?? null,
+            'verifiedAt' => $data['verified_at'] ?? $data['verifiedAt'] ?? null,
             'message' => $data['message'] ?? '',
         ];
+
+        if (isset($data['marketplace_status'])) {
+            $config['marketplace_status'] = $data['marketplace_status'];
+        }
+        if (isset($data['marketplace_status_checked_at'])) {
+            $config['marketplace_status_checked_at'] = $data['marketplace_status_checked_at'];
+        }
 
         return update_option(self::OPTION_PUBLISUITES_CONFIG, $config);
     }
@@ -93,7 +100,7 @@ class ContaiPublisuitesService
         }
 
         if (!$config || empty($config['publisuitesId'])) {
-            return new ContaiOnePlatformResponse(false, null, 'Publisuites not connected', 400);
+            return new ContaiOnePlatformResponse(false, null, 'Marketplace not connected', 400);
         }
 
         $endpoint = ContaiOnePlatformEndpoints::websitePublisuites($websiteId);
@@ -108,7 +115,7 @@ class ContaiPublisuitesService
         if (!$config) {
             return [
                 'success' => false,
-                'message' => 'Publisuites configuration not found',
+                'message' => 'Marketplace configuration not found',
             ];
         }
 
@@ -290,8 +297,8 @@ class ContaiPublisuitesService
         if ($response->isSuccess()) {
             if (!empty($config['verificationFileName'])) {
                 $filePath = ABSPATH . sanitize_file_name($config['verificationFileName']);
-                if (file_exists($filePath)) {
-                    @unlink($filePath);
+                if (file_exists($filePath) && !unlink($filePath)) {
+                    error_log('[1Platform] Failed to delete verification file: ' . $filePath);
                 }
             }
             $this->deletePublisuitesConfig();

--- a/includes/services/publisuites/PublisuitesService.php
+++ b/includes/services/publisuites/PublisuitesService.php
@@ -254,9 +254,50 @@ class ContaiPublisuitesService
 
         $endpoint = ContaiOnePlatformEndpoints::websitePublisuites($websiteId);
 
-        return $this->client->post($endpoint, [
+        $response = $this->client->post($endpoint, [
             'action' => 'sync',
         ]);
+
+        if ($response->isSuccess()) {
+            $data = $response->getData();
+            if (isset($data['marketplace_status'])) {
+                $config['marketplace_status'] = $data['marketplace_status'];
+                $config['marketplace_status_checked_at'] = gmdate('c');
+                $this->savePublisuitesConfig($config);
+            }
+        }
+
+        return $response;
+    }
+
+    public function deleteWebsiteFromMarketplace(): ContaiOnePlatformResponse
+    {
+        $config = $this->getPublisuitesConfig();
+        if (!$config) {
+            return new ContaiOnePlatformResponse(false, null, 'No marketplace configuration found', 400);
+        }
+
+        $websiteId = $this->websiteProvider->getWebsiteId();
+        if (!$websiteId) {
+            return new ContaiOnePlatformResponse(false, null, 'Website not configured', 400);
+        }
+
+        $endpoint = ContaiOnePlatformEndpoints::websitePublisuites($websiteId);
+        $response = $this->client->post($endpoint, [
+            'action' => 'delete',
+        ]);
+
+        if ($response->isSuccess()) {
+            if (!empty($config['verificationFileName'])) {
+                $filePath = ABSPATH . sanitize_file_name($config['verificationFileName']);
+                if (file_exists($filePath)) {
+                    @unlink($filePath);
+                }
+            }
+            $this->deletePublisuitesConfig();
+        }
+
+        return $response;
     }
 
     public function acceptOrder(int $orderId): ContaiOnePlatformResponse

--- a/includes/services/publisuites/PublisuitesService.php
+++ b/includes/services/publisuites/PublisuitesService.php
@@ -54,10 +54,10 @@ class ContaiPublisuitesService
         ];
 
         if (isset($data['marketplace_status'])) {
-            $config['marketplace_status'] = $data['marketplace_status'];
+            $config['marketplace_status'] = sanitize_text_field($data['marketplace_status']);
         }
         if (isset($data['marketplace_status_checked_at'])) {
-            $config['marketplace_status_checked_at'] = $data['marketplace_status_checked_at'];
+            $config['marketplace_status_checked_at'] = sanitize_text_field($data['marketplace_status_checked_at']);
         }
 
         return update_option(self::OPTION_PUBLISUITES_CONFIG, $config);
@@ -309,8 +309,15 @@ class ContaiPublisuitesService
         }
 
         $filePath = ABSPATH . sanitize_file_name($config['verificationFileName']);
-        if (file_exists($filePath) && !unlink($filePath)) {
-            error_log('[1Platform] Failed to delete verification file: ' . $filePath);
+        $realPath = realpath($filePath);
+
+        if ($realPath === false || strpos($realPath, realpath(ABSPATH)) !== 0) {
+            error_log('[1Platform] Blocked verification file deletion outside ABSPATH');
+            return;
+        }
+
+        if (!unlink($realPath)) {
+            error_log('[1Platform] Failed to delete verification file');
         }
     }
 

--- a/includes/services/publisuites/PublisuitesService.php
+++ b/includes/services/publisuites/PublisuitesService.php
@@ -290,21 +290,28 @@ class ContaiPublisuitesService
         }
 
         $endpoint = ContaiOnePlatformEndpoints::websitePublisuites($websiteId);
-        $response = $this->client->post($endpoint, [
-            'action' => 'delete',
-        ]);
+        $response = $this->client->post($endpoint, ['action' => 'delete']);
 
-        if ($response->isSuccess()) {
-            if (!empty($config['verificationFileName'])) {
-                $filePath = ABSPATH . sanitize_file_name($config['verificationFileName']);
-                if (file_exists($filePath) && !unlink($filePath)) {
-                    error_log('[1Platform] Failed to delete verification file: ' . $filePath);
-                }
-            }
-            $this->deletePublisuitesConfig();
+        if (!$response->isSuccess()) {
+            return $response;
         }
 
+        $this->deleteVerificationFile($config);
+        $this->deletePublisuitesConfig();
+
         return $response;
+    }
+
+    private function deleteVerificationFile(array $config): void
+    {
+        if (empty($config['verificationFileName'])) {
+            return;
+        }
+
+        $filePath = ABSPATH . sanitize_file_name($config['verificationFileName']);
+        if (file_exists($filePath) && !unlink($filePath)) {
+            error_log('[1Platform] Failed to delete verification file: ' . $filePath);
+        }
     }
 
     public function acceptOrder(int $orderId): ContaiOnePlatformResponse


### PR DESCRIPTION
## Summary
- Add `marketplace_pending` state when website is verified but awaiting marketplace approval
- Add "Remove from Marketplace" action (delete from external marketplace + reset local config + delete verification file)
- Update `triggerSync()` to save `marketplace_status` from sync response
- Add approved badge to `ConnectedSection` when marketplace status is active

## Files Changed (Plugin)
| File | Change |
|------|--------|
| `PublisuitesService.php` | `deleteWebsiteFromMarketplace()`, update `triggerSync()` |
| `PublisuitesFormHandler.php` | `handleDeleteFromMarketplace()` handler |
| `PublisuitesPanel.php` | `marketplace_pending` state logic + section routing |
| `MarketplacePendingSection.php` | **New** — pending state UI with Sync Now + Remove buttons |
| `ConnectedSection.php` | Approved badge + Remove from Marketplace button |

## Depends On
- API PR: 1platformlabs/1platform-api#87 (must deploy first)

## Test plan
- [ ] Verify pending state shows after website add + verify
- [ ] Verify Sync Now transitions to connected when marketplace approves
- [ ] Verify Remove from Marketplace deletes config, file, and redirects to not_connected
- [ ] Verify JS confirm dialog appears before delete
- [ ] Verify nonce + capability checks on delete handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)