### PR TITLE
fix(site-wizard): make AdSense Publisher ID optional (#101)

### DIFF
--- a/1platform-content-ai.php
+++ b/1platform-content-ai.php
@@ -4,7 +4,7 @@
  * Plugin Name: 1Platform Content AI
  * Plugin URI: https://1platform.pro/
  * Description: SaaS client for AI-powered content generation, SEO optimization, and site management. All AI processing happens on 1Platform external servers. Includes free local tools: Table of Contents and Internal Links.
- * Version: 2.31.0
+ * Version: 2.31.1
  * Author: 1Platform
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -18,7 +18,7 @@
 
 if (!defined('ABSPATH')) exit;
 
-define('CONTAI_VERSION', '2.30.3');
+define('CONTAI_VERSION', '2.31.1');
 
 require_once plugin_dir_path(__FILE__) . 'includes/helpers/security.php';
 require_once plugin_dir_path(__FILE__) . 'includes/helpers/crypto.php';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Content AI are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.31.1] - 2026-04-16
+
+### Fixed
+- **Site Wizard AdSense Publisher ID validation blocks save**: The `ADSENSE PUBLISHER ID` field on the AI Site Generator form was marked `required` in HTML, so browsers showed "Completa este campo" / "Please fill out this field" and blocked submit even for users without an AdSense account. The backend already treated the value as optional (empty values are ignored via `! empty()` + `^pub-\d+$` regex), so the HTML `required` constraint was inconsistent. Removed `required`, replaced the red asterisk with an "(optional)" hint, added a `pattern="pub-\d{10,20}"` attribute so format is still enforced *when provided*, and clarified the help text to say users can leave the field empty if they do not have an AdSense account yet (#101)
+
 ## [2.30.3] - 2026-04-13
 
 ### Fixed

--- a/includes/admin/ai-site-generator/site-generator-form.php
+++ b/includes/admin/ai-site-generator/site-generator-form.php
@@ -166,13 +166,13 @@ function contai_render_full_site_generator_form() {
 					<div class="contai-form-group">
 						<label for="contai_adsense_publisher" class="contai-label">
 							<?php esc_html_e( 'AdSense Publisher ID', '1platform-content-ai' ); ?>
-							<span class="contai-required">*</span>
+							<span class="contai-optional">(<?php esc_html_e( 'optional', '1platform-content-ai' ); ?>)</span>
 						</label>
 						<div class="contai-input-wrap contai-input-icon">
 							<span class="dashicons dashicons-money-alt"></span>
-							<input type="text" id="contai_adsense_publisher" name="contai_adsense_publisher" class="contai-input" value="<?php echo esc_attr( $post( 'contai_adsense_publisher' ) ); ?>" placeholder="pub-1234567890123456" autocomplete="off" spellcheck="false" required>
+							<input type="text" id="contai_adsense_publisher" name="contai_adsense_publisher" class="contai-input" value="<?php echo esc_attr( $post( 'contai_adsense_publisher' ) ); ?>" placeholder="pub-1234567890123456" autocomplete="off" spellcheck="false" pattern="pub-\d{10,20}">
 						</div>
-						<span class="contai-help-text"><?php esc_html_e( 'Account > Account information in AdSense', '1platform-content-ai' ); ?></span>
+						<span class="contai-help-text"><?php esc_html_e( 'Account > Account information in AdSense. Leave empty if you do not have an AdSense account yet.', '1platform-content-ai' ); ?></span>
 					</div>
 				</div>
 			</div>

--- a/includes/admin/assets/css/admin-ai-site-generator.css
+++ b/includes/admin/assets/css/admin-ai-site-generator.css
@@ -252,6 +252,15 @@
     font-size: 13px;
 }
 
+.contai-optional {
+    color: var(--contai-text-muted, #6b7280);
+    font-weight: 400;
+    font-size: 12px;
+    text-transform: none;
+    letter-spacing: 0;
+    margin-left: 4px;
+}
+
 /* -- Input Wrapper with Icon -- */
 .contai-input-wrap {
     position: relative;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai content, seo, content generation, internal links, table of contents
 Requires at least: 5.9
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.31.0
+Stable tag: 2.31.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/tests/unit/admin/site-generator/SiteGeneratorSubmissionTest.php
+++ b/tests/unit/admin/site-generator/SiteGeneratorSubmissionTest.php
@@ -472,6 +472,68 @@ class SiteGeneratorSubmissionTest extends TestCase
         );
     }
 
+    // ── Form: AdSense Publisher ID Optional (#101) ─────────────────
+
+    public function test_adsense_publisher_input_is_not_required(): void
+    {
+        $line = $this->findLineContaining($this->formContent, 'id="contai_adsense_publisher"');
+
+        $this->assertNotNull($line, 'AdSense publisher input line must exist');
+        $this->assertStringNotContainsString(
+            ' required',
+            $line,
+            'AdSense Publisher ID input must NOT be required — users without AdSense must be able to submit (#101)'
+        );
+    }
+
+    public function test_adsense_publisher_label_marks_field_as_optional(): void
+    {
+        $labelBlock = $this->extractBlock(
+            $this->formContent,
+            'for="contai_adsense_publisher"',
+            '</label>'
+        );
+
+        $this->assertNotNull($labelBlock, 'AdSense publisher label block must exist');
+        $this->assertStringNotContainsString(
+            'contai-required',
+            $labelBlock,
+            'AdSense Publisher ID label must NOT show required asterisk (#101)'
+        );
+        $this->assertStringContainsString(
+            'contai-optional',
+            $labelBlock,
+            'AdSense Publisher ID label must indicate the field is optional (#101)'
+        );
+    }
+
+    public function test_adsense_publisher_keeps_format_pattern_when_provided(): void
+    {
+        $line = $this->findLineContaining($this->formContent, 'id="contai_adsense_publisher"');
+
+        $this->assertNotNull($line, 'AdSense publisher input line must exist');
+        $this->assertMatchesRegularExpression(
+            '/pattern="pub-\\\\d\{[^}]+\}"/',
+            $line,
+            'AdSense Publisher ID must enforce "pub-<digits>" format when provided, even though empty is allowed (#101)'
+        );
+    }
+
+    public function test_adsense_publisher_backend_still_validates_when_non_empty(): void
+    {
+        $processingFunc = $this->extractFunction($this->handlerContent, 'contai_process_site_generation_submission');
+        $this->assertStringContainsString(
+            '! empty( $adsense_publisher )',
+            $processingFunc,
+            'Backend must guard save with ! empty() so the field being optional does not blank saved values (#101)'
+        );
+        $this->assertStringContainsString(
+            '/^pub-\\d+$/',
+            $processingFunc,
+            'Backend must still validate format with regex when a value is provided (#101)'
+        );
+    }
+
     // ── Form: Security ─────────────────────────────────────────────
 
     public function test_form_has_nonce_field(): void
@@ -522,6 +584,19 @@ class SiteGeneratorSubmissionTest extends TestCase
     }
 
     // ── Helper Methods ─────────────────────────────────────────────
+
+    /**
+     * Find the first line containing a substring.
+     */
+    private function findLineContaining(string $content, string $needle): ?string
+    {
+        foreach (preg_split('/\R/', $content) as $line) {
+            if (strpos($line, $needle) !== false) {
+                return $line;
+            }
+        }
+        return null;
+    }
 
     /**
      * Extract a code block between two markers.


### PR DESCRIPTION
## Summary
- `ADSENSE PUBLISHER ID` on the Site Wizard was HTML5 `required` so browsers blocked submit with "Completa este campo" even for users without an AdSense account
- Backend already treated the value as optional (`! empty()` + `^pub-\d+$` regex + `?? ''` fallback in `SiteGenerationJob`) — HTML and server were inconsistent
- Made the field optional in the UI while keeping format validation for non-empty values

## Changes
- `includes/admin/ai-site-generator/site-generator-form.php` — removed `required` attribute; swapped the red `*` asterisk for an `(optional)` hint; added `pattern="pub-\d{10,20}"` so format is still enforced only when a value is provided; clarified help text to say users can leave it empty
- `includes/admin/assets/css/admin-ai-site-generator.css` — added `.contai-optional` style (muted, non-uppercase, small)
- `tests/unit/admin/site-generator/SiteGeneratorSubmissionTest.php` — 4 new regression tests + `findLineContaining` helper
- `CHANGELOG.md` — [2.31.1] entry
- `1platform-content-ai.php` / `readme.txt` — version bump 2.31.0 → 2.31.1 (patch)

## Audit Results
- Provider-name scan on modified files: clean
- PHP lint on all modified files: clean
- 3-way version sync (`Version:` / `Stable tag:` / `CONTAI_VERSION`): matches at 2.31.1
- Pattern consistency: other optional fields already use plain hint text; this fix follows the same pattern
- No backend changes — contract with `SiteGenerationJob.setupAdsManager()` is preserved (it already handles empty `publisher_id`)

## Test Plan
- [x] 635 unit tests / 1135 assertions — all green
- [x] 4 new regression tests in `SiteGeneratorSubmissionTest`:
  - [x] `test_adsense_publisher_input_is_not_required`
  - [x] `test_adsense_publisher_label_marks_field_as_optional`
  - [x] `test_adsense_publisher_keeps_format_pattern_when_provided`
  - [x] `test_adsense_publisher_backend_still_validates_when_non_empty`
- [ ] Manual: open Site Wizard, submit with empty AdSense field → passes (no validation popup)
- [ ] Manual: open Site Wizard, enter `not-a-pub-id` → browser rejects via `pattern`
- [ ] Manual: open Site Wizard, enter `pub-1234567890123456` → saves and `Ads Manager` shows the publisher after job runs

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)