### PR TITLE
feat(billing): v2.36.0 — hold-capture support (#117)

### DIFF
--- a/1platform-content-ai.php
+++ b/1platform-content-ai.php
@@ -4,7 +4,7 @@
  * Plugin Name: 1Platform Content AI
  * Plugin URI: https://1platform.pro/
  * Description: SaaS client for AI-powered content generation, SEO optimization, and site management. All AI processing happens on 1Platform external servers. Includes free local tools: Table of Contents and Internal Links.
- * Version: 2.35.3
+ * Version: 2.36.0
  * Author: 1Platform
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -18,7 +18,7 @@
 
 if (!defined('ABSPATH')) exit;
 
-define('CONTAI_VERSION', '2.35.1');
+define('CONTAI_VERSION', '2.36.0');
 
 require_once plugin_dir_path(__FILE__) . 'includes/helpers/security.php';
 require_once plugin_dir_path(__FILE__) . 'includes/helpers/crypto.php';
@@ -79,6 +79,7 @@ require_once plugin_dir_path(__FILE__) . 'includes/database/migrations/CreateJob
 require_once plugin_dir_path(__FILE__) . 'includes/database/migrations/UpdateKeywordsTableStatus.php';
 require_once plugin_dir_path(__FILE__) . 'includes/database/migrations/CreateInternalLinksTable.php';
 require_once plugin_dir_path(__FILE__) . 'includes/database/migrations/BackfillAnalyticsMeta.php';
+require_once plugin_dir_path(__FILE__) . 'includes/database/migrations/AddHoldFieldsToJobsTable.php';
 
 /**
  * Build the migration runner with all registered migrations.
@@ -95,6 +96,7 @@ function contai_build_migration_runner(): ContaiMigrationRunner {
     $runner->register(4, new ContaiUpdateKeywordsTableStatus());
     $runner->register(5, new ContaiCreateInternalLinksTable());
     $runner->register(6, new ContaiBackfillAnalyticsMeta());
+    $runner->register(7, new ContaiAddHoldFieldsToJobsTable());
 
     return $runner;
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to Content AI are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.36.0] - 2026-05-19
+
+### Added
+- **Hold/Capture billing integration (#117)**: Opted the plugin into the new Authorize+Capture billing path. `OnePlatformClient` now sends `X-Plugin-Version: 2.36.0` on every outbound request; when the API recognizes the version it returns an `X-Hold-Id` response header which is persisted on the local job row. This lets each post-generation job carry the lifecycle of its credit hold (Reserved -> Charged | Refunded) instead of charging up-front and losing the balance on failure.
+- **New migration `ContaiAddHoldFieldsToJobsTable` (v7)**: Idempotently adds `hold_id VARCHAR(64) NULL` (indexed) and `credits_released TINYINT(1) NOT NULL DEFAULT 0` to `wp_contai_jobs` so the new credit lifecycle can be tracked locally.
+- **`ContaiOnePlatformResponse::getHeaders()` / `getHeader()`**: Response wrapper now exposes the raw HTTP response headers (case-insensitive lookup) so callers can read provider-issued headers such as `X-Hold-Id` without re-issuing the request.
+- **`ContaiJobRepository::setHoldId()` / `setCreditsReleased()`**: Targeted updates for the new columns; called from the content-generation pipeline when the API confirms a hold was created and again when polling reports the hold was released.
+- **`ContaiCreditGuard::isCreditsAlreadyReleased()`**: New helper that recognizes the released-hold terminal state so recovery and queue display logic can treat it as a non-blocking, retry-safe condition.
+- **Post Generator queue "Credit status" column**: Displays Reserved / Charged / Refunded badges per row so operators can audit the credit lifecycle of every active job at a glance.
+
+### Changed
+- **`ContaiContentGenerationPollingJob::handleFailed()`**: When the API reports the job as failed it now reads the `credits_released` flag, persists it on the local job row, and surfaces the message "Generation failed; credits have been refunded" instead of the previous generic error when credits were reintegrated.
+- **`ContaiResetToPendingStrategy`**: Jobs whose credits were already released by the API are now permitted to be re-queued; the existing 402 / insufficient-credits filter remains unchanged.
+- **Plugin version drift reconciled**: The header `Version:` and the `CONTAI_VERSION` constant now both report `2.36.0` (previously `2.35.3` and `2.35.1` respectively).
+
 ## [2.35.1] - 2026-04-30
 
 ### Changed

--- a/includes/admin/content-generator/handlers/PostGenerationQueueHandler.php
+++ b/includes/admin/content-generator/handlers/PostGenerationQueueHandler.php
@@ -228,4 +228,49 @@ class ContaiPostGenerationQueueHandler {
         wp_safe_redirect($url);
         exit;
     }
+
+    /**
+     * Resolve the credit status badge for a queue-table row.
+     *
+     * Returns an array with `label` (translated text), `tone` ('info'/'success'/
+     * 'warning'/'neutral'), or `null` when no badge should be displayed.
+     *
+     * The mapping mirrors the Authorize+Capture lifecycle:
+     *   - hold_id present + status pending/processing  → Reserved (info)
+     *   - credits_released = 1                          → Refunded (warning)
+     *   - hold_id present + status done                 → Charged  (success)
+     *   - no hold_id      + status done                 → Charged  (success, legacy path)
+     *
+     * @param array $row Raw row from JobRepository::getProcessingJobsWithKeywords()
+     *                   or any other listing that exposes status, hold_id, credits_released.
+     * @return array{label: string, tone: string}|null
+     */
+    public static function resolveCreditStatusBadge(array $row): ?array {
+        $status = (string) ($row['status'] ?? '');
+        $hold_id = isset($row['hold_id']) ? (string) $row['hold_id'] : '';
+        $credits_released = !empty($row['credits_released']);
+
+        if ($credits_released) {
+            return [
+                'label' => __('Refunded', '1platform-content-ai'),
+                'tone'  => 'warning',
+            ];
+        }
+
+        if ($hold_id !== '' && in_array($status, ['pending', 'processing'], true)) {
+            return [
+                'label' => __('Reserved', '1platform-content-ai'),
+                'tone'  => 'info',
+            ];
+        }
+
+        if ($status === 'done') {
+            return [
+                'label' => __('Charged', '1platform-content-ai'),
+                'tone'  => 'success',
+            ];
+        }
+
+        return null;
+    }
 }

--- a/includes/admin/content-generator/panels/post-generator.php
+++ b/includes/admin/content-generator/panels/post-generator.php
@@ -4,6 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 require_once __DIR__ . '/../../../services/jobs/QueueManager.php';
 require_once __DIR__ . '/../../../services/billing/CreditGuard.php';
+require_once __DIR__ . '/../handlers/PostGenerationQueueHandler.php';
 
 class ContaiPostGeneratorPanel {
 
@@ -256,15 +257,26 @@ class ContaiPostGeneratorPanel {
 						<th><?php esc_html_e( 'Title', '1platform-content-ai' ); ?></th>
 						<th><?php esc_html_e( 'Volume', '1platform-content-ai' ); ?></th>
 						<th><?php esc_html_e( 'Processing Time', '1platform-content-ai' ); ?></th>
+						<th><?php esc_html_e( 'Credit status', '1platform-content-ai' ); ?></th>
 					</tr>
 				</thead>
 				<tbody>
 					<?php foreach ( $jobs as $job ) : ?>
+						<?php $credit_badge = ContaiPostGenerationQueueHandler::resolveCreditStatusBadge( $job ); ?>
 						<tr>
 							<td><strong><?php echo esc_html( $job['keyword'] ); ?></strong></td>
 							<td><?php echo esc_html( $job['title'] ); ?></td>
 							<td class="contai-mono"><?php echo esc_html( number_format( $job['volume'] ) ); ?></td>
 							<td class="contai-mono"><?php echo esc_html( $this->calculateElapsedTime( $job['processed_at'] ) ); ?></td>
+							<td>
+								<?php if ( $credit_badge !== null ) : ?>
+									<span class="contai-badge contai-badge-<?php echo esc_attr( $credit_badge['tone'] ); ?>">
+										<?php echo esc_html( $credit_badge['label'] ); ?>
+									</span>
+								<?php else : ?>
+									<span class="contai-mono" style="color: var(--fg-3);" aria-hidden="true">—</span>
+								<?php endif; ?>
+							</td>
 						</tr>
 					<?php endforeach; ?>
 				</tbody>

--- a/includes/database/migrations/AddHoldFieldsToJobsTable.php
+++ b/includes/database/migrations/AddHoldFieldsToJobsTable.php
@@ -1,0 +1,110 @@
+<?php
+
+if (!defined('ABSPATH')) exit;
+
+require_once __DIR__ . '/../Database.php';
+
+/**
+ * Migration v7 — Add hold_id and credits_released columns to wp_contai_jobs.
+ *
+ * Backs the Authorize+Capture billing path introduced by the 1Platform API in
+ * v2.36.0 of the plugin. Each row may now carry the BalanceHold ObjectId
+ * returned by the API as well as the released-credits flag emitted on failure.
+ *
+ * Idempotent: re-running up() is a no-op once both columns exist.
+ */
+class ContaiAddHoldFieldsToJobsTable
+{
+    private ContaiDatabase $db;
+    private string $tableName = 'contai_jobs';
+
+    public function __construct()
+    {
+        $this->db = ContaiDatabase::getInstance();
+    }
+
+    public function up(): bool
+    {
+        // If the base table is missing, ContaiCreateJobsTable hasn't run yet
+        // and this migration cannot be applied — bail safely.
+        if (!$this->db->tableExists($this->tableName)) {
+            return false;
+        }
+
+        $hasHoldId = $this->columnExists('hold_id');
+        $hasCreditsReleased = $this->columnExists('credits_released');
+        $hasHoldIdIndex = $this->indexExists('idx_hold_id');
+
+        if ($hasHoldId && $hasCreditsReleased && $hasHoldIdIndex) {
+            return true;
+        }
+
+        $table = $this->db->getTableName($this->tableName);
+
+        if (!$hasHoldId) {
+            $sql = "ALTER TABLE {$table} ADD COLUMN hold_id VARCHAR(64) NULL AFTER error_message";
+            if (!$this->db->query($sql)) {
+                return false;
+            }
+        }
+
+        if (!$hasCreditsReleased) {
+            $sql = "ALTER TABLE {$table} ADD COLUMN credits_released TINYINT(1) NOT NULL DEFAULT 0 AFTER hold_id";
+            if (!$this->db->query($sql)) {
+                return false;
+            }
+        }
+
+        if (!$hasHoldIdIndex) {
+            $sql = "ALTER TABLE {$table} ADD KEY idx_hold_id (hold_id)";
+            if (!$this->db->query($sql)) {
+                return false;
+            }
+        }
+
+        return $this->columnExists('hold_id') && $this->columnExists('credits_released');
+    }
+
+    public function down(): bool
+    {
+        if (!$this->db->tableExists($this->tableName)) {
+            return true;
+        }
+
+        $table = $this->db->getTableName($this->tableName);
+        $success = true;
+
+        if ($this->indexExists('idx_hold_id')) {
+            $success = $this->db->query("ALTER TABLE {$table} DROP INDEX idx_hold_id") && $success;
+        }
+
+        if ($this->columnExists('credits_released')) {
+            $success = $this->db->query("ALTER TABLE {$table} DROP COLUMN credits_released") && $success;
+        }
+
+        if ($this->columnExists('hold_id')) {
+            $success = $this->db->query("ALTER TABLE {$table} DROP COLUMN hold_id") && $success;
+        }
+
+        return $success;
+    }
+
+    public function getTableName(): string
+    {
+        return $this->tableName;
+    }
+
+    private function columnExists(string $column): bool
+    {
+        $table = $this->db->getTableName($this->tableName);
+        $sql = $this->db->prepare("SHOW COLUMNS FROM {$table} LIKE %s", $column);
+        return $this->db->getVar($sql) !== null;
+    }
+
+    private function indexExists(string $index): bool
+    {
+        $table = $this->db->getTableName($this->tableName);
+        $sql = $this->db->prepare("SHOW INDEX FROM {$table} WHERE Key_name = %s", $index);
+        return $this->db->getRow($sql) !== null;
+    }
+}

--- a/includes/database/models/Job.php
+++ b/includes/database/models/Job.php
@@ -17,6 +17,8 @@ class ContaiJob
     private $created_at;
     private $updated_at;
     private $processed_at;
+    private ?string $hold_id = null;
+    private bool $credits_released = false;
 
     public function __construct()
     {
@@ -179,6 +181,28 @@ class ContaiJob
         }
     }
 
+    public function getHoldId(): ?string
+    {
+        return $this->hold_id;
+    }
+
+    public function setHoldId(?string $hold_id): void
+    {
+        $this->hold_id = $hold_id !== null && $hold_id !== '' ? $hold_id : null;
+        $this->updated_at = current_time('mysql');
+    }
+
+    public function getCreditsReleased(): bool
+    {
+        return $this->credits_released;
+    }
+
+    public function setCreditsReleased(bool $released): void
+    {
+        $this->credits_released = $released;
+        $this->updated_at = current_time('mysql');
+    }
+
     public function toArray()
     {
         return [
@@ -192,7 +216,9 @@ class ContaiJob
             'error_message' => $this->error_message,
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
-            'processed_at' => $this->processed_at
+            'processed_at' => $this->processed_at,
+            'hold_id' => $this->hold_id,
+            'credits_released' => $this->credits_released,
         ];
     }
 }

--- a/includes/database/repositories/JobRepository.php
+++ b/includes/database/repositories/JobRepository.php
@@ -339,7 +339,55 @@ class ContaiJobRepository
             $job->setProcessedAt($data['processed_at']);
         }
 
+        if (array_key_exists('hold_id', $data) && $data['hold_id'] !== null && $data['hold_id'] !== '') {
+            $job->setHoldId((string) $data['hold_id']);
+        }
+
+        if (array_key_exists('credits_released', $data)) {
+            $job->setCreditsReleased((bool) (int) $data['credits_released']);
+        }
+
         return $job;
+    }
+
+    /**
+     * Persist the BalanceHold id returned by the API for the given job row.
+     *
+     * Called by the content-generation pipeline when the API responds with an
+     * `X-Hold-Id` header (plugin >= 2.36.0, API path: Authorize+Capture).
+     */
+    public function setHoldId(int $jobId, string $holdId): bool
+    {
+        if ($jobId <= 0 || $holdId === '') {
+            return false;
+        }
+
+        $data = [
+            'hold_id' => $holdId,
+            'updated_at' => current_time('mysql'),
+        ];
+
+        return $this->db->update($this->table, $data, ['id' => $jobId]) > 0;
+    }
+
+    /**
+     * Flag a job row as having had its credit hold released by the API.
+     *
+     * Called from the polling job's failure branch when the API confirms via
+     * `credits_released: true` that the user's balance was reintegrated.
+     */
+    public function setCreditsReleased(int $jobId, bool $released = true): bool
+    {
+        if ($jobId <= 0) {
+            return false;
+        }
+
+        $data = [
+            'credits_released' => $released ? 1 : 0,
+            'updated_at' => current_time('mysql'),
+        ];
+
+        return $this->db->update($this->table, $data, ['id' => $jobId]) > 0;
     }
 
     public function findActiveSiteGenerationJob()

--- a/includes/services/api/OnePlatformClient.php
+++ b/includes/services/api/OnePlatformClient.php
@@ -107,6 +107,14 @@ class ContaiOnePlatformClient {
         }
 
         $headers = array_merge($auth_headers, $this->custom_headers);
+
+        // Advertise the plugin version on every outbound request. The 1Platform API
+        // routes to the Authorize+Capture billing path when this header is >= 2.36.0
+        // (and falls back to the legacy charge-first path otherwise).
+        if (defined('CONTAI_VERSION')) {
+            $headers['X-Plugin-Version'] = CONTAI_VERSION;
+        }
+
         $start_time = microtime(true);
 
         $response = $this->executeHttpRequest($method, $url, $data, $headers);
@@ -251,25 +259,27 @@ class ContaiOnePlatformClient {
     private function createResponse(ContaiHTTPResponse $http_response): ContaiOnePlatformResponse {
         $json = $http_response->getJson();
         $trace_id = $http_response->getHeader('x-trace-id');
+        $headers = $http_response->getHeaders();
 
         if ($http_response->isSuccess()) {
-            return $this->createSuccessResponse($json, $http_response->getStatusCode(), $trace_id);
+            return $this->createSuccessResponse($json, $http_response->getStatusCode(), $trace_id, $headers);
         }
 
-        return $this->createErrorResponse($json, $http_response, $trace_id);
+        return $this->createErrorResponse($json, $http_response, $trace_id, $headers);
     }
 
-    private function createSuccessResponse(array $json, int $status_code, ?string $trace_id = null): ContaiOnePlatformResponse {
+    private function createSuccessResponse(array $json, int $status_code, ?string $trace_id = null, array $headers = []): ContaiOnePlatformResponse {
         return new ContaiOnePlatformResponse(
             $json['success'] ?? true,
             $json['data'] ?? $json,
             $json['msg'] ?? null,
             $status_code,
-            $trace_id
+            $trace_id,
+            $headers
         );
     }
 
-    private function createErrorResponse(?array $json, ContaiHTTPResponse $http_response, ?string $trace_id = null): ContaiOnePlatformResponse {
+    private function createErrorResponse(?array $json, ContaiHTTPResponse $http_response, ?string $trace_id = null, array $headers = []): ContaiOnePlatformResponse {
         $status_code = $http_response->getStatusCode();
 
         // When neither the API nor wp_remote_request provide a diagnostic message
@@ -287,7 +297,8 @@ class ContaiOnePlatformClient {
             null,
             $error_message,
             $status_code,
-            $trace_id
+            $trace_id,
+            $headers
         );
     }
 
@@ -353,13 +364,15 @@ class ContaiOnePlatformResponse {
     private ?string $message;
     private int $status_code;
     private ?string $trace_id;
+    private array $headers;
 
-    public function __construct(bool $success, $data, ?string $message = null, int $status_code = 200, ?string $trace_id = null) {
+    public function __construct(bool $success, $data, ?string $message = null, int $status_code = 200, ?string $trace_id = null, array $headers = []) {
         $this->success = $success;
         $this->data = $data;
         $this->message = $message;
         $this->status_code = $status_code;
         $this->trace_id = $trace_id;
+        $this->headers = $headers;
     }
 
     public function isSuccess(): bool {
@@ -382,6 +395,35 @@ class ContaiOnePlatformResponse {
         return $this->trace_id;
     }
 
+    public function getHeaders(): array {
+        return $this->headers;
+    }
+
+    /**
+     * Case-insensitive header lookup.
+     *
+     * HTTP headers are case-insensitive (RFC 7230 §3.2). wp_remote_request
+     * normalizes them to lowercase via the Requests library, but callers
+     * commonly pass the canonical mixed-case spelling (e.g. "X-Hold-Id"),
+     * so we search both spellings transparently.
+     */
+    public function getHeader(string $name): ?string {
+        if (isset($this->headers[$name])) {
+            return is_array($this->headers[$name])
+                ? (string) reset($this->headers[$name])
+                : (string) $this->headers[$name];
+        }
+
+        $lower = strtolower($name);
+        foreach ($this->headers as $key => $value) {
+            if (strtolower((string) $key) === $lower) {
+                return is_array($value) ? (string) reset($value) : (string) $value;
+            }
+        }
+
+        return null;
+    }
+
     public function isPaymentRequired(): bool {
         return $this->status_code === 402;
     }
@@ -393,6 +435,7 @@ class ContaiOnePlatformResponse {
             'message' => $this->message,
             'status_code' => $this->status_code,
             'trace_id' => $this->trace_id,
+            'headers' => $this->headers,
         ];
     }
 }

--- a/includes/services/billing/CreditGuard.php
+++ b/includes/services/billing/CreditGuard.php
@@ -3,6 +3,7 @@
 if (!defined('ABSPATH')) exit;
 
 require_once __DIR__ . '/BillingService.php';
+require_once __DIR__ . '/../../database/models/Job.php';
 
 class ContaiCreditGuard {
 
@@ -91,6 +92,21 @@ class ContaiCreditGuard {
      */
     public static function isInsufficientCreditsError(string $errorMessage): bool {
         return strpos($errorMessage, self::INSUFFICIENT_CREDITS_PREFIX) === 0;
+    }
+
+    /**
+     * Whether the API has already released this job's credit hold.
+     *
+     * The Authorize+Capture path (API >= billing#117 with plugin >= 2.36.0)
+     * auto-releases the hold on failure and signals it back via the polling
+     * response, which the plugin persists in `wp_contai_jobs.credits_released`.
+     *
+     * Recovery + UI flows use this to treat such jobs as safe to re-queue or
+     * re-display as refunded — there is no double-charge risk because the
+     * API will authorize a fresh hold on the next attempt.
+     */
+    public static function isCreditsAlreadyReleased(ContaiJob $job): bool {
+        return $job->getCreditsReleased() === true;
     }
 
     /**

--- a/includes/services/content/ContentGeneratorService.php
+++ b/includes/services/content/ContentGeneratorService.php
@@ -35,7 +35,13 @@ class ContaiContentGeneratorService {
      * Returns an array with 'job_id' and 'status' on success, or
      * an array with 'success' => false and error details on failure.
      *
-     * @return array{success: bool, job_id?: string, status?: string, message?: string, status_code?: int}
+     * When the API runs the Authorize+Capture billing path (plugin >= 2.36.0)
+     * it returns an `X-Hold-Id` response header with the BalanceHold ObjectId.
+     * That value is forwarded transparently in the `hold_id` key so the caller
+     * can persist it on the local job row. The key is omitted when the API
+     * does not emit the header (legacy/test paths).
+     *
+     * @return array{success: bool, job_id?: string, status?: string, hold_id?: string, message?: string, status_code?: int}
      */
     public function createRemoteContentJob(
         string $keyword,
@@ -66,17 +72,29 @@ class ContaiContentGeneratorService {
             ];
         }
 
-        return [
+        $result = [
             'success' => true,
             'job_id' => sanitize_text_field($data['job_id']),
             'status' => sanitize_text_field($data['status'] ?? 'pending'),
         ];
+
+        $hold_id = $response->getHeader('X-Hold-Id');
+        if (is_string($hold_id) && $hold_id !== '') {
+            $result['hold_id'] = sanitize_text_field($hold_id);
+        }
+
+        return $result;
     }
 
     /**
      * Poll the remote content generation job by ID.
      *
-     * @return array{success: bool, status?: string, result?: array, error?: string, message?: string, status_code?: int}
+     * On failure the API (>= 2.36.0) reports whether the user's credit hold
+     * was released via the `credits_released` flag in the response body. The
+     * flag is propagated as a boolean so callers can both persist it on the
+     * local job row and surface an accurate message to the user.
+     *
+     * @return array{success: bool, status?: string, result?: array, error?: string, credits_released?: bool, message?: string, status_code?: int}
      */
     public function getRemoteJobStatus(string $remote_job_id): array {
         $endpoint = ContaiOnePlatformEndpoints::postsContentJobById($remote_job_id);
@@ -97,6 +115,7 @@ class ContaiContentGeneratorService {
             'status' => sanitize_text_field($data['status'] ?? 'unknown'),
             'result' => is_array($data['result'] ?? null) ? $data['result'] : null,
             'error' => isset($data['error']) ? sanitize_text_field($data['error']) : null,
+            'credits_released' => isset($data['credits_released']) ? (bool) $data['credits_released'] : false,
         ];
     }
 

--- a/includes/services/jobs/ContentGenerationPollingJob.php
+++ b/includes/services/jobs/ContentGenerationPollingJob.php
@@ -110,7 +110,7 @@ class ContaiContentGenerationPollingJob implements ContaiJobInterface
             }
 
             if ($status === 'failed') {
-                return $this->handleFailed($keyword, $poll_result, $remote_job_id);
+                return $this->handleFailed($keyword, $poll_result, $remote_job_id, $job_id);
             }
 
             if ($i < self::POLLS_PER_CYCLE - 1) {
@@ -193,16 +193,31 @@ class ContaiContentGenerationPollingJob implements ContaiJobInterface
         }
     }
 
-    private function handleFailed(ContaiKeyword $keyword, array $poll_result, string $remote_job_id): array
+    private function handleFailed(ContaiKeyword $keyword, array $poll_result, string $remote_job_id, ?int $job_id): array
     {
-        $error = $poll_result['error'] ?? 'Remote job failed without error details';
+        $api_error = $poll_result['error'] ?? 'Remote job failed without error details';
+        $credits_released = !empty($poll_result['credits_released']);
+
+        // When the API confirms the hold was released, persist that on the local
+        // row so recovery + UI logic can treat it as a non-blocking terminal state.
+        if ($credits_released && $job_id) {
+            $this->job_repository->setCreditsReleased($job_id, true);
+        }
+
         $this->updateKeywordStatus($keyword, ContaiKeyword::STATUS_FAILED);
-        contai_log("Remote content job {$remote_job_id} failed: {$error}");
+        contai_log("Remote content job {$remote_job_id} failed: {$api_error}");
+
+        // Admin-facing message: when credits were refunded we say so explicitly
+        // so the operator understands no further refund action is needed.
+        $message = $credits_released
+            ? 'Generation failed; credits have been refunded.'
+            : $api_error;
 
         return [
             'success' => true,
             'keyword_id' => $keyword->getId(),
-            'error' => $error,
+            'error' => $message,
+            'credits_released' => $credits_released,
         ];
     }
 

--- a/includes/services/jobs/PostGenerationJob.php
+++ b/includes/services/jobs/PostGenerationJob.php
@@ -108,6 +108,14 @@ class ContaiPostGenerationJob implements ContaiJobInterface
             );
         }
 
+        // Persist the BalanceHold id returned by the API (Authorize+Capture path).
+        // Header is only emitted when the API recognizes X-Plugin-Version >= 2.36.0,
+        // so legacy/test paths simply skip this step.
+        $local_job_id = isset($payload['job_id']) ? (int) $payload['job_id'] : 0;
+        if ($local_job_id > 0 && !empty($result['hold_id'])) {
+            $this->job_repository->setHoldId($local_job_id, (string) $result['hold_id']);
+        }
+
         return $result['job_id'];
     }
 

--- a/includes/services/jobs/recovery/ResetToPendingStrategy.php
+++ b/includes/services/jobs/recovery/ResetToPendingStrategy.php
@@ -32,6 +32,13 @@ class ContaiResetToPendingStrategy implements ContaiJobRecoveryStrategy
             return false;
         }
 
+        // Authorize+Capture: if the API already released the hold (refunded the
+        // user), re-queueing is safe — the next attempt will authorize a fresh
+        // hold against the restored balance, with no double-charge risk.
+        if (ContaiCreditGuard::isCreditsAlreadyReleased($job)) {
+            return true;
+        }
+
         $processedAt = $job->getProcessedAt();
 
         if (empty($processedAt)) {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai content, ai writer, seo, internal links, keyword research
 Requires at least: 5.9
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.35.3
+Stable tag: 2.36.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -159,6 +159,14 @@ The plugin sends your site URL, API key, and content generation parameters (keyw
 7. Tools — Google Analytics, Google Search Console, Publisuites, and Ads Manager integrations.
 
 == Changelog ==
+
+= 2.36.0 =
+* Added: Hold/Capture billing integration — every outbound request now advertises `X-Plugin-Version: 2.36.0` so the 1Platform API can route post-generation through its Authorize+Capture path. Each job carries its credit hold (Reserved / Charged / Refunded) instead of charging up-front and losing the balance on failure (#117)
+* Added: New migration `AddHoldFieldsToJobsTable` (v7) — adds `hold_id` and `credits_released` columns to `wp_contai_jobs`
+* Added: "Credit status" column in the Post Generator queue table showing each job's credit lifecycle at a glance
+* Changed: When the API reports a generation as failed with credits refunded, the polling job now surfaces "Generation failed; credits have been refunded" instead of the generic error
+* Changed: Recovery now permits re-queueing jobs whose credits were already released by the API; the 402 insufficient-credits filter remains
+* Fixed: Plugin version drift — header and `CONTAI_VERSION` constant now both report 2.36.0
 
 = 2.35.1 =
 * Changed: Site Wizard now sets `posts_per_page` to 15 (raised from 10) so generated sites surface more entries per blog/archive page out of the box. Existing sites are unaffected (#112)

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -166,6 +166,7 @@ require_once __DIR__ . '/../includes/database/migrations/CreateJobsTable.php';
 require_once __DIR__ . '/../includes/database/migrations/UpdateKeywordsTableStatus.php';
 require_once __DIR__ . '/../includes/database/migrations/CreateInternalLinksTable.php';
 require_once __DIR__ . '/../includes/database/migrations/BackfillAnalyticsMeta.php';
+require_once __DIR__ . '/../includes/database/migrations/AddHoldFieldsToJobsTable.php';
 
 /**
  * Build the migration runner — mirrors the function in the main plugin file.
@@ -179,6 +180,7 @@ if (!function_exists('contai_build_migration_runner')) {
         $runner->register(4, new ContaiUpdateKeywordsTableStatus());
         $runner->register(5, new ContaiCreateInternalLinksTable());
         $runner->register(6, new ContaiBackfillAnalyticsMeta());
+        $runner->register(7, new ContaiAddHoldFieldsToJobsTable());
         return $runner;
     }
 }


### PR DESCRIPTION
## Summary

Plugin half of PR 3 in the cross-repo Authorize+Capture rollout for issue #117. The API side ([1platform-api#112](https://github.com/1platformlabs/1platform-api/pull/112)) is already merged. This PR opts the plugin into the new path so every post-generation job carries its credit hold from creation through capture or refund.

- **Outbound `X-Plugin-Version` header** on every `OnePlatformClient` request lets the API route to the hold path when the version is `>= 2.36.0` (legacy plugins keep the charge-first path).
- **Response wrapper exposes headers** via `ContaiOnePlatformResponse::getHeaders()` / case-insensitive `getHeader()`, so the content service can read `X-Hold-Id` and persist it on the local job row.
- **New migration v7** `ContaiAddHoldFieldsToJobsTable` (idempotent) adds `hold_id VARCHAR(64) NULL` (indexed) and `credits_released TINYINT(1) NOT NULL DEFAULT 0` to `wp_contai_jobs`.
- **Polling job** reads `credits_released` from the API response on failure, marks the row, and surfaces "Generation failed; credits have been refunded" instead of the generic error message.
- **Recovery** — `ResetToPendingStrategy` now treats released holds as safe to re-queue (no double-charge risk; the API authorizes a fresh hold on the retry). The existing 402 / insufficient-credits filter is unchanged.
- **Admin UI** — Post Generator queue table gains a "Credit status" column (Reserved / Charged / Refunded badges, plus legacy Charged for rows without a `hold_id`).
- **Version drift fix** — header `Version:` and `CONTAI_VERSION` were `2.35.3` vs `2.35.1`; both reconciled to `2.36.0` in this PR.

Closes 1platformlabs/1platform-content-ai#117

## Test plan

- [x] `php -l` clean on every touched file (13 files)
- [x] `./vendor/bin/phpunit` — 653 tests / 1160 assertions, all green
- [ ] Manual: enqueue a post on QA against api-qa, confirm `X-Plugin-Version: 2.36.0` lands and `X-Hold-Id` is persisted in `wp_contai_jobs.hold_id`
- [ ] Manual: force an API failure on QA, confirm `credits_released=1` lands and queue table shows the **Refunded** badge
- [ ] Manual: confirm migration v7 runs idempotently on a fresh + an upgraded install
- [ ] Manual: confirm plugin `< 2.36.0` (no header) keeps working on PROD without regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)