### PR TITLE
feat(publisuites): auto-connect link building on license activation (#93)

### DIFF
--- a/1platform-content-ai.php
+++ b/1platform-content-ai.php
@@ -4,7 +4,7 @@
  * Plugin Name: 1Platform Content AI
  * Plugin URI: https://1platform.pro/
  * Description: SaaS client for AI-powered content generation, SEO optimization, and site management. All AI processing happens on 1Platform external servers. Includes free local tools: Table of Contents and Internal Links.
- * Version: 2.28.6
+ * Version: 2.29.0
  * Author: 1Platform
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -18,7 +18,7 @@
 
 if (!defined('ABSPATH')) exit;
 
-define('CONTAI_VERSION', '2.28.4');
+define('CONTAI_VERSION', '2.29.0');
 
 require_once plugin_dir_path(__FILE__) . 'includes/helpers/security.php';
 require_once plugin_dir_path(__FILE__) . 'includes/helpers/crypto.php';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Content AI are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.29.0] - 2026-04-13
+
+### Added
+- **Auto-connect link building on license activation**: When a user activates a license on a site that already has link building connected in the API, the plugin now automatically detects and restores that connection. Handles three scenarios: already verified (instant restore), registered but unverified (creates verification file and verifies), and not registered (full activation flow). Graceful degradation ensures license activation never fails due to link building issues (#93)
+
 ## [2.28.4] - 2026-04-13
 
 ### Fixed

--- a/includes/admin/licenses/WPContentAILicensePanel.php
+++ b/includes/admin/licenses/WPContentAILicensePanel.php
@@ -5,6 +5,7 @@ if (!defined('ABSPATH')) exit;
 require_once __DIR__ . '/../../services/user-profile/UserProfileService.php';
 require_once __DIR__ . '/../../services/api/OnePlatformAuthService.php';
 require_once __DIR__ . '/../../providers/WebsiteProvider.php';
+require_once __DIR__ . '/../../services/setup/PublisuitesSetupService.php';
 require_once __DIR__ . '/components/ActivateLicenseSection.php';
 require_once __DIR__ . '/components/UserProfileSection.php';
 require_once __DIR__ . '/components/CreateAccountSection.php';
@@ -52,6 +53,22 @@ class WPContentAILicensePanel
                         break;
                     case 'already_configured':
                         $message .= ' ' . __('Website already configured.', '1platform-content-ai');
+                        break;
+                }
+            }
+
+            if (isset($_GET['publisuites_setup'])) {
+                $publiAction = sanitize_key(wp_unslash($_GET['publisuites_setup']));
+
+                switch ($publiAction) {
+                    case 'restored':
+                        $message .= ' ' . __('Link building connection restored.', '1platform-content-ai');
+                        break;
+                    case 'verified':
+                        $message .= ' ' . __('Link building verified and connected.', '1platform-content-ai');
+                        break;
+                    case 'full_activation':
+                        $message .= ' ' . __('Link building activated.', '1platform-content-ai');
                         break;
                 }
             }
@@ -201,6 +218,18 @@ class WPContentAILicensePanel
 
         if ($websiteResult['success']) {
             $args['website_setup'] = sanitize_key($websiteResult['action']);
+
+            // Step 4: Auto-connect Publisuites (graceful — never blocks activation)
+            $websiteData = $websiteResult['website_data'] ?? [];
+            if (!empty($websiteData)) {
+                try {
+                    $publiSetup = new ContaiPublisuitesSetupService();
+                    $publiResult = $publiSetup->autoConnect($websiteData);
+                    $args['publisuites_setup'] = sanitize_key($publiResult['action'] ?? 'skipped');
+                } catch (\Exception $e) {
+                    $args['publisuites_setup'] = 'error';
+                }
+            }
         } else {
             $args['website_setup_error'] = '1';
         }

--- a/includes/providers/WebsiteProvider.php
+++ b/includes/providers/WebsiteProvider.php
@@ -300,10 +300,14 @@ class ContaiWebsiteProvider
             $this->debugLog('Website already configured locally (ID: ' . $existingConfig['websiteId'] . '), syncing status');
             $this->syncWebsiteStatus();
 
+            $apiResponse = $this->getWebsiteFromApi();
+            $websiteData = ($apiResponse && $apiResponse->isSuccess()) ? $apiResponse->getData() : [];
+
             return [
-                'success' => true,
-                'action'  => 'already_configured',
-                'message' => 'Website already configured',
+                'success'      => true,
+                'action'       => 'already_configured',
+                'message'      => 'Website already configured',
+                'website_data' => $websiteData,
             ];
         }
 
@@ -312,12 +316,14 @@ class ContaiWebsiteProvider
 
         if ($searchResponse->isSuccess()) {
             $this->debugLog('Website found in API, saving config locally');
-            $this->saveWebsiteConfig($searchResponse->getData());
+            $websiteData = $searchResponse->getData();
+            $this->saveWebsiteConfig($websiteData);
 
             return [
-                'success' => true,
-                'action'  => 'linked',
-                'message' => 'Website already exists',
+                'success'      => true,
+                'action'       => 'linked',
+                'message'      => 'Website already exists',
+                'website_data' => $websiteData,
             ];
         }
 
@@ -344,13 +350,15 @@ class ContaiWebsiteProvider
             ];
         }
 
-        $this->saveWebsiteConfig($createResponse->getData());
+        $websiteData = $createResponse->getData();
+        $this->saveWebsiteConfig($websiteData);
         $this->debugLog('Website created and saved successfully');
 
         return [
-            'success' => true,
-            'action'  => 'created',
-            'message' => 'Website added successfully',
+            'success'      => true,
+            'action'       => 'created',
+            'message'      => 'Website added successfully',
+            'website_data' => $websiteData,
         ];
     }
 

--- a/includes/services/setup/PublisuitesSetupService.php
+++ b/includes/services/setup/PublisuitesSetupService.php
@@ -14,6 +14,97 @@ class ContaiPublisuitesSetupService
         $this->publisuiteService = $publisuiteService ?? new ContaiPublisuitesService();
     }
 
+    /**
+     * Auto-connect Publisuites using website data from the API.
+     *
+     * Reads actions.publisuites.verification from the website response and:
+     * - If publisuites_id exists AND verified: saves config as active (no API calls)
+     * - If publisuites_id exists AND NOT verified: creates verification file + verifies
+     * - If no publisuites_id: runs the full activation flow (add → file → verify)
+     *
+     * @param array $websiteData Full website data from the API response
+     * @return array{success: bool, action: string, message: string}
+     */
+    public function autoConnect(array $websiteData): array
+    {
+        $publisuites = $websiteData['actions']['publisuites']['verification'] ?? [];
+        $publisuitesId = $publisuites['publisuites_id'] ?? null;
+
+        if (empty($publisuitesId)) {
+            $result = $this->activatePublisuites();
+
+            return [
+                'success' => $result['success'],
+                'action'  => 'full_activation',
+                'message' => $result['success']
+                    ? 'Publisuites registered and verified'
+                    : implode('; ', $result['errors']),
+            ];
+        }
+
+        $verified = $publisuites['verified'] ?? false;
+
+        if ($verified) {
+            $this->publisuiteService->savePublisuitesConfig([
+                'publisuites_id'            => $publisuitesId,
+                'verification_file_name'    => $publisuites['file_name'] ?? '',
+                'verification_file_content' => $publisuites['file_content'] ?? '',
+                'verified'                  => true,
+                'verified_at'               => $publisuites['verified_at'] ?? null,
+                'status'                    => 'active',
+                'marketplace_status'        => $publisuites['marketplace_status'] ?? null,
+            ]);
+
+            return [
+                'success' => true,
+                'action'  => 'restored',
+                'message' => 'Publisuites connection restored from API',
+            ];
+        }
+
+        // publisuites_id exists but not verified — create file and verify
+        $this->publisuiteService->savePublisuitesConfig([
+            'publisuites_id'            => $publisuitesId,
+            'verification_file_name'    => $publisuites['file_name'] ?? '',
+            'verification_file_content' => $publisuites['file_content'] ?? '',
+            'verified'                  => false,
+            'status'                    => 'pending_verification',
+        ]);
+
+        $fileResult = $this->publisuiteService->createVerificationFile();
+        if (!$fileResult['success']) {
+            return [
+                'success' => false,
+                'action'  => 'verification_file_failed',
+                'message' => $fileResult['message'] ?? 'Failed to create verification file',
+            ];
+        }
+
+        $verifyResponse = $this->publisuiteService->verifyWebsite();
+        if (!$verifyResponse->isSuccess()) {
+            return [
+                'success' => false,
+                'action'  => 'verification_failed',
+                'message' => $verifyResponse->getMessage() ?? 'Failed to verify website',
+            ];
+        }
+
+        $verifyData = $verifyResponse->getData();
+        $config = $this->publisuiteService->getPublisuitesConfig();
+        if ($config) {
+            $config['verified'] = $verifyData['verified'] ?? false;
+            $config['verifiedAt'] = $verifyData['verified_at'] ?? null;
+            $config['status'] = ($verifyData['verified'] ?? false) ? 'active' : 'pending_verification';
+            $this->publisuiteService->savePublisuitesConfig($config);
+        }
+
+        return [
+            'success' => true,
+            'action'  => 'verified',
+            'message' => 'Publisuites verified and connected',
+        ];
+    }
+
     public function activatePublisuites(): array
     {
         $results = [

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai content, seo, content generation, internal links, table of contents
 Requires at least: 5.9
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.28.6
+Stable tag: 2.29.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/tests/unit/services/setup/PublisuitesSetupServiceTest.php
+++ b/tests/unit/services/setup/PublisuitesSetupServiceTest.php
@@ -259,6 +259,218 @@ class PublisuitesSetupServiceTest extends TestCase
         $this->assertTrue($result['success']);
     }
 
+    // ── autoConnect: already verified ─────────────────────────────
+
+    public function test_autoConnect_restores_verified_publisuites(): void
+    {
+        $websiteData = [
+            'id' => 'ws-100',
+            'actions' => [
+                'publisuites' => [
+                    'verification' => [
+                        'publisuites_id' => 'ps-999',
+                        'file_name' => 'verify-token.html',
+                        'file_content' => '<html>ok</html>',
+                        'verified' => true,
+                        'verified_at' => '2026-04-01T10:00:00Z',
+                        'marketplace_status' => 'active',
+                    ],
+                ],
+            ],
+        ];
+
+        $this->service
+            ->shouldReceive('savePublisuitesConfig')
+            ->once()
+            ->with(Mockery::on(function ($config) {
+                return $config['publisuites_id'] === 'ps-999'
+                    && $config['verified'] === true
+                    && $config['status'] === 'active'
+                    && $config['verified_at'] === '2026-04-01T10:00:00Z'
+                    && $config['marketplace_status'] === 'active';
+            }));
+
+        // Should NOT call any API methods
+        $this->service->shouldNotReceive('connectWebsite');
+        $this->service->shouldNotReceive('verifyWebsite');
+        $this->service->shouldNotReceive('createVerificationFile');
+
+        $result = $this->setupService->autoConnect($websiteData);
+
+        $this->assertTrue($result['success']);
+        $this->assertEquals('restored', $result['action']);
+    }
+
+    // ── autoConnect: registered but not verified ────────────────
+
+    public function test_autoConnect_verifies_unverified_publisuites(): void
+    {
+        $websiteData = [
+            'id' => 'ws-100',
+            'actions' => [
+                'publisuites' => [
+                    'verification' => [
+                        'publisuites_id' => 'ps-888',
+                        'file_name' => 'verify-token.html',
+                        'file_content' => '<html>pending</html>',
+                        'verified' => false,
+                    ],
+                ],
+            ],
+        ];
+
+        // Save initial config
+        $this->service
+            ->shouldReceive('savePublisuitesConfig')
+            ->once()
+            ->with(Mockery::on(function ($config) {
+                return $config['publisuites_id'] === 'ps-888'
+                    && $config['verified'] === false
+                    && $config['status'] === 'pending_verification';
+            }))
+            ->ordered();
+
+        $this->service
+            ->shouldReceive('createVerificationFile')
+            ->once()
+            ->andReturn(['success' => true, 'message' => 'File created']);
+
+        $this->service
+            ->shouldReceive('verifyWebsite')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(true, ['verified' => true, 'verified_at' => '2026-04-01T12:00:00Z'], 'Verified', 200));
+
+        $this->service
+            ->shouldReceive('getPublisuitesConfig')
+            ->once()
+            ->andReturn(['publisuites_id' => 'ps-888', 'status' => 'pending_verification']);
+
+        // Save updated config after verify
+        $this->service
+            ->shouldReceive('savePublisuitesConfig')
+            ->once()
+            ->with(Mockery::on(function ($config) {
+                return $config['verified'] === true && $config['status'] === 'active';
+            }))
+            ->ordered();
+
+        // Should NOT call connectWebsite (already registered)
+        $this->service->shouldNotReceive('connectWebsite');
+
+        $result = $this->setupService->autoConnect($websiteData);
+
+        $this->assertTrue($result['success']);
+        $this->assertEquals('verified', $result['action']);
+    }
+
+    // ── autoConnect: no publisuites → full activation ───────────
+
+    public function test_autoConnect_runs_full_activation_when_no_publisuites(): void
+    {
+        $websiteData = [
+            'id' => 'ws-100',
+            'actions' => [
+                'search_console' => ['verification' => ['verified' => true]],
+            ],
+        ];
+
+        // Full activation flow
+        $connectData = [
+            'publisuites_id' => 'ps-new',
+            'verification_file_name' => 'verify.html',
+            'verification_file_content' => '<html>verify</html>',
+        ];
+
+        $this->service
+            ->shouldReceive('connectWebsite')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(true, $connectData, 'Added', 200));
+
+        $this->service->shouldReceive('savePublisuitesConfig')->twice();
+
+        $this->service
+            ->shouldReceive('createVerificationFile')
+            ->once()
+            ->andReturn(['success' => true, 'message' => 'File created']);
+
+        $this->service
+            ->shouldReceive('verifyWebsite')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(true, ['verified' => true, 'verified_at' => '2026-04-01'], 'Verified', 200));
+
+        $this->service
+            ->shouldReceive('getPublisuitesConfig')
+            ->once()
+            ->andReturn(['publisuites_id' => 'ps-new']);
+
+        $result = $this->setupService->autoConnect($websiteData);
+
+        $this->assertTrue($result['success']);
+        $this->assertEquals('full_activation', $result['action']);
+    }
+
+    // ── autoConnect: verification file creation fails ───────────
+
+    public function test_autoConnect_returns_failure_when_verification_file_fails(): void
+    {
+        $websiteData = [
+            'id' => 'ws-100',
+            'actions' => [
+                'publisuites' => [
+                    'verification' => [
+                        'publisuites_id' => 'ps-777',
+                        'file_name' => 'verify.html',
+                        'file_content' => '<html>v</html>',
+                        'verified' => false,
+                    ],
+                ],
+            ],
+        ];
+
+        $this->service->shouldReceive('savePublisuitesConfig')->once();
+
+        $this->service
+            ->shouldReceive('createVerificationFile')
+            ->once()
+            ->andReturn(['success' => false, 'message' => 'Permission denied']);
+
+        $this->service->shouldNotReceive('verifyWebsite');
+
+        $result = $this->setupService->autoConnect($websiteData);
+
+        $this->assertFalse($result['success']);
+        $this->assertEquals('verification_file_failed', $result['action']);
+    }
+
+    // ── autoConnect: empty actions falls back to full activation ─
+
+    public function test_autoConnect_with_empty_publisuites_id_runs_full_activation(): void
+    {
+        $websiteData = [
+            'id' => 'ws-100',
+            'actions' => [
+                'publisuites' => [
+                    'verification' => [
+                        'publisuites_id' => null,
+                    ],
+                ],
+            ],
+        ];
+
+        // Full activation should be called
+        $this->service
+            ->shouldReceive('connectWebsite')
+            ->once()
+            ->andReturn(new ContaiOnePlatformResponse(false, null, 'API error', 500));
+
+        $this->service->shouldNotReceive('savePublisuitesConfig');
+
+        $result = $this->setupService->autoConnect($websiteData);
+
+        $this->assertFalse($result['success']);
+        $this->assertEquals('full_activation', $result['action']);
+    }
+
     // ── Config updated to active after verify ────────────────────
 
     public function test_activate_updates_config_to_active_after_verify(): void


### PR DESCRIPTION
## Summary
- Auto-detect and restore Publisuites connection when activating a license on a site that already has it connected in the API
- Handle three scenarios: already verified (instant restore), unverified (file + verify), not registered (full flow)
- Graceful degradation — Publisuites failures never block license activation

## Changes
- **`WebsiteProvider::ensureWebsiteExists()`** — Returns `website_data` (including `actions.publisuites`) in the result array for all 3 paths (already_configured, linked, created)
- **`PublisuitesSetupService::autoConnect()`** — New method that reads Publisuites state from website API data and takes the correct action
- **`WPContentAILicensePanel::handleActivateLicense()`** — Calls `autoConnect()` after website setup (Step 4), wrapped in try/catch for graceful degradation
- **User-facing messages** — Uses "Link building" terminology (no provider name exposure)
- **5 new unit tests** covering all `autoConnect` scenarios

## Audit Results
- PHP syntax: clean on all modified files
- Provider name scan: clean (user-facing strings say "Link building")
- Version sync: 2.29.0 across all 3 locations (header, constant, readme)
- All 615 tests pass (1084 assertions)

## Test Plan
- [x] All 615 tests pass (1084 assertions)
- [x] 5 new tests: restore verified, verify unverified, full activation, file creation failure, empty publisuites_id
- [x] No regressions in existing test suites
- [ ] Manual: Activate license on site with Publisuites already connected → auto-connects
- [ ] Manual: Activate license on site without Publisuites → runs full activation
- [ ] Manual: If Publisuites API fails → license still activates successfully

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)