### PR TITLE
fix(legal-pages): rewrite persistent warning copy (closes #129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- **Legal Pages: persistent warning resolved (#129)**: The "All fields are required..." copy on the Legal Pages panel no longer renders as a static warning notice. It is now an informational helper that does not look like a validation error. A real error banner only appears after the user submits with empty required fields (named in the message), and a green "Ready to generate" indicator appears in the Generate Pages section once all four legal information fields are saved. The Generate button is disabled until the required information is on file.
+
 ### Changed
 - **Recovery thresholds tightened (queue Phase 4)**: `ContaiJobRecoveryService` now defaults to `ContaiResetToPendingStrategy(5)` (was `30`) and `ContaiMarkAsFailedStrategy(30)` (was `240`). The zombie-job blocking window shrinks from 4 h to 30 min on sites with healthy ticks. Both thresholds remain operator-configurable through the new `contai_recovery_reset_threshold_minutes` and `contai_recovery_fail_threshold_minutes` filters. Justification: with 5 PROCESSING slots and polling cycles of ≤ 50 s, a legitimate job should never exceed 60 s in PROCESSING without re-queueing — 5 min is a 5× safety margin.
 

--- a/includes/admin/content-generator/panels/legal-pages.php
+++ b/includes/admin/content-generator/panels/legal-pages.php
@@ -10,6 +10,14 @@ class ContaiLegalPagesPanel {
     private ?array $api_generation_result = null;
     private bool $legal_info_saved = false;
     private bool $cookie_settings_saved = false;
+    private array $missing_required_fields = [];
+
+    private const REQUIRED_FIELDS = [
+        'owner'    => 'Owner Name',
+        'email'    => 'Contact Email',
+        'address'  => 'Fiscal Address',
+        'activity' => 'Business Activity',
+    ];
 
     public function __construct() {
         $this->legal_info = ContaiLegalPagesHelper::get_legal_info();
@@ -32,7 +40,10 @@ class ContaiLegalPagesPanel {
             if (!current_user_can('manage_options')) {
                 wp_die(esc_html__('You do not have permission to perform this action.', '1platform-content-ai'));
             }
-            $this->api_generation_result = $this->generate_via_api();
+            $this->missing_required_fields = $this->compute_missing_required_fields();
+            if (empty($this->missing_required_fields)) {
+                $this->api_generation_result = $this->generate_via_api();
+            }
         } elseif (isset($_POST['contai_save_cookie_settings'])) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
             check_admin_referer('contai_cookie_nonce', 'contai_cookie_nonce');
             if (!current_user_can('manage_options')) {
@@ -68,8 +79,26 @@ class ContaiLegalPagesPanel {
         update_option('contai_legal_activity', $activity);
         update_option('contai_legal_email', $email);
 
-        $this->legal_info_saved = true;
         $this->legal_info = ContaiLegalPagesHelper::get_legal_info();
+        $this->missing_required_fields = $this->compute_missing_required_fields();
+
+        if (empty($this->missing_required_fields)) {
+            $this->legal_info_saved = true;
+        }
+    }
+
+    private function compute_missing_required_fields(): array {
+        $missing = [];
+        foreach (self::REQUIRED_FIELDS as $key => $label) {
+            if (trim((string) ($this->legal_info[$key] ?? '')) === '') {
+                $missing[] = $label;
+            }
+        }
+        return $missing;
+    }
+
+    private function is_ready_to_generate(): bool {
+        return empty($this->compute_missing_required_fields());
     }
 
     public function render(): void {
@@ -85,6 +114,20 @@ class ContaiLegalPagesPanel {
         if ($this->legal_info_saved): ?>
             <div class="notice notice-success is-dismissible">
                 <p><?php esc_html_e('Legal information saved successfully!', '1platform-content-ai'); ?></p>
+            </div>
+        <?php endif;
+
+        if (!empty($this->missing_required_fields)):
+            $field_list = implode(', ', array_map(
+                static fn ($label) => __($label, '1platform-content-ai'),
+                $this->missing_required_fields
+            ));
+            ?>
+            <div class="notice notice-error">
+                <p>
+                    <strong><?php esc_html_e('Missing required information:', '1platform-content-ai'); ?></strong>
+                    <?php echo esc_html($field_list); ?>
+                </p>
             </div>
         <?php endif;
 
@@ -112,12 +155,12 @@ class ContaiLegalPagesPanel {
             </div>
 
             <div class="contai-panel-body">
-                <div class="contai-notice contai-notice-warning">
+                <div class="contai-notice contai-notice-info">
                     <div class="contai-notice-icon">
-                        <span class="dashicons dashicons-warning"></span>
+                        <span class="dashicons dashicons-info"></span>
                     </div>
                     <div class="contai-notice-body">
-                        <p><?php esc_html_e('All fields are required to generate legal pages via the API. Please fill in all information before generating.', '1platform-content-ai'); ?></p>
+                        <p><?php esc_html_e('All four fields below are required for legal page generation.', '1platform-content-ai'); ?></p>
                     </div>
                 </div>
 
@@ -234,6 +277,7 @@ class ContaiLegalPagesPanel {
     }
 
     private function render_generate_pages_section(): void {
+        $is_ready = $this->is_ready_to_generate();
         ?>
         <div class="contai-panel contai-panel-generate-pages">
             <div class="contai-panel-head">
@@ -249,6 +293,26 @@ class ContaiLegalPagesPanel {
             </div>
 
             <div class="contai-panel-body">
+                <?php if ($is_ready): ?>
+                    <div class="contai-notice contai-notice-success contai-ready-indicator">
+                        <div class="contai-notice-icon">
+                            <span class="dashicons dashicons-yes-alt"></span>
+                        </div>
+                        <div class="contai-notice-body">
+                            <p><strong><?php esc_html_e('Ready to generate', '1platform-content-ai'); ?></strong> — <?php esc_html_e('All required legal information is filled in.', '1platform-content-ai'); ?></p>
+                        </div>
+                    </div>
+                <?php else: ?>
+                    <div class="contai-notice contai-notice-warning contai-ready-indicator">
+                        <div class="contai-notice-icon">
+                            <span class="dashicons dashicons-warning"></span>
+                        </div>
+                        <div class="contai-notice-body">
+                            <p><?php esc_html_e('Fill in the legal information above before generating pages.', '1platform-content-ai'); ?></p>
+                        </div>
+                    </div>
+                <?php endif; ?>
+
                 <div class="contai-notice contai-notice-info">
                     <div class="contai-notice-icon">
                         <span class="dashicons dashicons-info"></span>
@@ -266,7 +330,7 @@ class ContaiLegalPagesPanel {
                 <form method="post" class="contai-legal-form">
                     <?php wp_nonce_field('contai_legal_nonce', 'contai_legal_nonce'); ?>
                     <div class="contai-button-group">
-                        <button type="submit" name="contai_generate_legal_pages" class="button button-primary contai-button-action contai-button-generate">
+                        <button type="submit" name="contai_generate_legal_pages" class="button button-primary contai-button-action contai-button-generate" <?php disabled(!$is_ready); ?>>
                             <span class="dashicons dashicons-admin-page"></span>
                             <span class="contai-button-text"><?php esc_html_e('Generate Legal Pages', '1platform-content-ai'); ?></span>
                         </button>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,6 +6,13 @@ define('ARRAY_A', 'ARRAY_A');
 define('DAY_IN_SECONDS', 86400);
 define('HOUR_IN_SECONDS', 3600);
 
+if (!function_exists('plugin_dir_path')) {
+    function plugin_dir_path(string $file): string
+    {
+        return rtrim(dirname($file), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+    }
+}
+
 // Create dummy WP admin files so ImageUploader::ensureMediaFunctionsLoaded() doesn't fatal
 $wp_admin_includes = ABSPATH . 'wp-admin/includes/';
 if (!is_dir($wp_admin_includes)) {
@@ -121,6 +128,8 @@ require_once __DIR__ . '/../includes/services/jobs/recovery/JobRecoveryService.p
 require_once __DIR__ . '/../includes/services/jobs/JobProcessor.php';
 require_once __DIR__ . '/../includes/admin/content-generator/handlers/PostGenerationQueueHandler.php';
 require_once __DIR__ . '/../includes/admin/content-generator/panels/post-maintenance.php';
+require_once __DIR__ . '/../includes/admin/content-generator/helpers/legal-pages-helper.php';
+require_once __DIR__ . '/../includes/admin/content-generator/panels/legal-pages.php';
 
 // ── User Profile & License ─────────────────────────────────────
 require_once __DIR__ . '/../includes/services/user-profile/UserProfileService.php';

--- a/tests/integration/JobLifecycleTest.php
+++ b/tests/integration/JobLifecycleTest.php
@@ -426,6 +426,7 @@ class JobLifecycleTest extends TestCase
         });
         WP_Mock::userFunction('get_site_url')->andReturn('https://example.test');
         WP_Mock::userFunction('get_option')->andReturn(false);
+        WP_Mock::userFunction('update_option')->andReturn(true);
         WP_Mock::userFunction('wp_upload_dir')->andReturn([
             'basedir' => '/tmp',
             'baseurl' => '/uploads',

--- a/tests/integration/QueueWithoutTrafficTest.php
+++ b/tests/integration/QueueWithoutTrafficTest.php
@@ -65,6 +65,7 @@ class QueueWithoutTrafficTest extends TestCase
         });
         WP_Mock::userFunction('get_site_url')->andReturn('https://example.test');
         WP_Mock::userFunction('get_option')->andReturn(false);
+        WP_Mock::userFunction('update_option')->andReturn(true);
         WP_Mock::userFunction('wp_upload_dir')->andReturn([
             'basedir' => '/tmp',
             'baseurl' => '/uploads',

--- a/tests/unit/admin/content-generator/panels/LegalPagesPanelTest.php
+++ b/tests/unit/admin/content-generator/panels/LegalPagesPanelTest.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace ContAI\Tests\Unit\Admin\ContentGenerator\Panels;
+
+use WP_Mock;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use ContaiLegalPagesPanel;
+
+class LegalPagesPanelTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        WP_Mock::setUp();
+    }
+
+    public function tearDown(): void
+    {
+        unset(
+            $_POST['contai_save_legal_info'],
+            $_POST['contai_generate_legal_pages'],
+            $_POST['contai_save_cookie_settings'],
+            $_POST['contai_legal_owner'],
+            $_POST['contai_legal_address'],
+            $_POST['contai_legal_activity'],
+            $_POST['contai_legal_email']
+        );
+        WP_Mock::tearDown();
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_renders_neutral_informational_notice_on_fresh_load(): void
+    {
+        $this->mockLegalOptions(['', '', '', '']);
+        $this->stubRenderHelpers();
+
+        $panel = new ContaiLegalPagesPanel();
+        $output = $this->captureRender($panel);
+
+        // The persistent warning copy from #129 must NOT be present anymore.
+        $this->assertStringNotContainsString('All fields are required to generate legal pages via the API', $output);
+        $this->assertStringNotContainsString('contai-notice-warning', $this->extractLegalInfoBody($output));
+        $this->assertStringContainsString('All four fields below are required for legal page generation.', $output);
+    }
+
+    public function test_save_with_empty_required_field_shows_missing_banner(): void
+    {
+        $this->mockLegalOptions(['', '', '', '']);
+        $this->stubRenderHelpers();
+        $this->stubSaveRequest([
+            'contai_legal_owner'    => 'Javier Perez',
+            'contai_legal_email'    => 'info@example.com',
+            'contai_legal_address'  => 'España',
+            'contai_legal_activity' => '', // missing
+        ]);
+
+        $panel = new ContaiLegalPagesPanel();
+        $output = $this->captureRender($panel);
+
+        $this->assertStringContainsString('Missing required information', $output);
+        $this->assertStringContainsString('Business Activity', $output);
+        $this->assertStringNotContainsString('Legal information saved successfully', $output);
+    }
+
+    public function test_save_with_all_fields_shows_success_and_ready_indicator(): void
+    {
+        // After save, helper should return populated values.
+        $this->mockLegalOptions(['Javier', 'info@example.com', 'España', 'Empleo']);
+        $this->stubRenderHelpers();
+        $this->stubSaveRequest([
+            'contai_legal_owner'    => 'Javier',
+            'contai_legal_email'    => 'info@example.com',
+            'contai_legal_address'  => 'España',
+            'contai_legal_activity' => 'Empleo',
+        ]);
+
+        $panel = new ContaiLegalPagesPanel();
+        $output = $this->captureRender($panel);
+
+        $this->assertStringContainsString('Legal information saved successfully', $output);
+        $this->assertStringContainsString('Ready to generate', $output);
+    }
+
+    public function test_generate_button_disabled_when_not_ready(): void
+    {
+        $this->mockLegalOptions(['', '', '', '']);
+        $this->stubRenderHelpers();
+
+        $panel = new ContaiLegalPagesPanel();
+        $output = $this->captureRender($panel);
+
+        // Disabled HTML attribute should appear on the generate button when fields are missing.
+        $generateButtonChunk = $this->extractGenerateButton($output);
+        $this->assertStringContainsString('disabled', $generateButtonChunk);
+    }
+
+    public function test_generate_button_enabled_when_ready(): void
+    {
+        $this->mockLegalOptions(['Javier', 'info@example.com', 'España', 'Empleo']);
+        $this->stubRenderHelpers();
+
+        $panel = new ContaiLegalPagesPanel();
+        $output = $this->captureRender($panel);
+
+        $generateButtonChunk = $this->extractGenerateButton($output);
+        $this->assertStringNotContainsString('disabled', $generateButtonChunk);
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────
+
+    /**
+     * @param array{0:string,1:string,2:string,3:string} $values [owner, email, address, activity]
+     */
+    private function mockLegalOptions(array $values): void
+    {
+        WP_Mock::userFunction('home_url')->andReturn('https://example.com');
+        WP_Mock::userFunction('wp_parse_url')->andReturn('example.com');
+        WP_Mock::userFunction('get_option')->with('contai_legal_owner', '')->andReturn($values[0]);
+        WP_Mock::userFunction('get_option')->with('contai_legal_email', Mockery::any())->andReturn($values[1]);
+        WP_Mock::userFunction('get_option')->with('contai_legal_address', '')->andReturn($values[2]);
+        WP_Mock::userFunction('get_option')->with('contai_legal_activity', '')->andReturn($values[3]);
+        // Cookie section helpers
+        WP_Mock::userFunction('get_option')->with('contai_cookie_notice_enabled')->andReturn('1');
+        WP_Mock::userFunction('get_option')->with('contai_site_language', 'spanish')->andReturn('spanish');
+        WP_Mock::userFunction('get_option')->with('contai_cookie_notice_text', Mockery::any())->andReturn('');
+        WP_Mock::userFunction('get_option')->with('contai_consent_mode', 'opt_out')->andReturn('opt_out');
+        WP_Mock::userFunction('get_option')->with('contai_site_theme', '')->andReturn('');
+    }
+
+    private function stubSaveRequest(array $fields): void
+    {
+        $_POST['contai_save_legal_info'] = '1';
+        foreach ($fields as $key => $value) {
+            $_POST[$key] = $value;
+        }
+
+        WP_Mock::userFunction('check_admin_referer')
+            ->with('contai_legal_info_nonce', 'contai_legal_info_nonce')
+            ->andReturn(1);
+        WP_Mock::userFunction('current_user_can')->with('manage_options')->andReturn(true);
+        WP_Mock::userFunction('wp_unslash')->andReturnUsing(static fn ($v) => $v);
+        WP_Mock::userFunction('sanitize_text_field')->andReturnUsing(static fn ($v) => $v);
+        WP_Mock::userFunction('sanitize_email')->andReturnUsing(static fn ($v) => $v);
+        WP_Mock::userFunction('is_email')->andReturn(true);
+        WP_Mock::userFunction('update_option')->andReturn(true);
+    }
+
+    private function stubRenderHelpers(): void
+    {
+        WP_Mock::userFunction('settings_errors')->andReturn(null);
+        WP_Mock::userFunction('wp_nonce_field')->andReturn('');
+        WP_Mock::userFunction('esc_html_e')->andReturnUsing(static function ($text) {
+            echo $text;
+        });
+        WP_Mock::userFunction('esc_html__')->andReturnUsing(static fn ($text) => $text);
+        WP_Mock::userFunction('esc_attr_e')->andReturnUsing(static function ($text) {
+            echo $text;
+        });
+        WP_Mock::userFunction('esc_html')->andReturnUsing(static fn ($text) => $text);
+        WP_Mock::userFunction('esc_attr')->andReturnUsing(static fn ($text) => $text);
+        WP_Mock::userFunction('esc_textarea')->andReturnUsing(static fn ($text) => $text);
+        WP_Mock::userFunction('checked')->andReturn('');
+        WP_Mock::userFunction('selected')->andReturn('');
+        WP_Mock::userFunction('disabled')->andReturnUsing(static function ($cond) {
+            if ($cond) {
+                echo ' disabled';
+            }
+        });
+        WP_Mock::userFunction('__')->andReturnUsing(static fn ($text) => $text);
+    }
+
+    private function captureRender(ContaiLegalPagesPanel $panel): string
+    {
+        ob_start();
+        $panel->render();
+        return ob_get_clean();
+    }
+
+    private function extractLegalInfoBody(string $output): string
+    {
+        $start = strpos($output, 'contai-panel-legal-info');
+        $end   = strpos($output, 'contai-panel-generate-pages');
+        if ($start === false || $end === false) {
+            return $output;
+        }
+        return substr($output, $start, $end - $start);
+    }
+
+    private function extractGenerateButton(string $output): string
+    {
+        $start = strpos($output, 'contai_generate_legal_pages');
+        if ($start === false) {
+            return '';
+        }
+        $btnStart = strrpos(substr($output, 0, $start), '<button');
+        $btnEnd   = strpos($output, '</button>', $start);
+        return substr($output, $btnStart, $btnEnd - $btnStart);
+    }
+}


### PR DESCRIPTION
## Cluster
**F — Legal Pages persistent warning** (`docs/ISSUE-RESOLUTION-PLAN-2026-05-27.md`, p2 quick win).

## Why
The "All fields are required to generate legal pages via the API..." copy on the Legal Pages panel rendered as a warning notice on every load, so users read it as a validation error and assumed their input wasn't accepted. Issue #129 was the result.

## What changed
- Reword the persistent notice as a neutral informational helper (no warning styling).
- Real validation banner only renders after Save with empty required fields, naming the missing fields.
- Green "Ready to generate" indicator appears on the Generate Pages section once all four legal information fields are saved.
- The Generate Legal Pages button is disabled while required information is missing. The submit handler also short-circuits and re-renders the missing-fields banner instead of calling the API.

## Acceptance checklist (from plan)
- [x] Fresh load with empty fields → neutral informational copy (no warning styling).
- [x] Submit with empty field → red banner naming the missing field.
- [x] All fields filled → green "Ready to generate" indicator.

## Test plan
- `vendor/bin/phpunit --testsuite=unit --filter LegalPagesPanelTest` → 5 cases, 10 assertions, all pass.
- Full unit suite: 680/680 OK locally.
- Manual: open Legal Pages with empty fields → only neutral info appears; submit → missing fields banner names the empty ones; fill all four + save → success + ready indicator + button enabled.

Closes #129.