### PR TITLE
fix(cookie-notice): add default fallback text to frontend cookie banner (#85)

### DIFF
--- a/1platform-content-ai.php
+++ b/1platform-content-ai.php
@@ -4,7 +4,7 @@
  * Plugin Name: 1Platform Content AI
  * Plugin URI: https://1platform.pro/
  * Description: SaaS client for AI-powered content generation, SEO optimization, and site management. All AI processing happens on 1Platform external servers. Includes free local tools: Table of Contents and Internal Links.
- * Version: 2.28.3
+ * Version: 2.28.4
  * Author: 1Platform
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -18,7 +18,7 @@
 
 if (!defined('ABSPATH')) exit;
 
-define('CONTAI_VERSION', '2.28.2');
+define('CONTAI_VERSION', '2.28.4');
 
 require_once plugin_dir_path(__FILE__) . 'includes/helpers/security.php';
 require_once plugin_dir_path(__FILE__) . 'includes/helpers/crypto.php';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Content AI are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.28.4] - 2026-04-13
+
+### Fixed
+- **Cookie banner missing text**: Frontend `render_cookie_notice()` called `get_option('contai_cookie_notice_text')` without a default fallback, so the banner showed buttons but no text when the option was never explicitly saved. Added `ContaiLegalPagesHelper::get_cookie_text()` as default, matching the admin panel behavior (#85)
+
 ## [2.28.2] - 2026-04-08
 
 ### Fixed

--- a/includes/admin/content-generator/helpers/cookie-notice-helper.php
+++ b/includes/admin/content-generator/helpers/cookie-notice-helper.php
@@ -4,6 +4,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+require_once __DIR__ . '/legal-pages-helper.php';
+
 class ContaiCookieNoticeHelper {
 
 	public static function enqueue_assets(): void {
@@ -37,7 +39,7 @@ class ContaiCookieNoticeHelper {
 		self::enqueue_assets();
 
 		$language = get_option( 'contai_site_language', 'spanish' );
-		$text = get_option( 'contai_cookie_notice_text' );
+		$text = get_option( 'contai_cookie_notice_text', ContaiLegalPagesHelper::get_cookie_text() );
 		$privacy_page = get_posts( array(
 			'post_type'   => 'page',
 			'meta_key'    => '_contai_legal_key',

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai content, seo, content generation, internal links, table of contents
 Requires at least: 5.9
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.28.3
+Stable tag: 2.28.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -159,6 +159,9 @@ The plugin sends your site URL, API key, and content generation parameters (keyw
 7. Tools — Google Analytics, Google Search Console, Publisuites, and Ads Manager integrations.
 
 == Changelog ==
+
+= 2.28.4 =
+* Fixed: Cookie banner displayed buttons but no informative text when cookie text option was never explicitly saved (#85)
 
 = 2.27.1 =
 * Fixed: WP 6.9 sanitize_callback crash on onboarding REST route (floatval argument count)


### PR DESCRIPTION
## Summary
- Cookie consent banner showed buttons ("Estoy de acuerdo", "Rechazar", "Política de privacidad") but **no informative text** on the frontend
- Root cause: `get_option('contai_cookie_notice_text')` had no default fallback in `render_cookie_notice()` — returns empty when the option was never explicitly saved
- Added the same `ContaiLegalPagesHelper::get_cookie_text()` default that the admin panel already uses

## Changes
- `includes/admin/content-generator/helpers/cookie-notice-helper.php`:
  - Added `require_once` for `legal-pages-helper.php` (class needed on frontend, was only loaded in admin context)
  - Added default fallback parameter to `get_option()` call on line 42

## Audit Results
- PHP syntax: ✅ No errors
- Provider name scan: ✅ Clean
- Version sync: ✅ All 3 locations match (2.28.4)
- PHPUnit: ✅ 610 tests, 1074 assertions

## Test Plan
- [ ] Visit a site with the plugin active where "Save Cookie Settings" was never clicked
- [ ] Verify the cookie banner now shows the default text above the buttons
- [ ] Verify that custom text (when explicitly saved) still takes precedence
- [ ] Clear browser cookies and verify banner reappears with text

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)