### PR TITLE
fix(jobs): catch \Throwable and fix recovery infinite loop (#86)

### DIFF
--- a/1platform-content-ai.php
+++ b/1platform-content-ai.php
@@ -4,7 +4,7 @@
  * Plugin Name: 1Platform Content AI
  * Plugin URI: https://1platform.pro/
  * Description: SaaS client for AI-powered content generation, SEO optimization, and site management. All AI processing happens on 1Platform external servers. Includes free local tools: Table of Contents and Internal Links.
- * Version: 2.30.0
+ * Version: 2.30.1
  * Author: 1Platform
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -18,7 +18,7 @@
 
 if (!defined('ABSPATH')) exit;
 
-define('CONTAI_VERSION', '2.29.0');
+define('CONTAI_VERSION', '2.30.1');
 
 require_once plugin_dir_path(__FILE__) . 'includes/helpers/security.php';
 require_once plugin_dir_path(__FILE__) . 'includes/helpers/crypto.php';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Content AI are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.30.1] - 2026-04-13
+
+### Fixed
+- **Post Generation jobs stuck in Processing forever**: Jobs that threw PHP `Error` types (TypeError, ValueError) escaped the `catch (Exception)` block, leaving them permanently stuck in PROCESSING status. Changed to `catch (\Throwable)` to handle all error types. Additionally, the recovery system created an infinite retry loop — `ResetToPendingStrategy` always fired before `MarkAsFailedStrategy` without tracking attempts. Recovery now increments attempts and respects `max_attempts`, allowing jobs to properly escalate to FAILED after 3 retries. Enabled `set_time_limit(300)` to prevent PHP from hanging indefinitely during job execution (#86)
+
+### Added
+- **Job processor and recovery strategy tests**: 16 new regression tests covering Throwable catch behavior, recovery attempt tracking, and the full escalation chain from reset-to-pending through mark-as-failed
+
 ## [2.29.0] - 2026-04-13
 
 ### Added

--- a/includes/services/jobs/JobProcessor.php
+++ b/includes/services/jobs/JobProcessor.php
@@ -30,8 +30,8 @@ class ContaiJobProcessor
 
     public function processQueue()
     {
-        //set_time_limit(300);
-        //ini_set('max_execution_time', '300');
+        set_time_limit(300);
+        ini_set('max_execution_time', '300');
 
         if (!$this->acquireLock()) {
             return 0;
@@ -100,7 +100,7 @@ class ContaiJobProcessor
 
             $job->markAsCompleted();
             $this->jobRepository->update($job);
-        } catch (Exception $e) {
+        } catch (\Throwable $e) {
             $errorMessage = $e->getMessage(); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 
             // Tag 402 errors so recovery strategies can skip them
@@ -141,7 +141,7 @@ class ContaiJobProcessor
         return $this->jobHandlers[$jobType] ?? null;
     }
 
-    private function isInsufficientCreditsException(Exception $e): bool {
+    private function isInsufficientCreditsException(\Throwable $e): bool {
         $message = strtolower($e->getMessage());
 
         if (strpos($message, 'insufficient balance') !== false

--- a/includes/services/jobs/recovery/MarkAsFailedStrategy.php
+++ b/includes/services/jobs/recovery/MarkAsFailedStrategy.php
@@ -20,6 +20,11 @@ class ContaiMarkAsFailedStrategy implements ContaiJobRecoveryStrategy
             return false;
         }
 
+        // Always fail jobs that have exhausted all retry attempts
+        if ($job->hasReachedMaxAttempts()) {
+            return true;
+        }
+
         $processedAt = $job->getProcessedAt();
 
         if (empty($processedAt)) {

--- a/includes/services/jobs/recovery/ResetToPendingStrategy.php
+++ b/includes/services/jobs/recovery/ResetToPendingStrategy.php
@@ -21,6 +21,11 @@ class ContaiResetToPendingStrategy implements ContaiJobRecoveryStrategy
             return false;
         }
 
+        // Don't reset if max attempts reached — let MarkAsFailedStrategy handle it
+        if ($job->hasReachedMaxAttempts()) {
+            return false;
+        }
+
         // Never re-queue jobs that failed due to insufficient credits
         $errorMessage = $job->getErrorMessage() ?? '';
         if (ContaiCreditGuard::isInsufficientCreditsError($errorMessage)) {
@@ -49,6 +54,7 @@ class ContaiResetToPendingStrategy implements ContaiJobRecoveryStrategy
 
     public function recover(ContaiJob $job): void
     {
+        $job->incrementAttempts();
         $job->setStatus(ContaiJobStatus::PENDING);
         $job->setProcessedAt(null);
     }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai content, seo, content generation, internal links, table of contents
 Requires at least: 5.9
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.30.0
+Stable tag: 2.30.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -159,6 +159,9 @@ The plugin sends your site URL, API key, and content generation parameters (keyw
 7. Tools — Google Analytics, Google Search Console, Publisuites, and Ads Manager integrations.
 
 == Changelog ==
+
+= 2.30.1 =
+* Fixed: Post Generation jobs stuck in Processing status indefinitely — now catches all PHP error types and properly escalates to Failed after max retries (#86)
 
 = 2.28.4 =
 * Fixed: Cookie banner displayed buttons but no informative text when cookie text option was never explicitly saved (#85)

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -114,6 +114,11 @@ require_once __DIR__ . '/../includes/admin/content-generator/handlers/KeywordExt
 require_once __DIR__ . '/../includes/services/jobs/QueueManager.php';
 require_once __DIR__ . '/../includes/services/jobs/JobInterface.php';
 require_once __DIR__ . '/../includes/services/jobs/SiteGenerationJob.php';
+require_once __DIR__ . '/../includes/services/jobs/recovery/JobRecoveryStrategy.php';
+require_once __DIR__ . '/../includes/services/jobs/recovery/ResetToPendingStrategy.php';
+require_once __DIR__ . '/../includes/services/jobs/recovery/MarkAsFailedStrategy.php';
+require_once __DIR__ . '/../includes/services/jobs/recovery/JobRecoveryService.php';
+require_once __DIR__ . '/../includes/services/jobs/JobProcessor.php';
 require_once __DIR__ . '/../includes/admin/content-generator/handlers/PostGenerationQueueHandler.php';
 require_once __DIR__ . '/../includes/admin/content-generator/panels/post-maintenance.php';
 

--- a/tests/unit/services/jobs/JobProcessorTest.php
+++ b/tests/unit/services/jobs/JobProcessorTest.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace ContAI\Tests\Unit\Services\Jobs;
+
+use WP_Mock;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use ContaiJobProcessor;
+use ContaiJobRepository;
+use ContaiJobRecoveryService;
+use ContaiJob;
+use ContaiJobStatus;
+use ContaiJobInterface;
+use ContaiDatabase;
+use ContaiConfig;
+
+class JobProcessorTest extends TestCase
+{
+    private ContaiJobProcessor $processor;
+    private $jobRepository;
+    private $recoveryService;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        WP_Mock::setUp();
+
+        // Reset singletons
+        $dbRef = new \ReflectionClass(ContaiDatabase::class);
+        $instanceProp = $dbRef->getProperty('instance');
+        $instanceProp->setAccessible(true);
+        $instanceProp->setValue(null, null);
+
+        $configRef = new \ReflectionClass(ContaiConfig::class);
+        $configProp = $configRef->getProperty('instance');
+        $configProp->setAccessible(true);
+        $configProp->setValue(null, null);
+
+        global $wpdb;
+        $wpdb = Mockery::mock('wpdb');
+        $wpdb->prefix = 'wp_';
+        $wpdb->options = 'wp_options';
+
+        // Mock WP functions needed by handler constructors
+        WP_Mock::userFunction('current_time')->andReturn('2025-01-15 10:00:00');
+        WP_Mock::userFunction('get_site_url')->andReturn('https://example.com');
+        WP_Mock::userFunction('get_option')->andReturn(false);
+        WP_Mock::userFunction('wp_upload_dir')->andReturn(['basedir' => '/tmp', 'baseurl' => '/uploads']);
+
+        $this->recoveryService = Mockery::mock(ContaiJobRecoveryService::class);
+        $this->processor = new ContaiJobProcessor($this->recoveryService);
+
+        // Inject mock repository
+        $this->jobRepository = Mockery::mock(ContaiJobRepository::class);
+        $ref = new \ReflectionClass($this->processor);
+        $prop = $ref->getProperty('jobRepository');
+        $prop->setAccessible(true);
+        $prop->setValue($this->processor, $this->jobRepository);
+    }
+
+    public function tearDown(): void
+    {
+        $this->addToAssertionCount(Mockery::getContainer()->mockery_getExpectationCount());
+        WP_Mock::tearDown();
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    private function injectHandler(string $type, ContaiJobInterface $handler): void
+    {
+        $ref = new \ReflectionClass($this->processor);
+        $prop = $ref->getProperty('jobHandlers');
+        $prop->setAccessible(true);
+        $handlers = $prop->getValue($this->processor);
+        $handlers[$type] = $handler;
+        $prop->setValue($this->processor, $handlers);
+    }
+
+    private function invokeProcessJob(ContaiJob $job): void
+    {
+        $ref = new \ReflectionClass($this->processor);
+        $method = $ref->getMethod('processJob');
+        $method->setAccessible(true);
+        $method->invoke($this->processor, $job);
+    }
+
+    private function createJob(int $id, string $type = 'post_generation'): ContaiJob
+    {
+        $job = new ContaiJob();
+        $job->setId($id);
+        $job->setJobType($type);
+        $job->setPayload(['keyword_id' => $id]);
+        return $job;
+    }
+
+    public function test_process_job_catches_throwable_type_error(): void
+    {
+        $job = $this->createJob(1);
+
+        $handler = new class implements ContaiJobInterface {
+            public function handle(array $payload) {
+                throw new \TypeError('Argument must be of type string, null given');
+            }
+            public function getType() { return 'post_generation'; }
+        };
+
+        $this->injectHandler('post_generation', $handler);
+        $this->jobRepository->shouldReceive('update')->once();
+
+        $this->invokeProcessJob($job);
+
+        $this->assertSame(ContaiJobStatus::FAILED, $job->getStatus());
+        $this->assertSame(1, $job->getAttempts());
+        $this->assertStringContainsString('Argument must be of type string', $job->getErrorMessage());
+    }
+
+    public function test_process_job_catches_throwable_value_error(): void
+    {
+        $job = $this->createJob(2);
+
+        $handler = new class implements ContaiJobInterface {
+            public function handle(array $payload) {
+                throw new \ValueError('Value out of range');
+            }
+            public function getType() { return 'post_generation'; }
+        };
+
+        $this->injectHandler('post_generation', $handler);
+        $this->jobRepository->shouldReceive('update')->once();
+
+        $this->invokeProcessJob($job);
+
+        $this->assertSame(ContaiJobStatus::FAILED, $job->getStatus());
+        $this->assertStringContainsString('Value out of range', $job->getErrorMessage());
+    }
+
+    public function test_process_job_still_catches_regular_exceptions(): void
+    {
+        $job = $this->createJob(3);
+
+        $handler = new class implements ContaiJobInterface {
+            public function handle(array $payload) {
+                throw new \RuntimeException('API timeout');
+            }
+            public function getType() { return 'post_generation'; }
+        };
+
+        $this->injectHandler('post_generation', $handler);
+        $this->jobRepository->shouldReceive('update')->once();
+
+        $this->invokeProcessJob($job);
+
+        $this->assertSame(ContaiJobStatus::FAILED, $job->getStatus());
+        $this->assertSame(1, $job->getAttempts());
+        $this->assertStringContainsString('API timeout', $job->getErrorMessage());
+    }
+
+    public function test_process_job_marks_completed_on_success(): void
+    {
+        $job = $this->createJob(4);
+
+        $handler = new class implements ContaiJobInterface {
+            public function handle(array $payload) {
+                return ['success' => true];
+            }
+            public function getType() { return 'post_generation'; }
+        };
+
+        $this->injectHandler('post_generation', $handler);
+        $this->jobRepository->shouldReceive('update')->once();
+
+        $this->invokeProcessJob($job);
+
+        $this->assertSame(ContaiJobStatus::DONE, $job->getStatus());
+    }
+
+    public function test_process_job_returns_on_continue(): void
+    {
+        $job = $this->createJob(5);
+
+        $handler = new class implements ContaiJobInterface {
+            public function handle(array $payload) {
+                return ['continue' => true];
+            }
+            public function getType() { return 'post_generation'; }
+        };
+
+        $this->injectHandler('post_generation', $handler);
+        // No repository update expected for 'continue'
+
+        $this->invokeProcessJob($job);
+
+        // Status should remain unchanged (handler manages its own state)
+        $this->assertSame(ContaiJobStatus::PENDING, $job->getStatus());
+    }
+}

--- a/tests/unit/services/jobs/recovery/MarkAsFailedStrategyTest.php
+++ b/tests/unit/services/jobs/recovery/MarkAsFailedStrategyTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace ContAI\Tests\Unit\Services\Jobs\Recovery;
+
+use WP_Mock;
+use PHPUnit\Framework\TestCase;
+use ContaiMarkAsFailedStrategy;
+use ContaiResetToPendingStrategy;
+use ContaiJob;
+use ContaiJobStatus;
+
+class MarkAsFailedStrategyTest extends TestCase
+{
+    private ContaiMarkAsFailedStrategy $strategy;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        WP_Mock::setUp();
+        $this->strategy = new ContaiMarkAsFailedStrategy(240);
+    }
+
+    public function tearDown(): void
+    {
+        WP_Mock::tearDown();
+        parent::tearDown();
+    }
+
+    private function mockTime(): void
+    {
+        WP_Mock::userFunction('current_time')
+            ->withArgs(['mysql'])
+            ->andReturn(gmdate('Y-m-d H:i:s'));
+
+        WP_Mock::userFunction('current_time')
+            ->withArgs(['timestamp'])
+            ->andReturn(time());
+    }
+
+    public function test_should_recover_when_max_attempts_reached(): void
+    {
+        $this->mockTime();
+
+        $job = new ContaiJob();
+        $job->setId(1);
+        $job->setJobType('post_generation');
+        $job->setStatus(ContaiJobStatus::PROCESSING);
+        $job->setMaxAttempts(3);
+
+        $job->incrementAttempts();
+        $job->incrementAttempts();
+        $job->incrementAttempts();
+
+        // Even with recent processed_at, should recover because max attempts reached
+        $recentTime = gmdate('Y-m-d H:i:s', time() - (5 * 60));
+        $job->setProcessedAt($recentTime);
+
+        $this->assertTrue($job->hasReachedMaxAttempts());
+        $this->assertTrue($this->strategy->shouldRecover($job));
+    }
+
+    public function test_should_recover_after_time_threshold(): void
+    {
+        $this->mockTime();
+
+        $job = new ContaiJob();
+        $job->setId(1);
+        $job->setJobType('post_generation');
+        $job->setStatus(ContaiJobStatus::PROCESSING);
+
+        $stuckTime = gmdate('Y-m-d H:i:s', time() - (250 * 60));
+        $job->setProcessedAt($stuckTime);
+
+        $this->assertTrue($this->strategy->shouldRecover($job));
+    }
+
+    public function test_should_not_recover_pending_job(): void
+    {
+        $this->mockTime();
+
+        $job = new ContaiJob();
+        $job->setId(1);
+        $job->setStatus(ContaiJobStatus::PENDING);
+
+        $this->assertFalse($this->strategy->shouldRecover($job));
+    }
+
+    public function test_recover_marks_as_failed_with_message(): void
+    {
+        $this->mockTime();
+
+        $job = new ContaiJob();
+        $job->setId(1);
+        $job->setStatus(ContaiJobStatus::PROCESSING);
+
+        $this->strategy->recover($job);
+
+        $this->assertSame(ContaiJobStatus::FAILED, $job->getStatus());
+        $this->assertStringContainsString('240 minutes', $job->getErrorMessage());
+    }
+
+    public function test_recovery_chain_max_attempts_escalates_to_failed(): void
+    {
+        $this->mockTime();
+
+        $resetStrategy = new ContaiResetToPendingStrategy(30);
+
+        $job = new ContaiJob();
+        $job->setId(1);
+        $job->setJobType('post_generation');
+        $job->setStatus(ContaiJobStatus::PROCESSING);
+        $job->setMaxAttempts(3);
+
+        $stuckTime = gmdate('Y-m-d H:i:s', time() - (45 * 60));
+        $job->setProcessedAt($stuckTime);
+
+        // Attempt 1: ResetToPending handles it
+        $this->assertTrue($resetStrategy->shouldRecover($job));
+        $resetStrategy->recover($job);
+        $this->assertSame(ContaiJobStatus::PENDING, $job->getStatus());
+        $this->assertSame(1, $job->getAttempts());
+
+        // Simulate stuck again
+        $job->setStatus(ContaiJobStatus::PROCESSING);
+        $job->setProcessedAt($stuckTime);
+
+        // Attempt 2
+        $this->assertTrue($resetStrategy->shouldRecover($job));
+        $resetStrategy->recover($job);
+        $this->assertSame(2, $job->getAttempts());
+
+        // Simulate stuck again
+        $job->setStatus(ContaiJobStatus::PROCESSING);
+        $job->setProcessedAt($stuckTime);
+
+        // Attempt 3 — last reset
+        $this->assertTrue($resetStrategy->shouldRecover($job));
+        $resetStrategy->recover($job);
+        $this->assertSame(3, $job->getAttempts());
+
+        // Simulate stuck again — max attempts now reached
+        $job->setStatus(ContaiJobStatus::PROCESSING);
+        $job->setProcessedAt($stuckTime);
+
+        // ResetToPending should SKIP (max attempts reached)
+        $this->assertFalse($resetStrategy->shouldRecover($job));
+
+        // MarkAsFailed should handle it
+        $this->assertTrue($this->strategy->shouldRecover($job));
+        $this->strategy->recover($job);
+        $this->assertSame(ContaiJobStatus::FAILED, $job->getStatus());
+    }
+}

--- a/tests/unit/services/jobs/recovery/ResetToPendingStrategyTest.php
+++ b/tests/unit/services/jobs/recovery/ResetToPendingStrategyTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace ContAI\Tests\Unit\Services\Jobs\Recovery;
+
+use WP_Mock;
+use PHPUnit\Framework\TestCase;
+use ContaiResetToPendingStrategy;
+use ContaiJob;
+use ContaiJobStatus;
+
+class ResetToPendingStrategyTest extends TestCase
+{
+    private ContaiResetToPendingStrategy $strategy;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        WP_Mock::setUp();
+        $this->strategy = new ContaiResetToPendingStrategy(30);
+    }
+
+    public function tearDown(): void
+    {
+        WP_Mock::tearDown();
+        parent::tearDown();
+    }
+
+    private function mockTime(): void
+    {
+        WP_Mock::userFunction('current_time')
+            ->withArgs(['mysql'])
+            ->andReturn(gmdate('Y-m-d H:i:s'));
+
+        WP_Mock::userFunction('current_time')
+            ->withArgs(['timestamp'])
+            ->andReturn(time());
+    }
+
+    private function createStuckProcessingJob(int $minutesStuck = 45): ContaiJob
+    {
+        $this->mockTime();
+
+        $job = new ContaiJob();
+        $job->setId(1);
+        $job->setJobType('post_generation');
+        $job->setStatus(ContaiJobStatus::PROCESSING);
+
+        $stuckTime = gmdate('Y-m-d H:i:s', time() - ($minutesStuck * 60));
+        $job->setProcessedAt($stuckTime);
+
+        return $job;
+    }
+
+    public function test_should_not_recover_when_max_attempts_reached(): void
+    {
+        $job = $this->createStuckProcessingJob(45);
+        $job->setMaxAttempts(3);
+        $job->incrementAttempts();
+        $job->incrementAttempts();
+        $job->incrementAttempts();
+
+        $this->assertTrue($job->hasReachedMaxAttempts());
+        $this->assertFalse($this->strategy->shouldRecover($job));
+    }
+
+    public function test_should_recover_when_under_max_attempts(): void
+    {
+        $job = $this->createStuckProcessingJob(45);
+        $job->setMaxAttempts(3);
+        $job->incrementAttempts();
+
+        $this->assertFalse($job->hasReachedMaxAttempts());
+        $this->assertTrue($this->strategy->shouldRecover($job));
+    }
+
+    public function test_recover_increments_attempts(): void
+    {
+        $job = $this->createStuckProcessingJob(45);
+
+        $this->assertSame(0, $job->getAttempts());
+
+        $this->strategy->recover($job);
+
+        $this->assertSame(1, $job->getAttempts());
+        $this->assertSame(ContaiJobStatus::PENDING, $job->getStatus());
+        $this->assertNull($job->getProcessedAt());
+    }
+
+    public function test_recover_increments_attempts_cumulatively(): void
+    {
+        $job = $this->createStuckProcessingJob(45);
+
+        $this->strategy->recover($job);
+        $this->assertSame(1, $job->getAttempts());
+
+        // Simulate being claimed and stuck again
+        $job->setStatus(ContaiJobStatus::PROCESSING);
+        $stuckTime = gmdate('Y-m-d H:i:s', time() - (45 * 60));
+        $job->setProcessedAt($stuckTime);
+
+        $this->strategy->recover($job);
+        $this->assertSame(2, $job->getAttempts());
+    }
+
+    public function test_should_not_recover_pending_job(): void
+    {
+        $this->mockTime();
+
+        $job = new ContaiJob();
+        $job->setId(1);
+        $job->setStatus(ContaiJobStatus::PENDING);
+
+        $this->assertFalse($this->strategy->shouldRecover($job));
+    }
+
+    public function test_should_not_recover_recently_processing_job(): void
+    {
+        $job = $this->createStuckProcessingJob(5); // Only 5 min, threshold is 30
+
+        $this->assertFalse($this->strategy->shouldRecover($job));
+    }
+}


### PR DESCRIPTION
## Summary
- **Fix stuck Processing jobs**: Changed `catch (Exception)` to `catch (\Throwable)` in `JobProcessor::processJob()` so PHP Error types (TypeError, ValueError) are properly caught and jobs are marked as FAILED instead of staying stuck in PROCESSING forever
- **Fix recovery infinite loop**: `ResetToPendingStrategy` now increments attempts and skips when `max_attempts` is reached, allowing `MarkAsFailedStrategy` to properly escalate stuck jobs to FAILED
- **Enable execution timeout**: Uncommented `set_time_limit(300)` to prevent jobs from hanging indefinitely

## Changes
- `JobProcessor.php` — `catch (\Throwable $e)` instead of `catch (Exception $e)`; enable `set_time_limit(300)`; update `isInsufficientCreditsException` signature to `\Throwable`
- `ResetToPendingStrategy.php` — Add `hasReachedMaxAttempts()` check in `shouldRecover()`; increment attempts in `recover()`
- `MarkAsFailedStrategy.php` — Also trigger when `hasReachedMaxAttempts()` is true (regardless of time threshold)
- `tests/bootstrap.php` — Register recovery and processor classes
- 3 new test files with 16 regression tests

## Root Cause
Three compounding bugs:
1. `catch (Exception $e)` doesn't catch PHP `Error` types — jobs stuck in PROCESSING forever
2. `ResetToPendingStrategy(30min)` always fires before `MarkAsFailedStrategy(240min)` without tracking attempts — infinite PENDING↔PROCESSING loop
3. `set_time_limit()` commented out — no execution timeout protection

## Test Plan
- [x] All 631 tests pass (1126 assertions)
- [x] 16 new regression tests for JobProcessor and recovery strategies
- [x] PHP syntax check clean on all modified files
- [x] No provider name exposure
- [x] Version sync verified (header, readme, constant all at 2.30.1)

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)