### PR TITLE
feat(site-wizard): raise default posts_per_page to 15 (#112)

### DIFF
--- a/1platform-content-ai.php
+++ b/1platform-content-ai.php
@@ -4,7 +4,7 @@
  * Plugin Name: 1Platform Content AI
  * Plugin URI: https://1platform.pro/
  * Description: SaaS client for AI-powered content generation, SEO optimization, and site management. All AI processing happens on 1Platform external servers. Includes free local tools: Table of Contents and Internal Links.
- * Version: 2.35.0
+ * Version: 2.35.1
  * Author: 1Platform
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -18,7 +18,7 @@
 
 if (!defined('ABSPATH')) exit;
 
-define('CONTAI_VERSION', '2.34.2');
+define('CONTAI_VERSION', '2.35.1');
 
 require_once plugin_dir_path(__FILE__) . 'includes/helpers/security.php';
 require_once plugin_dir_path(__FILE__) . 'includes/helpers/crypto.php';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Content AI are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.35.1] - 2026-04-30
+
+### Changed
+- **Site Wizard `posts_per_page` raised from 10 to 15** (#112): `contai_apply_theme_defaults()` now sets `posts_per_page = 15` for every supported theme so generated sites surface more entries per blog/archive page out of the box. Existing sites are unaffected — only applies on new wizard runs.
+
+### Added
+- **`SiteGenerationDefaultsTest`**: Pins the `posts_per_page = 15` default so a future regression to the WordPress default of 10 is caught at test time.
+
 ## [2.34.2] - 2026-04-21
 
 ### Fixed

--- a/includes/helpers/site-generation.php
+++ b/includes/helpers/site-generation.php
@@ -115,7 +115,7 @@ function contai_get_primary_nav_location(): ?string {
 function contai_apply_theme_defaults( string $theme ): void {
 	// Common defaults for all themes
 	update_option( 'show_on_front', 'posts' );
-	update_option( 'posts_per_page', 10 );
+	update_option( 'posts_per_page', 15 );
 
 	switch ( $theme ) {
 		case 'newsmatic':

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai content, ai writer, seo, internal links, keyword research
 Requires at least: 5.9
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.35.0
+Stable tag: 2.35.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -159,6 +159,10 @@ The plugin sends your site URL, API key, and content generation parameters (keyw
 7. Tools — Google Analytics, Google Search Console, Publisuites, and Ads Manager integrations.
 
 == Changelog ==
+
+= 2.35.1 =
+* Changed: Site Wizard now sets `posts_per_page` to 15 (raised from 10) so generated sites surface more entries per blog/archive page out of the box. Existing sites are unaffected (#112)
+* Added: Regression test pinning the new default
 
 = 2.34.2 =
 * Fixed: Missing CSS on Tools panels (Internal Links, Publisuites, Search Console, AdSense Account) after the UI redesign — assets now enqueue per-screen on the Apps pages (#111)

--- a/tests/unit/helpers/SiteGenerationDefaultsTest.php
+++ b/tests/unit/helpers/SiteGenerationDefaultsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace ContAI\Tests\Unit\Helpers;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression tests for contai_apply_theme_defaults() in site-generation.php.
+ *
+ * Validates GitHub issue #112: site wizard must set posts_per_page to 15
+ * (raised from WordPress default 10) so generated sites show more entries
+ * per page in blog/archive views.
+ */
+class SiteGenerationDefaultsTest extends TestCase
+{
+    private string $helperFile;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->helperFile = dirname(__DIR__, 3) . '/includes/helpers/site-generation.php';
+    }
+
+    public function test_apply_theme_defaults_sets_posts_per_page_to_15(): void
+    {
+        $content = file_get_contents($this->helperFile);
+
+        $this->assertStringContainsString(
+            "update_option( 'posts_per_page', 15 );",
+            $content,
+            'contai_apply_theme_defaults() must set posts_per_page to 15 (#112)'
+        );
+
+        $this->assertStringNotContainsString(
+            "update_option( 'posts_per_page', 10 );",
+            $content,
+            'Legacy posts_per_page=10 must not remain in site-generation.php (#112)'
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Site Wizard now sets `posts_per_page = 15` (raised from the stock WordPress default of 10) so generated sites surface more entries per blog/archive page out of the box.
- Existing sites are untouched — only applies on new wizard runs, no upgrade semantics change.
- Bumps plugin version to **2.35.1** (patch) and re-aligns the `CONTAI_VERSION` constant that had drifted from the header (was 2.34.2).

## Changes
- `includes/helpers/site-generation.php` — `contai_apply_theme_defaults()`: `update_option( 'posts_per_page', 10 )` → `update_option( 'posts_per_page', 15 )`.
- `tests/unit/helpers/SiteGenerationDefaultsTest.php` — new regression test that asserts the source pins `posts_per_page = 15` and rejects a silent revert to 10.
- `CHANGELOG.md` — new `## [2.35.1] - 2026-04-30` section with `Changed` + `Added` entries.
- `readme.txt` — `Stable tag: 2.35.1`, plus a matching `= 2.35.1 =` block under `== Changelog ==` (the public wordpress.org listing — CI does not auto-bump this).
- `1platform-content-ai.php` — `Version: 2.35.1` in the header **and** `CONTAI_VERSION = '2.35.1'` (the constant had stayed at 2.34.2 after the prior CI bump; this PR re-syncs all 3 plugin version locations).

## Audit Results
Lightweight audit (single-line behavior change, no API/contract surface):
- ✅ PHP syntax check (`php -l`) clean on both modified files.
- ✅ Provider-name scan on the new diff — clean (`OpenAI/Migo/TribuTax/Pixabay/Pexels/ValueSerp/Publisuites/Anthropic/Nicho`). Pre-existing references in `site-generation.php` (legacy comment + helper name) are untouched and out of scope.
- ✅ Pattern match — sits next to `update_option( 'show_on_front', 'posts' )` in the same `contai_apply_theme_defaults()` body, fully consistent with neighboring code.
- ✅ Backward-compatibility — `update_option` only fires inside the wizard flow, so no existing site silently jumps from 10 → 15 on plugin update.
- ✅ Version sync gate — header / `Stable tag` / `CONTAI_VERSION` all = `2.35.1`; `readme.txt == Changelog ==` and `CHANGELOG.md` both contain the `2.35.1` entry.

## Test Plan
- [x] All **653** tests pass (**1160** assertions) — `vendor/bin/phpunit` green on the final HEAD.
- [x] New `SiteGenerationDefaultsTest` (1 test, 2 assertions) catches a future regression to `posts_per_page = 10`.
- [x] No regressions in existing test suites.
- [ ] Reviewer manual smoke: run Site Wizard on a fresh WP install for any supported theme (Astra/Neve/Blocksy/Kadence/OceanWP/Sydney/Newsmatic/ColorMag/GeneratePress) and confirm `Settings → Reading → Blog pages show at most: 15`.

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)