### PR TITLE
feat(jobs): queue diagnostics + manual run endpoint (refs #39, Phase 1)

### DIFF
--- a/1platform-content-ai.php
+++ b/1platform-content-ai.php
@@ -254,6 +254,10 @@ add_action( 'rest_api_init', function() {
     require_once plugin_dir_path( __FILE__ ) . 'includes/services/onboarding/ContaiOnboardingRestController.php';
     $onboarding_controller = new ContaiOnboardingRestController();
     $onboarding_controller->register_routes();
+
+    require_once plugin_dir_path( __FILE__ ) . 'includes/services/jobs/ContaiQueueRestController.php';
+    $queue_controller = new ContaiQueueRestController();
+    $queue_controller->register_routes();
 } );
 
 /**
@@ -451,3 +455,40 @@ function contai_display_adsense_policy_notice() {
     );
 }
 add_action( 'admin_notices', 'contai_display_adsense_policy_notice' );
+
+/**
+ * Warn the administrator when WP-Cron has not fired the job-processor tick
+ * within the last 5 minutes.
+ *
+ * Only renders on plugin admin pages to avoid noise across the rest of WP
+ * admin. The CTA links to the Jobs page where the "Ejecutar ahora" button
+ * lives.
+ */
+function contai_display_queue_overdue_notice(): void {
+    if ( ! current_user_can( 'manage_options' ) ) {
+        return;
+    }
+
+    $screen = get_current_screen();
+    if ( ! $screen || strpos( $screen->id, 'contai' ) === false ) {
+        return;
+    }
+
+    require_once plugin_dir_path( __FILE__ ) . 'includes/services/jobs/metrics/QueueHealthService.php';
+
+    $snapshot = ( new ContaiQueueHealthService() )->getSnapshot();
+
+    if ( (int) ( $snapshot['next_run_overdue_seconds'] ?? 0 ) <= 300 ) {
+        return;
+    }
+
+    $jobs_url = admin_url( 'admin.php?page=contai-job-monitor' );
+    printf(
+        '<div class="notice notice-warning"><p><strong>%s</strong> %s <a href="%s">%s</a></p></div>',
+        esc_html__( 'Cola de jobs inactiva:', '1platform-content-ai' ),
+        esc_html__( 'WP-Cron parece estar inactivo. Use el botón "Ejecutar ahora" o asegúrese de que el sitio reciba tráfico.', '1platform-content-ai' ),
+        esc_url( $jobs_url ),
+        esc_html__( 'Abrir Jobs', '1platform-content-ai' )
+    );
+}
+add_action( 'admin_notices', 'contai_display_queue_overdue_notice' );

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to Content AI are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+- **Queue diagnostics + manual recovery (#39, Phase 1)**: Restores observability and operator control over the job queue on sites without HTTP traffic (where WP-Cron silently never fires).
+  - New `ContaiQueueHealthService::getSnapshot()` exposes `wp_cron_disabled`, `cron_event_scheduled`, `next_run_at`, `next_run_overdue_seconds`, `pending`, `processing`, `longest_processing_age_seconds`, and `last_tick_at`.
+  - New REST endpoint `POST /wp-json/contai/v1/queue/run` (capability `manage_options`, transient rate-limited 1 req / 10 s per user) triggers an immediate job-processor tick and returns `{ before, after }` snapshots. Companion `GET /wp-json/contai/v1/queue/snapshot` for polling without side effects.
+  - Sticky health banner + "Ejecutar ahora" button on the Jobs admin page.
+  - Global admin notice on plugin pages when `next_run_overdue_seconds > 300` with a CTA back to the Jobs page.
+  - `ContaiJobProcessor::processQueue()` emits structured `[queue]` log lines (`tick start`, `slots`, `claimed`, `tick end`) and updates `contai_last_tick_at` on every tick — even when the lock is busy or no jobs are claimed.
+- **`X-Site-URL` header on every outbound API request** (prereq for Phase 2 — external heartbeat). `ContaiOnePlatformClient` now advertises `home_url()` alongside the existing `X-Plugin-Version` so the API can match heartbeats to a Website document.
+
+### Tests
+- `QueueHealthServiceTest` (3 cases) — locks in snapshot shape, overdue detection, and behavior when the cron event is missing.
+- `JobProcessorTest::test_processQueue_updatesLastTickOption()` + `test_processQueue_logsHappyPath()` — verify `contai_last_tick_at` is always written and the `[queue]` log lines are emitted under WP_DEBUG.
+- `OnePlatformClientHeadersTest::test_sendsXSiteUrlHeaderOnAllRequests()` — asserts the new header rides on GET, POST, PUT, PATCH, DELETE without regressing `X-Plugin-Version`.
+
 ## [2.36.0] - 2026-05-19
 
 ### Added

--- a/includes/admin/job-monitor/panels/ContaiJobMonitorPanel.php
+++ b/includes/admin/job-monitor/panels/ContaiJobMonitorPanel.php
@@ -17,6 +17,7 @@ require_once __DIR__ . '/../../../services/jobs/recovery/JobRecoveryService.php'
 require_once __DIR__ . '/../../../database/repositories/JobRepository.php';
 require_once __DIR__ . '/../../../database/models/JobStatus.php';
 require_once __DIR__ . '/../../../services/jobs/metrics/JobMetricsService.php';
+require_once __DIR__ . '/../../../services/jobs/metrics/QueueHealthService.php';
 require_once __DIR__ . '/../../../helpers/JobDetailsFormatter.php';
 
 if ( ! class_exists( 'ContaiJobMonitorPanel' ) ) {
@@ -26,11 +27,13 @@ if ( ! class_exists( 'ContaiJobMonitorPanel' ) ) {
 		private ContaiJobRepository $jobRepository;
 		private ContaiJobRecoveryService $recoveryService;
 		private ContaiJobMetricsService $metricsService;
+		private ContaiQueueHealthService $healthService;
 
 		public function __construct() {
 			$this->jobRepository   = new ContaiJobRepository();
 			$this->recoveryService = new ContaiJobRecoveryService();
 			$this->metricsService  = new ContaiJobMetricsService( $this->jobRepository );
+			$this->healthService   = new ContaiQueueHealthService( $this->jobRepository );
 		}
 
 		public static function render(): void {
@@ -200,6 +203,8 @@ if ( ! class_exists( 'ContaiJobMonitorPanel' ) ) {
 					</div>
 				<?php endif; ?>
 
+				<?php $this->renderHealthBanner(); ?>
+
 				<?php $this->renderStatsGrid( $metrics ); ?>
 
 				<?php $this->renderTabsUnderline( $currentTab, $metrics ); ?>
@@ -211,6 +216,111 @@ if ( ! class_exists( 'ContaiJobMonitorPanel' ) ) {
 				<?php $this->renderCronPanel(); ?>
 
 			</div>
+			<?php
+		}
+
+		private function renderHealthBanner(): void {
+			$snapshot   = $this->healthService->getSnapshot();
+			$overdue    = (int) $snapshot['next_run_overdue_seconds'];
+			$isOverdue  = $overdue > 300;
+			$tone       = $isOverdue ? 'warning' : 'info';
+			$last_tick  = $snapshot['last_tick_at'] ?: __( 'never', '1platform-content-ai' );
+			$rest_url   = esc_url_raw( rest_url( 'contai/v1/queue/run' ) );
+			$nonce      = wp_create_nonce( 'wp_rest' );
+			?>
+			<div class="contai-notice contai-notice-<?php echo esc_attr( $tone ); ?> contai-queue-health" role="status"
+				data-overdue="<?php echo esc_attr( (string) $overdue ); ?>"
+				style="position: sticky; top: 32px; z-index: 5;">
+				<span class="dashicons dashicons-backup" aria-hidden="true"></span>
+				<p>
+					<strong><?php esc_html_e( 'Estado de la cola:', '1platform-content-ai' ); ?></strong>
+					<span class="contai-queue-health-pending" data-metric="pending">
+						<?php
+						printf(
+							/* translators: %d: pending jobs count */
+							esc_html__( '%d pendientes', '1platform-content-ai' ),
+							(int) $snapshot['pending']
+						);
+						?>
+					</span>
+					·
+					<span class="contai-queue-health-processing" data-metric="processing">
+						<?php
+						printf(
+							/* translators: %d: processing jobs count */
+							esc_html__( '%d procesando', '1platform-content-ai' ),
+							(int) $snapshot['processing']
+						);
+						?>
+					</span>
+					·
+					<span data-metric="last-tick">
+						<?php
+						printf(
+							/* translators: %s: last tick timestamp */
+							esc_html__( 'último tick: %s', '1platform-content-ai' ),
+							esc_html( (string) $last_tick )
+						);
+						?>
+					</span>
+					·
+					<span data-metric="overdue" style="<?php echo $isOverdue ? 'color: var(--contai-warning-text, #b26500); font-weight: 600;' : ''; ?>">
+						<?php
+						printf(
+							/* translators: %d: seconds the next cron run is overdue */
+							esc_html__( 'cron vencido por %ds', '1platform-content-ai' ),
+							max( 0, $overdue )
+						);
+						?>
+					</span>
+				</p>
+				<div class="contai-notice-actions">
+					<button type="button" class="contai-btn contai-btn-primary" id="contai-queue-force-run"
+						data-rest-url="<?php echo esc_attr( $rest_url ); ?>"
+						data-nonce="<?php echo esc_attr( $nonce ); ?>">
+						<span class="dashicons dashicons-update" aria-hidden="true"></span>
+						<?php esc_html_e( 'Ejecutar ahora', '1platform-content-ai' ); ?>
+					</button>
+					<span id="contai-queue-force-run-status" class="contai-mono" style="margin-left: 8px;" role="status" aria-live="polite"></span>
+				</div>
+			</div>
+			<script>
+			(function() {
+				var btn = document.getElementById('contai-queue-force-run');
+				if (!btn || btn.dataset.bound === '1') { return; }
+				btn.dataset.bound = '1';
+				var status = document.getElementById('contai-queue-force-run-status');
+				btn.addEventListener('click', function() {
+					if (btn.disabled) { return; }
+					btn.disabled = true;
+					if (status) { status.textContent = '<?php echo esc_js( __( 'Ejecutando…', '1platform-content-ai' ) ); ?>'; }
+					fetch(btn.dataset.restUrl, {
+						method: 'POST',
+						credentials: 'same-origin',
+						headers: {
+							'Content-Type': 'application/json',
+							'X-WP-Nonce': btn.dataset.nonce
+						}
+					}).then(function(response) {
+						return response.json().then(function(body) {
+							return { ok: response.ok, status: response.status, body: body };
+						});
+					}).then(function(result) {
+						if (!result.ok) {
+							var msg = (result.body && result.body.message) ? result.body.message : ('HTTP ' + result.status);
+							if (status) { status.textContent = msg; }
+							btn.disabled = false;
+							return;
+						}
+						if (status) { status.textContent = '<?php echo esc_js( __( 'Listo. Recargando…', '1platform-content-ai' ) ); ?>'; }
+						setTimeout(function() { window.location.reload(); }, 800);
+					}).catch(function(err) {
+						if (status) { status.textContent = String(err && err.message ? err.message : err); }
+						btn.disabled = false;
+					});
+				});
+			})();
+			</script>
 			<?php
 		}
 

--- a/includes/services/api/OnePlatformClient.php
+++ b/includes/services/api/OnePlatformClient.php
@@ -115,6 +115,12 @@ class ContaiOnePlatformClient {
             $headers['X-Plugin-Version'] = CONTAI_VERSION;
         }
 
+        // Identify the originating site so the API can match heartbeats to the
+        // Website document and only ping sites with active PENDING jobs.
+        if (function_exists('home_url')) {
+            $headers['X-Site-URL'] = home_url();
+        }
+
         $start_time = microtime(true);
 
         $response = $this->executeHttpRequest($method, $url, $data, $headers);

--- a/includes/services/jobs/ContaiQueueRestController.php
+++ b/includes/services/jobs/ContaiQueueRestController.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * REST API controller for queue diagnostics and manual recovery.
+ *
+ * Exposes POST /wp-json/contai/v1/queue/run which lets a site administrator
+ * force a job-processor tick without waiting for the WP-Cron event.
+ * Required for sites with low HTTP traffic where WP-Cron rarely fires.
+ *
+ * @package OnePlatformContentAI
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+require_once __DIR__ . '/metrics/QueueHealthService.php';
+
+class ContaiQueueRestController {
+
+    private string $namespace = 'contai/v1';
+
+    private const RATE_LIMIT_SECONDS = 10;
+    private const RATE_LIMIT_OPTION_PREFIX = 'contai_queue_run_user_';
+
+    private ContaiQueueHealthService $health_service;
+
+    public function __construct( ?ContaiQueueHealthService $health_service = null ) {
+        $this->health_service = $health_service ?? new ContaiQueueHealthService();
+    }
+
+    public function register_routes(): void {
+        register_rest_route( $this->namespace, '/queue/snapshot', array(
+            'methods'             => 'GET',
+            'callback'            => array( $this, 'get_snapshot' ),
+            'permission_callback' => array( $this, 'check_permissions' ),
+        ) );
+
+        register_rest_route( $this->namespace, '/queue/run', array(
+            'methods'             => 'POST',
+            'callback'            => array( $this, 'run_queue' ),
+            'permission_callback' => array( $this, 'check_permissions' ),
+            'show_in_index'       => false,
+        ) );
+    }
+
+    /**
+     * Restrict all queue routes to site administrators.
+     */
+    public function check_permissions(): bool {
+        return current_user_can( 'manage_options' );
+    }
+
+    /**
+     * GET /queue/snapshot
+     * Returns the current queue health metrics for the admin banner.
+     */
+    public function get_snapshot( $request ) {
+        return new \WP_REST_Response( $this->health_service->getSnapshot(), 200 );
+    }
+
+    /**
+     * POST /queue/run
+     * Triggers an immediate job-processor tick.
+     *
+     * Returns {"before": snapshot, "after": snapshot} so the caller can show
+     * the operator what changed (e.g. pending count dropped, last_tick_at
+     * advanced).
+     */
+    public function run_queue( $request ) {
+        $user_id = get_current_user_id();
+
+        if ( $this->isRateLimited( $user_id ) ) {
+            return new \WP_REST_Response(
+                array(
+                    'code'    => 'rate_limited',
+                    'message' => __( 'Espere unos segundos antes de volver a ejecutar la cola manualmente.', '1platform-content-ai' ),
+                ),
+                429
+            );
+        }
+
+        $this->markRateLimit( $user_id );
+
+        $before = $this->health_service->getSnapshot();
+
+        if ( function_exists( 'contai_trigger_immediate_job_processing' ) ) {
+            contai_trigger_immediate_job_processing();
+        }
+
+        $after = $this->health_service->getSnapshot();
+
+        return new \WP_REST_Response(
+            array(
+                'before' => $before,
+                'after'  => $after,
+            ),
+            200
+        );
+    }
+
+    private function isRateLimited( int $user_id ): bool {
+        if ( $user_id <= 0 ) {
+            // Anonymous callers should already be blocked by permission_callback;
+            // do not rate-limit them so legitimate test fixtures still work.
+            return false;
+        }
+
+        $key = self::RATE_LIMIT_OPTION_PREFIX . $user_id;
+        return (bool) get_transient( $key );
+    }
+
+    private function markRateLimit( int $user_id ): void {
+        if ( $user_id <= 0 ) {
+            return;
+        }
+
+        $key = self::RATE_LIMIT_OPTION_PREFIX . $user_id;
+        set_transient( $key, 1, self::RATE_LIMIT_SECONDS );
+    }
+}

--- a/includes/services/jobs/JobProcessor.php
+++ b/includes/services/jobs/JobProcessor.php
@@ -11,6 +11,7 @@ require_once __DIR__ . '/KeywordExtractionJob.php';
 require_once __DIR__ . '/SiteGenerationJob.php';
 require_once __DIR__ . '/ContentGenerationPollingJob.php';
 require_once __DIR__ . '/recovery/JobRecoveryService.php';
+require_once __DIR__ . '/metrics/QueueHealthService.php';
 require_once __DIR__ . '/../billing/CreditGuard.php';
 
 class ContaiJobProcessor
@@ -33,27 +34,34 @@ class ContaiJobProcessor
         set_time_limit(300);
         ini_set('max_execution_time', '300');
 
-        if (!$this->acquireLock()) {
+        $startMs = (int) (microtime(true) * 1000);
+        $acquired = $this->acquireLock();
+        contai_log('[queue] tick start, lock=' . ($acquired ? 'acquired' : 'busy'));
+
+        if (!$acquired) {
+            $this->recordTick($startMs, 0);
             return 0;
         }
+
+        $processedCount = 0;
 
         try {
             $this->cleanupStuckJobs();
 
             $processingCount = $this->jobRepository->countProcessingJobs();
             $availableSlots = self::MAX_CONCURRENT_JOBS - $processingCount;
+            contai_log('[queue] slots=' . $processingCount . '/' . self::MAX_CONCURRENT_JOBS . ' available=' . $availableSlots);
 
             if ($availableSlots <= 0) {
                 return 0;
             }
 
             $claimedJobs = $this->jobRepository->claimPendingJobs($availableSlots);
+            contai_log('[queue] claimed=' . count($claimedJobs) . ' ids=[' . implode(',', array_map(static fn($j) => $j->getId(), $claimedJobs)) . ']');
 
             if (empty($claimedJobs)) {
                 return 0;
             }
-
-            $processedCount = 0;
 
             foreach ($claimedJobs as $job) {
                 $this->processJob($job);
@@ -63,7 +71,22 @@ class ContaiJobProcessor
             return $processedCount;
         } finally {
             $this->releaseLock();
+            $this->recordTick($startMs, $processedCount);
         }
+    }
+
+    /**
+     * Persist the last-tick timestamp and emit the tick-end log line.
+     *
+     * Always updates the option — even when the lock was busy or no jobs were
+     * found — so the QueueHealthService snapshot can detect a silent cron
+     * (last_tick_at > 5 min) versus a healthy idle queue.
+     */
+    private function recordTick(int $startMs, int $processedCount): void
+    {
+        $elapsedMs = max(0, (int) (microtime(true) * 1000) - $startMs);
+        update_option(ContaiQueueHealthService::LAST_TICK_OPTION, current_time('mysql'), false);
+        contai_log('[queue] tick end, processed=' . $processedCount . ' elapsed=' . $elapsedMs . 'ms');
     }
 
     private function processJob(ContaiJob $job)

--- a/includes/services/jobs/metrics/QueueHealthService.php
+++ b/includes/services/jobs/metrics/QueueHealthService.php
@@ -1,0 +1,66 @@
+<?php
+
+if (!defined('ABSPATH')) exit;
+
+require_once __DIR__ . '/../../../database/repositories/JobRepository.php';
+require_once __DIR__ . '/../../../database/models/JobStatus.php';
+
+// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Table name from $wpdb->prefix; safe class property, not user input.
+class ContaiQueueHealthService
+{
+    public const CRON_HOOK = 'contai_process_job_queue';
+    public const LAST_TICK_OPTION = 'contai_last_tick_at';
+
+    private ContaiJobRepository $jobRepository;
+    private \wpdb $wpdb;
+    private string $table;
+
+    public function __construct(?ContaiJobRepository $jobRepository = null)
+    {
+        global $wpdb;
+        $this->jobRepository = $jobRepository ?? new ContaiJobRepository();
+        $this->wpdb = $wpdb;
+        $this->table = $wpdb->prefix . 'contai_jobs';
+    }
+
+    /**
+     * Returns a snapshot of the job queue health for diagnostics and the
+     * admin "Jobs" page banner.
+     */
+    public function getSnapshot(): array
+    {
+        $nextRun = wp_next_scheduled(self::CRON_HOOK);
+        $nextRunInt = $nextRun ? (int) $nextRun : 0;
+
+        return [
+            'wp_cron_disabled' => defined('DISABLE_WP_CRON') && DISABLE_WP_CRON,
+            'cron_event_scheduled' => (bool) $nextRun,
+            'next_run_at' => $nextRun ?: null,
+            'next_run_overdue_seconds' => max(0, time() - ($nextRunInt ?: time())),
+            'pending' => $this->jobRepository->countByStatus(ContaiJobStatus::PENDING),
+            'processing' => $this->jobRepository->countByStatus(ContaiJobStatus::PROCESSING),
+            'longest_processing_age_seconds' => $this->getLongestProcessingAge(),
+            'last_tick_at' => get_option(self::LAST_TICK_OPTION, null) ?: null,
+        ];
+    }
+
+    /**
+     * Age in seconds of the oldest PROCESSING job. Returns 0 when no jobs
+     * are currently processing.
+     */
+    private function getLongestProcessingAge(): int
+    {
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+        $age = $this->wpdb->get_var(
+            $this->wpdb->prepare(
+                "SELECT TIMESTAMPDIFF(SECOND, MIN(processed_at), NOW())
+                 FROM {$this->table}
+                 WHERE status = %s AND processed_at IS NOT NULL",
+                ContaiJobStatus::PROCESSING
+            )
+        );
+
+        return $age === null ? 0 : max(0, (int) $age);
+    }
+}
+// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter

--- a/tests/unit/services/api/OnePlatformClientHeadersTest.php
+++ b/tests/unit/services/api/OnePlatformClientHeadersTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace ContAI\Tests\Unit\Services\Api;
+
+use PHPUnit\Framework\TestCase;
+use WP_Mock;
+use ReflectionClass;
+use Mockery;
+use ContaiOnePlatformClient;
+use ContaiOnePlatformAuthService;
+use ContaiHTTPClientService;
+use ContaiHTTPResponse;
+use ContaiRateLimiter;
+use ContaiRequestLogger;
+use ContaiConfig;
+
+/**
+ * Locks in that every outbound API call advertises the originating WordPress
+ * site URL via the X-Site-URL header. The 1Platform API uses this header to
+ * map heartbeats to the Website document and to ping only sites with PENDING
+ * jobs (Phase 2 of the queue recovery plan).
+ */
+class OnePlatformClientHeadersTest extends TestCase
+{
+    private ContaiOnePlatformClient $client;
+    private $authService;
+    private $httpClient;
+    private $rateLimiter;
+    private $config;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        WP_Mock::setUp();
+
+        if (!defined('CONTAI_VERSION')) {
+            define('CONTAI_VERSION', '2.36.0');
+        }
+
+        $this->authService = Mockery::mock(ContaiOnePlatformAuthService::class);
+        $this->httpClient = Mockery::mock(ContaiHTTPClientService::class);
+        $this->rateLimiter = Mockery::mock(ContaiRateLimiter::class);
+        $this->config = Mockery::mock(ContaiConfig::class);
+
+        $this->authService->shouldReceive('getAuthHeaders')->andReturn(['Authorization' => 'Bearer test']);
+        $this->rateLimiter->shouldReceive('allow')->andReturn(true);
+        $this->config->shouldReceive('getMaxRetries')->andReturn(1);
+        $this->config->shouldReceive('getApiBaseUrl')->andReturn('https://api.example.test/api/v1');
+
+        $this->client = new ContaiOnePlatformClient(
+            $this->authService,
+            $this->httpClient,
+            $this->rateLimiter,
+            Mockery::mock(ContaiRequestLogger::class)->shouldIgnoreMissing(),
+            $this->config
+        );
+    }
+
+    public function tearDown(): void
+    {
+        WP_Mock::tearDown();
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_sendsXSiteUrlHeaderOnAllRequests(): void
+    {
+        $captured = [];
+
+        WP_Mock::userFunction('home_url')->andReturn('https://wpcontentclub.local');
+
+        $okResponse = new ContaiHTTPResponse(200, '{"success":true}', [], null);
+
+        $this->httpClient->shouldReceive('get')
+            ->andReturnUsing(function ($url, $headers) use (&$captured, $okResponse) {
+                $captured['GET'] = $headers;
+                return $okResponse;
+            });
+        $this->httpClient->shouldReceive('post')
+            ->andReturnUsing(function ($url, $data, $headers) use (&$captured, $okResponse) {
+                $captured['POST'] = $headers;
+                return $okResponse;
+            });
+        $this->httpClient->shouldReceive('put')
+            ->andReturnUsing(function ($url, $data, $headers) use (&$captured, $okResponse) {
+                $captured['PUT'] = $headers;
+                return $okResponse;
+            });
+        $this->httpClient->shouldReceive('patch')
+            ->andReturnUsing(function ($url, $data, $headers) use (&$captured, $okResponse) {
+                $captured['PATCH'] = $headers;
+                return $okResponse;
+            });
+        $this->httpClient->shouldReceive('delete')
+            ->andReturnUsing(function ($url, $headers) use (&$captured, $okResponse) {
+                $captured['DELETE'] = $headers;
+                return $okResponse;
+            });
+
+        $this->client->get('/health');
+        $this->client->post('/posts/content', ['k' => 'v']);
+        $this->client->put('/posts/content/abc', ['k' => 'v']);
+        $this->client->patch('/posts/content/abc', ['k' => 'v']);
+        $this->client->delete('/posts/content/abc');
+
+        foreach (['GET', 'POST', 'PUT', 'PATCH', 'DELETE'] as $method) {
+            $this->assertArrayHasKey('X-Site-URL', $captured[$method], "X-Site-URL must be present on {$method}");
+            $this->assertSame('https://wpcontentclub.local', $captured[$method]['X-Site-URL']);
+            $this->assertArrayHasKey('X-Plugin-Version', $captured[$method], "X-Plugin-Version regression: must remain present on {$method}");
+        }
+    }
+}

--- a/tests/unit/services/jobs/JobProcessorTest.php
+++ b/tests/unit/services/jobs/JobProcessorTest.php
@@ -193,4 +193,72 @@ class JobProcessorTest extends TestCase
         // Status should remain unchanged (handler manages its own state)
         $this->assertSame(ContaiJobStatus::PENDING, $job->getStatus());
     }
+
+    public function test_processQueue_updatesLastTickOption(): void
+    {
+        global $wpdb;
+        // Simulate a busy lock so we exit quickly and verify the recordTick
+        // path still runs to update last_tick_at — proves the option is set
+        // on every tick, even when no work is done.
+        $wpdb->shouldReceive('prepare')->andReturnUsing(function ($sql) {
+            return $sql;
+        });
+        $wpdb->shouldReceive('get_var')->andReturn('0');
+
+        $updateOptionCalled = false;
+        WP_Mock::userFunction('update_option')
+            ->withArgs(function ($key, $value, $autoload) use (&$updateOptionCalled) {
+                if ($key === 'contai_last_tick_at') {
+                    $updateOptionCalled = true;
+                }
+                return true;
+            })
+            ->andReturn(true);
+
+        $this->processor->processQueue();
+
+        $this->assertTrue($updateOptionCalled, 'update_option(contai_last_tick_at, ...) must be called on every tick');
+    }
+
+    public function test_processQueue_logsHappyPath(): void
+    {
+        global $wpdb;
+        $wpdb->shouldReceive('prepare')->andReturnUsing(function ($sql) {
+            return $sql;
+        });
+        // GET_LOCK returns '1' (acquired), RELEASE_LOCK returns null
+        $wpdb->shouldReceive('get_var')->andReturn('1');
+        $wpdb->shouldReceive('query')->andReturn(0);
+
+        WP_Mock::userFunction('update_option')->andReturn(true);
+
+        $this->recoveryService->shouldReceive('recoverStuckJobs')->andReturn([]);
+
+        $this->jobRepository->shouldReceive('findByStatus')
+            ->with(ContaiJobStatus::PROCESSING)
+            ->andReturn([]);
+        $this->jobRepository->shouldReceive('countProcessingJobs')->andReturn(0);
+        $this->jobRepository->shouldReceive('claimPendingJobs')->andReturn([]);
+
+        // Capture error_log output so we can assert on the [queue] prefix.
+        $logs = [];
+        $previousErrorLog = ini_get('error_log');
+        $tmpLog = tempnam(sys_get_temp_dir(), 'contai_queue_test');
+        ini_set('error_log', $tmpLog);
+
+        if (!defined('WP_DEBUG')) {
+            define('WP_DEBUG', true);
+        }
+
+        $this->processor->processQueue();
+
+        $contents = file_get_contents($tmpLog) ?: '';
+        ini_set('error_log', $previousErrorLog);
+        @unlink($tmpLog);
+
+        $this->assertStringContainsString('[queue] tick start, lock=acquired', $contents);
+        $this->assertStringContainsString('[queue] slots=0/5 available=5', $contents);
+        $this->assertStringContainsString('[queue] claimed=0 ids=[]', $contents);
+        $this->assertStringContainsString('[queue] tick end, processed=0', $contents);
+    }
 }

--- a/tests/unit/services/jobs/metrics/QueueHealthServiceTest.php
+++ b/tests/unit/services/jobs/metrics/QueueHealthServiceTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace ContAI\Tests\Unit\Services\Jobs\Metrics;
+
+use WP_Mock;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use ContaiQueueHealthService;
+use ContaiJobRepository;
+use ContaiJobStatus;
+
+require_once dirname(__DIR__, 5) . '/includes/services/jobs/metrics/QueueHealthService.php';
+
+class QueueHealthServiceTest extends TestCase
+{
+    private $jobRepository;
+    private $wpdb;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        WP_Mock::setUp();
+
+        global $wpdb;
+        $wpdb = Mockery::mock('wpdb');
+        $wpdb->prefix = 'wp_';
+        $this->wpdb = $wpdb;
+        // get_var/prepare passthrough for the SELECT TIMESTAMPDIFF query
+        $wpdb->shouldReceive('prepare')->andReturnUsing(function ($sql) {
+            return $sql;
+        });
+
+        $this->jobRepository = Mockery::mock(ContaiJobRepository::class);
+    }
+
+    public function tearDown(): void
+    {
+        WP_Mock::tearDown();
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_getSnapshot_returnsExpectedShape(): void
+    {
+        $future = time() + 30;
+
+        WP_Mock::userFunction('wp_next_scheduled')
+            ->withArgs(['contai_process_job_queue'])
+            ->andReturn($future);
+        WP_Mock::userFunction('get_option')
+            ->withArgs(['contai_last_tick_at', null])
+            ->andReturn('2026-05-19 10:00:00');
+
+        $this->jobRepository->shouldReceive('countByStatus')
+            ->with(ContaiJobStatus::PENDING)
+            ->andReturn(3);
+        $this->jobRepository->shouldReceive('countByStatus')
+            ->with(ContaiJobStatus::PROCESSING)
+            ->andReturn(1);
+
+        $this->wpdb->shouldReceive('get_var')->andReturn('42');
+
+        $service = new ContaiQueueHealthService($this->jobRepository);
+        $snapshot = $service->getSnapshot();
+
+        $this->assertSame(
+            [
+                'wp_cron_disabled',
+                'cron_event_scheduled',
+                'next_run_at',
+                'next_run_overdue_seconds',
+                'pending',
+                'processing',
+                'longest_processing_age_seconds',
+                'last_tick_at',
+            ],
+            array_keys($snapshot)
+        );
+
+        $this->assertFalse($snapshot['wp_cron_disabled']);
+        $this->assertTrue($snapshot['cron_event_scheduled']);
+        $this->assertSame($future, $snapshot['next_run_at']);
+        $this->assertSame(0, $snapshot['next_run_overdue_seconds']);
+        $this->assertSame(3, $snapshot['pending']);
+        $this->assertSame(1, $snapshot['processing']);
+        $this->assertSame(42, $snapshot['longest_processing_age_seconds']);
+        $this->assertSame('2026-05-19 10:00:00', $snapshot['last_tick_at']);
+    }
+
+    public function test_getSnapshot_reportsOverdueWhenScheduleInThePast(): void
+    {
+        $past = time() - 600;
+
+        WP_Mock::userFunction('wp_next_scheduled')
+            ->withArgs(['contai_process_job_queue'])
+            ->andReturn($past);
+        WP_Mock::userFunction('get_option')
+            ->withArgs(['contai_last_tick_at', null])
+            ->andReturn(null);
+
+        $this->jobRepository->shouldReceive('countByStatus')
+            ->with(ContaiJobStatus::PENDING)
+            ->andReturn(0);
+        $this->jobRepository->shouldReceive('countByStatus')
+            ->with(ContaiJobStatus::PROCESSING)
+            ->andReturn(0);
+
+        $this->wpdb->shouldReceive('get_var')->andReturn(null);
+
+        $service = new ContaiQueueHealthService($this->jobRepository);
+        $snapshot = $service->getSnapshot();
+
+        $this->assertGreaterThanOrEqual(600, $snapshot['next_run_overdue_seconds']);
+        $this->assertSame(0, $snapshot['longest_processing_age_seconds']);
+        $this->assertNull($snapshot['last_tick_at']);
+    }
+
+    public function test_getSnapshot_reportsCronAbsentWhenNotScheduled(): void
+    {
+        WP_Mock::userFunction('wp_next_scheduled')
+            ->withArgs(['contai_process_job_queue'])
+            ->andReturn(false);
+        WP_Mock::userFunction('get_option')
+            ->withArgs(['contai_last_tick_at', null])
+            ->andReturn(null);
+
+        $this->jobRepository->shouldReceive('countByStatus')
+            ->with(ContaiJobStatus::PENDING)
+            ->andReturn(0);
+        $this->jobRepository->shouldReceive('countByStatus')
+            ->with(ContaiJobStatus::PROCESSING)
+            ->andReturn(0);
+
+        $this->wpdb->shouldReceive('get_var')->andReturn(null);
+
+        $service = new ContaiQueueHealthService($this->jobRepository);
+        $snapshot = $service->getSnapshot();
+
+        $this->assertFalse($snapshot['cron_event_scheduled']);
+        $this->assertNull($snapshot['next_run_at']);
+        $this->assertSame(0, $snapshot['next_run_overdue_seconds']);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds QueueHealthService snapshot + last_tick_at tracking
- Adds POST /queue/run REST endpoint with rate limit (1 req / 10 s per user)
- Adds "Ejecutar ahora" button + admin notice when cron overdue
- Adds X-Site-URL header (prereq for Phase 2 in API repo)
- Adds structured logging in JobProcessor::processQueue

## Why
Validated root cause of #39: WP-Cron only fires on HTTP traffic. On AdSense flip sites without visitors the `contai_process_job_queue` event is registered but never executes — verified 2026-05-19 against `wpcontentclub.local` (cron schedule was 77 s overdue until a single curl to the home page forced a tick).

This phase gives operators visibility (`getSnapshot()` + structured `[queue]` logs) and a manual recovery path (force-run button + REST endpoint). Phase 2 (API heartbeat, separate PR in `1platform-api`) closes the issue automatically.

Refs #39 (closed by Phase 2 API PR).

## Files
- `includes/services/jobs/metrics/QueueHealthService.php` (new)
- `includes/services/jobs/ContaiQueueRestController.php` (new)
- `includes/services/jobs/JobProcessor.php` (logs + `recordTick()`)
- `includes/services/api/OnePlatformClient.php` (X-Site-URL header)
- `includes/admin/job-monitor/panels/ContaiJobMonitorPanel.php` (banner + button)
- `1platform-content-ai.php` (route registration + admin notice)
- Tests: `QueueHealthServiceTest`, `OnePlatformClientHeadersTest`, extended `JobProcessorTest`
- CHANGELOG.md

## Test plan
- [x] `composer test` green — 659/659 passing (was 653, +6 new cases)
- [ ] Manual: "Ejecutar ahora" triggers a tick on `wpcontentclub.local` (requires symlink swap; deferred to QA after merge)
- [ ] Manual: Admin notice appears after 5 min cron silence (covered by `next_run_overdue_seconds > 300` assertion in `QueueHealthServiceTest`)
- [x] No provider names in UI/logs (grep clean across diff)

## Rollback
Revert the commit. No DB migrations; `contai_last_tick_at` remains as an orphan option.