### PR TITLE
chore(ci): add workflow_dispatch to QA + PROD pipelines

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -3,6 +3,7 @@ name: 1Platform Content AI — PROD
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions: {}
 
@@ -20,6 +21,10 @@ env:
 jobs:
   tests:
     name: Unit Tests
+    # Restrict workflow_dispatch to the main branch so a manual deploy
+    # cannot ship arbitrary commits to production. Downstream PROD jobs
+    # chain via `needs: tests` so the gate propagates.
+    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: PROD

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -127,6 +128,8 @@ jobs:
 
   code-review:
     name: Code Review (Claude AI)
+    # PR-only — workflow_dispatch has no diff to analyse.
+    if: github.event_name == 'pull_request'
     needs: [tests]
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -1071,8 +1074,9 @@ jobs:
 
   approve:
     name: Approve & Label
+    # PR-only — labels and PR approvals don't apply to dispatch.
     needs: code-review
-    if: needs.code-review.outputs.verdict == 'approved'
+    if: github.event_name == 'pull_request' && needs.code-review.outputs.verdict == 'approved'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -1107,6 +1111,8 @@ jobs:
 
   ready-to-prod:
     name: Ready to PROD
+    # PR-only — merge-readiness signal is meaningless on dispatch.
+    if: github.event_name == 'pull_request'
     needs: approve
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
Adds a manual trigger to both Actions tabs.

**QA**: dispatch surfaces tests + audit for manual reruns. PR-only jobs (code-review, approve, ready-to-prod) skip on dispatch so the Claude review and PR-label automation only run with an actual PR. No deploy in QA — the plugin only ships on PROD.

**PROD**: workflow_dispatch gated on main via `if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main'` so a manual run from a non-main ref cannot ship to wordpress.org. Downstream jobs chain via `needs: tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)