### PR TITLE
fix(site-wizard): PRG redirect + per-user notice transient (closes #54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Fixed
+- **Site Wizard: PRG redirect + per-user notice transient (#54)**: Submitting "Launch Site Generation" now uses a Post-Redirect-Get pattern on every code path (nonce failure, validation error, uncaught exception, success). The notice + previously-submitted form values are stashed in a per-user transient (`contai_site_gen_notice_<user_id>`) and consumed on the next request, so a browser refresh no longer re-submits the form and the user no longer sees an empty form after a silent server-side rejection. On expired-nonce paths the wizard re-renders with all previously-typed values preserved alongside an explicit "session expired" banner.
 - **Legal Pages: persistent warning resolved (#129)**: The "All fields are required..." copy on the Legal Pages panel no longer renders as a static warning notice. It is now an informational helper that does not look like a validation error. A real error banner only appears after the user submits with empty required fields (named in the message), and a green "Ready to generate" indicator appears in the Generate Pages section once all four legal information fields are saved. The Generate button is disabled until the required information is on file.
 
 ### Changed

--- a/includes/admin/admin-ai-site-generator.php
+++ b/includes/admin/admin-ai-site-generator.php
@@ -18,6 +18,76 @@ require_once __DIR__ . '/../database/repositories/JobRepository.php';
 require_once __DIR__ . '/../database/models/Job.php';
 require_once __DIR__ . '/../services/category-api/CategoryAPIService.php';
 
+/**
+ * Per-user transient key for the wizard notice + preserved POST values.
+ *
+ * Keying by user ID prevents leakage between operators that share a session
+ * cookie pool (e.g. a tab opened just before logout).
+ */
+function contai_site_gen_notice_transient_key( int $user_id ): string {
+	return 'contai_site_gen_notice_' . $user_id;
+}
+
+/**
+ * Whitelist of form fields preserved across the PRG redirect on error.
+ *
+ * Mirrors the inputs in includes/admin/ai-site-generator/site-generator-form.php.
+ */
+function contai_site_gen_preserved_fields(): array {
+	return array(
+		'contai_site_topic',
+		'contai_site_category',
+		'contai_site_language',
+		'contai_wordpress_theme',
+		'contai_legal_owner',
+		'contai_legal_email',
+		'contai_legal_address',
+		'contai_legal_activity',
+		'contai_source_topic',
+		'contai_target_country',
+		'contai_num_posts',
+		'contai_comments_per_post',
+		'contai_image_provider',
+		'contai_adsense_publisher',
+	);
+}
+
+/**
+ * Capture and sanitize the submitted form values for re-display after a PRG redirect.
+ */
+function contai_capture_submitted_form_values(): array {
+	$values = array();
+	foreach ( contai_site_gen_preserved_fields() as $field ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Values are only echoed back; not used for processing.
+		if ( isset( $_POST[ $field ] ) ) {
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$values[ $field ] = sanitize_text_field( wp_unslash( $_POST[ $field ] ) );
+		}
+	}
+	return $values;
+}
+
+/**
+ * Stash the notice (and optionally preserved form values) for the next request,
+ * then redirect back to the wizard so refreshing does not re-submit.
+ */
+function contai_redirect_with_notice( array $notice, array $form_values = array() ): void {
+	$user_id = get_current_user_id();
+	if ( $user_id > 0 ) {
+		set_transient(
+			contai_site_gen_notice_transient_key( $user_id ),
+			array(
+				'notice'      => $notice,
+				'form_values' => $form_values,
+			),
+			MINUTE_IN_SECONDS
+		);
+	}
+
+	wp_safe_redirect( admin_url( 'admin.php?page=contai-ai-site-generator' ) );
+	exit;
+}
+
 function contai_handle_ai_site_generator_submission() {
 	// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce is verified below via wp_verify_nonce().
 	if ( ! isset( $_POST['contai_start_site_generation'] ) ) {
@@ -29,11 +99,13 @@ function contai_handle_ai_site_generator_submission() {
 		: '';
 
 	if ( ! wp_verify_nonce( $nonce_value, 'contai_site_generator_nonce' ) ) {
-		$GLOBALS['contai_site_gen_inline_notice'] = array(
-			'type'    => 'error',
-			'message' => __( 'Your session has expired. Please reload the page and try again.', '1platform-content-ai' ),
+		contai_redirect_with_notice(
+			array(
+				'type'    => 'error',
+				'message' => __( 'Your session expired before the form could be submitted. Your data is preserved below — click Launch Site Generation again to retry.', '1platform-content-ai' ),
+			),
+			contai_capture_submitted_form_values()
 		);
-		return;
 	}
 
 	if ( ! current_user_can( 'manage_options' ) ) {
@@ -43,16 +115,17 @@ function contai_handle_ai_site_generator_submission() {
 	try {
 		$error = contai_process_site_generation_submission();
 		if ( $error ) {
-			$GLOBALS['contai_site_gen_inline_notice'] = $error;
-			return;
+			contai_redirect_with_notice( $error, contai_capture_submitted_form_values() );
 		}
 	} catch ( \Throwable $e ) {
 		contai_log( 'Site generation submission failed: ' . $e->getMessage() ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
-		$GLOBALS['contai_site_gen_inline_notice'] = array(
-			'type'    => 'error',
-			'message' => __( 'An unexpected error occurred while starting site generation. Please try again.', '1platform-content-ai' ),
+		contai_redirect_with_notice(
+			array(
+				'type'    => 'error',
+				'message' => __( 'An unexpected error occurred while starting site generation. Please try again.', '1platform-content-ai' ),
+			),
+			contai_capture_submitted_form_values()
 		);
-		return;
 	}
 }
 
@@ -154,14 +227,12 @@ function contai_process_site_generation_submission() {
 		}
 	}
 
-	// Success — redirect to show the progress panel
-	$redirect_url = admin_url( 'admin.php?page=contai-ai-site-generator' );
-	set_transient( 'contai_site_gen_notice', array(
-		'type'    => 'success',
-		'message' => __( 'Site generation process has been started successfully!', '1platform-content-ai' ),
-	), 30 );
-	wp_safe_redirect( $redirect_url );
-	exit;
+	contai_redirect_with_notice(
+		array(
+			'type'    => 'success',
+			'message' => __( 'Site generation process has been started successfully!', '1platform-content-ai' ),
+		)
+	);
 }
 add_action( 'admin_init', 'contai_handle_ai_site_generator_submission' );
 
@@ -174,16 +245,25 @@ function contai_ai_site_generator_page() {
 	$activeJob = $jobRepository->findActiveSiteGenerationJob();
 	$hasActiveJob = ! empty( $activeJob );
 
-	$notice = $GLOBALS['contai_site_gen_inline_notice'] ?? null;
+	$notice              = null;
+	$preserved_form_data = array();
 
-	if ( ! $notice ) {
-		$notice = get_transient( 'contai_site_gen_notice' );
-		if ( ! empty( $notice ) && is_array( $notice ) ) {
-			delete_transient( 'contai_site_gen_notice' );
-		} else {
-			$notice = null;
+	$user_id = get_current_user_id();
+	if ( $user_id > 0 ) {
+		$transient_key = contai_site_gen_notice_transient_key( $user_id );
+		$payload       = get_transient( $transient_key );
+		if ( ! empty( $payload ) && is_array( $payload ) ) {
+			delete_transient( $transient_key );
+			if ( ! empty( $payload['notice'] ) && is_array( $payload['notice'] ) ) {
+				$notice = $payload['notice'];
+			}
+			if ( ! empty( $payload['form_values'] ) && is_array( $payload['form_values'] ) ) {
+				$preserved_form_data = $payload['form_values'];
+			}
 		}
 	}
+
+	$GLOBALS['contai_site_gen_preserved_form_data'] = $preserved_form_data;
 
 	if ( $notice ) {
 		$type = in_array( $notice['type'], array( 'success', 'error', 'warning', 'info' ), true ) ? $notice['type'] : 'info';

--- a/includes/admin/ai-site-generator/site-generator-form.php
+++ b/includes/admin/ai-site-generator/site-generator-form.php
@@ -22,15 +22,18 @@ function contai_render_full_site_generator_form() {
 	$site_domain      = wp_parse_url( home_url(), PHP_URL_HOST );
 	$default_email    = 'info@' . preg_replace( '/^www\./', '', $site_domain );
 
-	// Preserve form data on validation error (inline notice = POST was rejected).
-	// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Values are only used for re-display, not processing.
-	$has_post_data = ! empty( $GLOBALS['contai_site_gen_inline_notice'] ) && isset( $_POST['contai_start_site_generation'] );
-	$post          = static function ( $key, $default = '' ) use ( $has_post_data ) {
-		if ( ! $has_post_data || ! isset( $_POST[ $key ] ) ) {
-			return $default;
+	// After a PRG redirect on validation error, the previously submitted values
+	// arrive via the per-user transient (see contai_redirect_with_notice in
+	// admin-ai-site-generator.php). The stash is already sanitized; re-display
+	// directly without touching $_POST so the page works even after a refresh.
+	$preserved_form_data = isset( $GLOBALS['contai_site_gen_preserved_form_data'] ) && is_array( $GLOBALS['contai_site_gen_preserved_form_data'] )
+		? $GLOBALS['contai_site_gen_preserved_form_data']
+		: array();
+	$post = static function ( $key, $default = '' ) use ( $preserved_form_data ) {
+		if ( isset( $preserved_form_data[ $key ] ) && $preserved_form_data[ $key ] !== '' ) {
+			return $preserved_form_data[ $key ];
 		}
-		// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		return sanitize_text_field( wp_unslash( $_POST[ $key ] ) );
+		return $default;
 	};
 
 	$creditGuard = new ContaiCreditGuard();

--- a/tests/unit/admin/site-generator/SiteGeneratorSubmissionTest.php
+++ b/tests/unit/admin/site-generator/SiteGeneratorSubmissionTest.php
@@ -10,15 +10,14 @@ use PHPUnit\Framework\TestCase;
  * Covers GitHub issue #54: "Launch Site Generation" refreshed the page
  * silently without executing any action or showing error/success feedback.
  *
- * The fix replaced redirect-on-error with inline error display via
- * $GLOBALS['contai_site_gen_inline_notice'], preserving form data on
- * validation failures. Only the success path redirects.
- *
- * Tests are organized by branch coverage:
- * - Handler branches (nonce fail, capability, error return, exception)
- * - Processing branches (category, credits, active job, job creation, success)
- * - Page renderer (inline notice priority, transient fallback)
- * - Form (POST data preservation, provider masking, escaping)
+ * Current contract:
+ * - All submission paths (nonce failure, validation error, success,
+ *   uncaught exception) use a Post-Redirect-Get redirect so that the
+ *   refresh button can no longer re-submit the form and any notice
+ *   survives the redirect via a per-user transient.
+ * - On error paths the submitted form values are stashed alongside the
+ *   notice so the wizard re-renders pre-filled.
+ * - The capability check is the only path that wp_die()s.
  */
 class SiteGeneratorSubmissionTest extends TestCase
 {
@@ -30,28 +29,26 @@ class SiteGeneratorSubmissionTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->handlerFile = dirname(__DIR__, 4) . '/includes/admin/admin-ai-site-generator.php';
-        $this->formFile = dirname(__DIR__, 4) . '/includes/admin/ai-site-generator/site-generator-form.php';
+        $this->handlerFile    = dirname(__DIR__, 4) . '/includes/admin/admin-ai-site-generator.php';
+        $this->formFile       = dirname(__DIR__, 4) . '/includes/admin/ai-site-generator/site-generator-form.php';
         $this->handlerContent = file_get_contents($this->handlerFile);
-        $this->formContent = file_get_contents($this->formFile);
+        $this->formContent    = file_get_contents($this->formFile);
     }
 
     // ── Handler: Entry Guard ───────────────────────────────────────
 
     public function test_handler_returns_early_when_no_post_data(): void
     {
-        // Branch: line 37 — if ( ! isset( $_POST['contai_start_site_generation'] ) )
         $this->assertStringContainsString(
             "if ( ! isset( \$_POST['contai_start_site_generation'] ) )",
             $this->handlerContent,
             'Handler must check for POST submission marker before processing'
         );
 
-        // Must return immediately — no GLOBALS, no redirect
         $earlyReturn = $this->extractBlock($this->handlerContent, "isset( \$_POST['contai_start_site_generation']", 'return;');
         $this->assertNotNull($earlyReturn, 'Early return must follow POST check');
-        $this->assertStringNotContainsString('GLOBALS', $earlyReturn, 'Early return must not set any GLOBALS');
         $this->assertStringNotContainsString('wp_safe_redirect', $earlyReturn, 'Early return must not redirect');
+        $this->assertStringNotContainsString('set_transient', $earlyReturn, 'Early return must not stash a transient');
     }
 
     // ── Handler: Nonce Verification ────────────────────────────────
@@ -71,37 +68,40 @@ class SiteGeneratorSubmissionTest extends TestCase
         );
     }
 
-    public function test_nonce_failure_sets_inline_notice_not_redirect(): void
+    public function test_nonce_failure_redirects_via_helper_and_preserves_form(): void
     {
-        // Branch: line 46 — if ( ! wp_verify_nonce(...) )
-        $nonceBlock = $this->extractBlock($this->handlerContent, '! wp_verify_nonce(', "return;\n\t}");
+        $nonceBlock = $this->extractBlock($this->handlerContent, '! wp_verify_nonce(', '}');
         $this->assertNotNull($nonceBlock, 'Nonce failure block must exist');
 
         $this->assertStringContainsString(
+            'contai_redirect_with_notice(',
+            $nonceBlock,
+            'Nonce failure must redirect via contai_redirect_with_notice (#54)'
+        );
+
+        $this->assertStringContainsString(
+            'contai_capture_submitted_form_values()',
+            $nonceBlock,
+            'Nonce failure must preserve submitted form values across the redirect (#54)'
+        );
+
+        $this->assertStringContainsString(
+            "'type'    => 'error'",
+            $nonceBlock,
+            'Nonce failure notice must be of type error'
+        );
+
+        $this->assertStringContainsString(
+            'session expired',
+            $nonceBlock,
+            'Nonce failure must surface a human-readable "session expired" message'
+        );
+
+        $this->assertStringNotContainsString(
             "GLOBALS['contai_site_gen_inline_notice']",
             $nonceBlock,
-            'Nonce failure must set inline notice (#54)'
+            'Nonce failure must no longer rely on a global notice (#54)'
         );
-
-        $this->assertStringNotContainsString(
-            'wp_safe_redirect',
-            $nonceBlock,
-            'Nonce failure must NOT redirect — error shown inline (#54)'
-        );
-
-        $this->assertStringNotContainsString(
-            'set_transient',
-            $nonceBlock,
-            'Nonce failure must NOT use transient — inline notice only (#54)'
-        );
-    }
-
-    public function test_nonce_failure_notice_has_correct_type(): void
-    {
-        $nonceBlock = $this->extractBlock($this->handlerContent, '! wp_verify_nonce(', "return;\n\t}");
-        $this->assertNotNull($nonceBlock, 'Nonce failure block must exist');
-        $this->assertStringContainsString("'type'    => 'error'", $nonceBlock);
-        $this->assertStringContainsString('session has expired', $nonceBlock);
     }
 
     // ── Handler: Capability Check ──────────────────────────────────
@@ -132,26 +132,32 @@ class SiteGeneratorSubmissionTest extends TestCase
         );
     }
 
-    public function test_handler_stores_processing_error_in_inline_notice(): void
+    public function test_handler_redirects_with_validation_error(): void
     {
-        // Branch: line 60 — if ( $error ) { $GLOBALS[...] = $error; return; }
         $this->assertStringContainsString(
             '$error = contai_process_site_generation_submission()',
             $this->handlerContent,
             'Handler must capture return value from processing function'
         );
 
+        $errorBlock = $this->extractBlock($this->handlerContent, 'if ( $error )', '}');
+        $this->assertNotNull($errorBlock, 'Validation error block must exist');
+
         $this->assertStringContainsString(
-            "if ( \$error ) {\n\t\t\t\$GLOBALS['contai_site_gen_inline_notice'] = \$error;",
-            $this->handlerContent,
-            'Handler must set inline notice when processing returns error (#54)'
+            'contai_redirect_with_notice( $error',
+            $errorBlock,
+            'Handler must redirect with the validation error notice (#54)'
+        );
+        $this->assertStringContainsString(
+            'contai_capture_submitted_form_values()',
+            $errorBlock,
+            'Handler must preserve submitted form values on validation error (#54)'
         );
     }
 
-    public function test_exception_handler_logs_and_sets_inline_notice(): void
+    public function test_exception_handler_logs_and_redirects_with_form_values(): void
     {
-        // Branch: line 64-71 — catch block
-        $catchBlock = $this->extractBlock($this->handlerContent, 'catch ( \\Throwable $e )', 'return;');
+        $catchBlock = $this->extractBlock($this->handlerContent, 'catch ( \\Throwable $e )', 'contai_capture_submitted_form_values()');
         $this->assertNotNull($catchBlock, 'Catch block must exist');
 
         $this->assertStringContainsString(
@@ -161,32 +167,80 @@ class SiteGeneratorSubmissionTest extends TestCase
         );
 
         $this->assertStringContainsString(
-            "GLOBALS['contai_site_gen_inline_notice']",
+            'contai_redirect_with_notice(',
             $catchBlock,
-            'Exception handler must set inline notice (#54)'
-        );
-
-        $this->assertStringNotContainsString(
-            'wp_safe_redirect',
-            $catchBlock,
-            'Exception handler must NOT redirect (#54)'
+            'Exception handler must redirect with a notice (#54)'
         );
     }
 
-    // ── Handler: No Redirect on Errors ─────────────────────────────
+    // ── Helper: Per-user Transient Key ─────────────────────────────
 
-    public function test_handler_never_redirects_in_error_paths(): void
+    public function test_transient_key_is_scoped_per_user(): void
     {
-        // The handler function should NOT contain wp_safe_redirect at all
-        // Only the processing function redirects on success
-        $handlerFunc = $this->extractFunction($this->handlerContent, 'contai_handle_ai_site_generator_submission');
-        $this->assertNotNull($handlerFunc, 'Handler function must exist');
-
-        $this->assertStringNotContainsString(
-            'wp_safe_redirect',
-            $handlerFunc,
-            'Handler must never redirect — only processing function redirects on success (#54)'
+        $this->assertStringContainsString(
+            'function contai_site_gen_notice_transient_key( int $user_id )',
+            $this->handlerContent,
+            'Per-user transient key helper must exist (#54)'
         );
+        $this->assertStringContainsString(
+            "return 'contai_site_gen_notice_' . \$user_id",
+            $this->handlerContent,
+            'Transient key must be namespaced by user id to avoid cross-user notice leaks (#54)'
+        );
+    }
+
+    // ── Helper: Form Value Capture ─────────────────────────────────
+
+    public function test_form_value_capture_uses_whitelist(): void
+    {
+        $this->assertStringContainsString(
+            'function contai_site_gen_preserved_fields()',
+            $this->handlerContent,
+            'Preserved fields whitelist helper must exist'
+        );
+
+        foreach ([
+            'contai_site_topic',
+            'contai_site_category',
+            'contai_site_language',
+            'contai_legal_owner',
+            'contai_legal_email',
+            'contai_legal_address',
+            'contai_legal_activity',
+            'contai_num_posts',
+            'contai_comments_per_post',
+            'contai_image_provider',
+            'contai_adsense_publisher',
+        ] as $field) {
+            $this->assertStringContainsString(
+                "'{$field}'",
+                $this->handlerContent,
+                "Preserved-field whitelist must include {$field}"
+            );
+        }
+    }
+
+    public function test_form_value_capture_sanitizes_values(): void
+    {
+        $this->assertStringContainsString(
+            'sanitize_text_field( wp_unslash( $_POST[ $field ] ) )',
+            $this->handlerContent,
+            'Captured POST values must be sanitized before being stashed in the transient (#54)'
+        );
+    }
+
+    // ── Helper: Redirect-with-notice ───────────────────────────────
+
+    public function test_redirect_with_notice_writes_to_per_user_transient(): void
+    {
+        $func = $this->extractFunction($this->handlerContent, 'contai_redirect_with_notice');
+        $this->assertNotNull($func, 'contai_redirect_with_notice must exist (#54)');
+
+        $this->assertStringContainsString('get_current_user_id()', $func);
+        $this->assertStringContainsString('contai_site_gen_notice_transient_key( $user_id )', $func);
+        $this->assertStringContainsString('set_transient(', $func);
+        $this->assertStringContainsString('wp_safe_redirect(', $func);
+        $this->assertStringContainsString('exit;', $func);
     }
 
     // ── Processing: Validation Returns ─────────────────────────────
@@ -196,13 +250,12 @@ class SiteGeneratorSubmissionTest extends TestCase
         $this->assertStringContainsString(
             'function contai_process_site_generation_submission()',
             $this->handlerContent,
-            'Processing function must accept no redirect_url param — errors are returned inline (#54)'
+            'Processing function must accept no redirect_url param — errors are returned to the handler (#54)'
         );
     }
 
     public function test_processing_returns_error_on_empty_category(): void
     {
-        // Branch: line 86 — if ( empty( $site_category ) )
         $this->assertReturnErrorPattern(
             'empty( $site_category )',
             'Please select a category',
@@ -212,7 +265,6 @@ class SiteGeneratorSubmissionTest extends TestCase
 
     public function test_processing_returns_error_on_no_credits(): void
     {
-        // Branch: line 98 — if ( ! $creditCheck['has_credits'] )
         $this->assertReturnErrorPattern(
             "! \$creditCheck['has_credits']",
             "\$creditCheck['message']",
@@ -222,7 +274,6 @@ class SiteGeneratorSubmissionTest extends TestCase
 
     public function test_processing_returns_error_on_active_job(): void
     {
-        // Branch: line 108 — if ( $activeJob )
         $this->assertReturnErrorPattern(
             '$activeJob',
             'already an active site generation',
@@ -232,7 +283,6 @@ class SiteGeneratorSubmissionTest extends TestCase
 
     public function test_processing_returns_error_on_job_creation_failure(): void
     {
-        // Branch: line 163 — if ( ! $created )
         $this->assertReturnErrorPattern(
             '! $created',
             'Failed to start site generation',
@@ -240,41 +290,28 @@ class SiteGeneratorSubmissionTest extends TestCase
         );
     }
 
-    public function test_processing_error_returns_use_return_not_redirect(): void
+    public function test_processing_uses_only_helper_for_redirects(): void
     {
         $processingFunc = $this->extractFunction($this->handlerContent, 'contai_process_site_generation_submission');
         $this->assertNotNull($processingFunc, 'Processing function must exist');
 
-        // Count error paths: should use 'return array(' not 'wp_safe_redirect'
+        // Errors return arrays.
         $returnArrayCount = substr_count($processingFunc, 'return array(');
         $this->assertGreaterThanOrEqual(4, $returnArrayCount,
             'Processing function must have at least 4 error return paths (category, credits, active job, job creation)'
         );
 
-        // Only ONE redirect (success path)
-        $redirectCount = substr_count($processingFunc, 'wp_safe_redirect');
-        $this->assertEquals(1, $redirectCount,
-            'Processing function must have exactly 1 redirect (success path only)'
-        );
-    }
-
-    // ── Processing: Success Path ───────────────────────────────────
-
-    public function test_processing_success_uses_transient_and_redirect(): void
-    {
+        // Success path delegates redirecting to the helper.
         $this->assertStringContainsString(
-            "set_transient( 'contai_site_gen_notice'",
-            $this->handlerContent,
-            'Success path must use transient for notice delivery (#54)'
+            'contai_redirect_with_notice(',
+            $processingFunc,
+            'Success path must redirect via the contai_redirect_with_notice helper (#54)'
         );
-
-        // Verify success transient contains success type
-        $successBlock = $this->extractBlock($this->handlerContent, "// Success — redirect", 'exit;');
-        $this->assertNotNull($successBlock, 'Success block must exist');
-
-        $this->assertStringContainsString("'type'    => 'success'", $successBlock);
-        $this->assertStringContainsString('wp_safe_redirect', $successBlock);
-        $this->assertStringContainsString('exit;', $successBlock);
+        $this->assertStringNotContainsString(
+            'wp_safe_redirect',
+            $processingFunc,
+            'Processing function must not call wp_safe_redirect directly — use the helper (#54)'
+        );
     }
 
     public function test_processing_saves_adsense_publisher_on_success(): void
@@ -292,33 +329,32 @@ class SiteGeneratorSubmissionTest extends TestCase
         );
     }
 
-    // ── Page Renderer: Notice Priority ─────────────────────────────
+    // ── Page Renderer ──────────────────────────────────────────────
 
-    public function test_page_renderer_checks_inline_notice_first(): void
+    public function test_page_renderer_consumes_per_user_transient(): void
     {
         $rendererFunc = $this->extractFunction($this->handlerContent, 'contai_ai_site_generator_page');
         $this->assertNotNull($rendererFunc, 'Page renderer function must exist');
 
-        $inlinePos = strpos($rendererFunc, "GLOBALS['contai_site_gen_inline_notice']");
-        $transientPos = strpos($rendererFunc, "get_transient( 'contai_site_gen_notice' )");
-
-        $this->assertNotFalse($inlinePos, 'Page renderer must check inline notice');
-        $this->assertNotFalse($transientPos, 'Page renderer must check transient as fallback');
-        $this->assertLessThan(
-            $transientPos,
-            $inlinePos,
-            'Inline notice must be checked before transient fallback in page renderer (#54)'
+        $this->assertStringContainsString(
+            'contai_site_gen_notice_transient_key( $user_id )',
+            $rendererFunc,
+            'Page renderer must read from the per-user transient key (#54)'
+        );
+        $this->assertStringContainsString(
+            'delete_transient( $transient_key )',
+            $rendererFunc,
+            'Page renderer must delete the transient after reading to prevent stale notices (#54)'
         );
     }
 
-    public function test_page_renderer_deletes_transient_after_reading(): void
+    public function test_page_renderer_exposes_preserved_form_data_to_form(): void
     {
         $rendererFunc = $this->extractFunction($this->handlerContent, 'contai_ai_site_generator_page');
-
         $this->assertStringContainsString(
-            "delete_transient( 'contai_site_gen_notice' )",
+            "GLOBALS['contai_site_gen_preserved_form_data']",
             $rendererFunc,
-            'Page render must delete transient after display to prevent stale notices (#54)'
+            'Page renderer must expose preserved form values to the form template (#54)'
         );
     }
 
@@ -343,37 +379,22 @@ class SiteGeneratorSubmissionTest extends TestCase
 
     // ── Form: POST Data Preservation ───────────────────────────────
 
-    public function test_form_detects_post_data_via_inline_notice(): void
+    public function test_form_reads_preserved_values_from_transient_bridge(): void
     {
         $this->assertStringContainsString(
-            "! empty( \$GLOBALS['contai_site_gen_inline_notice'] ) && isset( \$_POST['contai_start_site_generation'] )",
+            "GLOBALS['contai_site_gen_preserved_form_data']",
             $this->formContent,
-            'Form must detect POST data availability by checking inline notice AND POST marker (#54)'
+            'Form must read preserved values from the transient bridge global (#54)'
         );
     }
 
-    public function test_form_post_closure_sanitizes_values(): void
+    public function test_form_post_closure_does_not_touch_post(): void
     {
-        $this->assertStringContainsString(
+        // The new approach pulls from the sanitized transient stash, never from $_POST.
+        $this->assertStringNotContainsString(
             'sanitize_text_field( wp_unslash( $_POST[ $key ] ) )',
             $this->formContent,
-            'POST data closure must sanitize all values with sanitize_text_field + wp_unslash'
-        );
-    }
-
-    public function test_form_post_closure_returns_default_when_no_post(): void
-    {
-        // When $has_post_data is false, closure must return default
-        $this->assertStringContainsString(
-            "if ( ! \$has_post_data || ! isset( \$_POST[ \$key ] ) )",
-            $this->formContent,
-            'POST closure must check both data availability and key existence'
-        );
-
-        $this->assertStringContainsString(
-            'return $default;',
-            $this->formContent,
-            'POST closure must return default value when no POST data'
+            'Form must no longer re-sanitize from $_POST — values come pre-sanitized from the transient (#54)'
         );
     }
 
@@ -403,24 +424,23 @@ class SiteGeneratorSubmissionTest extends TestCase
     public function test_form_preserves_select_values_on_error(): void
     {
         $selects = [
-            'contai_site_category'   => 'selected_category',
-            'contai_site_language'   => 'post_language',
-            'contai_target_country'  => 'post_country',
-            'contai_image_provider'  => 'post_image',
+            'contai_site_category',
+            'contai_site_language',
+            'contai_target_country',
+            'contai_image_provider',
         ];
 
-        foreach ($selects as $field => $_var) {
+        foreach ($selects as $field) {
             $this->assertStringContainsString(
                 "\$post( '{$field}'",
                 $this->formContent,
-                "Select field {$field} must use \$post() for POST data retrieval (#54)"
+                "Select field {$field} must use \$post() for value retrieval (#54)"
             );
         }
     }
 
     public function test_form_text_inputs_escape_with_esc_attr(): void
     {
-        // Every $post() call in a value attribute must be wrapped with esc_attr()
         preg_match_all('/value="<\?php echo esc_attr\( \$post\(/', $this->formContent, $matches);
 
         $this->assertGreaterThanOrEqual(7, count($matches[0]),
@@ -585,9 +605,6 @@ class SiteGeneratorSubmissionTest extends TestCase
 
     // ── Helper Methods ─────────────────────────────────────────────
 
-    /**
-     * Find the first line containing a substring.
-     */
     private function findLineContaining(string $content, string $needle): ?string
     {
         foreach (preg_split('/\R/', $content) as $line) {
@@ -598,9 +615,6 @@ class SiteGeneratorSubmissionTest extends TestCase
         return null;
     }
 
-    /**
-     * Extract a code block between two markers.
-     */
     private function extractBlock(string $content, string $startMarker, string $endMarker): ?string
     {
         $startPos = strpos($content, $startMarker);
@@ -614,27 +628,27 @@ class SiteGeneratorSubmissionTest extends TestCase
         return substr($content, $startPos, $endPos - $startPos + strlen($endMarker));
     }
 
-    /**
-     * Extract a function body from source code.
-     */
     private function extractFunction(string $content, string $funcName): ?string
     {
-        $pattern = '/function\s+' . preg_quote($funcName, '/') . '\s*\([^)]*\)\s*\{/';
-        if (!preg_match($pattern, $content, $matches, PREG_OFFSET_CAPTURE)) {
+        $needle = 'function ' . $funcName;
+        $startPos = strpos($content, $needle);
+        if ($startPos === false) {
             return null;
         }
-        $startPos = $matches[0][1];
+        // Walk forward to the first '{' that opens the function body.
+        $bodyStart = strpos($content, '{', $startPos);
+        if ($bodyStart === false) {
+            return null;
+        }
         $braceCount = 0;
-        $len = strlen($content);
-        $started = false;
+        $len        = strlen($content);
 
-        for ($i = $startPos; $i < $len; $i++) {
+        for ($i = $bodyStart; $i < $len; $i++) {
             if ($content[$i] === '{') {
                 $braceCount++;
-                $started = true;
             } elseif ($content[$i] === '}') {
                 $braceCount--;
-                if ($started && $braceCount === 0) {
+                if ($braceCount === 0) {
                     return substr($content, $startPos, $i - $startPos + 1);
                 }
             }
@@ -642,9 +656,6 @@ class SiteGeneratorSubmissionTest extends TestCase
         return null;
     }
 
-    /**
-     * Assert that a condition triggers a return array('type' => 'error') pattern.
-     */
     private function assertReturnErrorPattern(string $condition, string $_messageHint, string $description): void
     {
         $condPos = strpos($this->handlerContent, $condition);


### PR DESCRIPTION
## Cluster
**A — Site Wizard form submission** (`docs/ISSUE-RESOLUTION-PLAN-2026-05-27.md`, p1).

## Why
"Launch Site Generation" reloaded the page with no message and an empty form. Root cause: the handler stashed errors in `\$GLOBALS['contai_site_gen_inline_notice']` and only the success path redirected. On nonce failure the same request re-rendered the form without reliably preserving submitted values, and refreshing the browser re-POSTed the form. #54 is the user-visible symptom.

## What changed
- New helpers in `admin-ai-site-generator.php`:
  - `contai_site_gen_notice_transient_key(int \$user_id)` — per-user transient key.
  - `contai_site_gen_preserved_fields()` — whitelist of fields preserved across the PRG redirect.
  - `contai_capture_submitted_form_values()` — sanitized snapshot of submitted POST values.
  - `contai_redirect_with_notice(array \$notice, array \$form_values = [])` — single PRG exit point.
- All submission paths (nonce failure / validation error / `Throwable` / success) now go through `contai_redirect_with_notice` so the browser ends up on a GET that cannot re-submit on refresh.
- The page renderer consumes the per-user transient (deleting it after reading), reads the stashed notice, and exposes the preserved form values to the form template via `\$GLOBALS['contai_site_gen_preserved_form_data']`.
- The form template (`site-generator-form.php`) now reads pre-sanitized values from that bridge instead of touching `\$_POST` directly.
- Tests rewritten in `tests/unit/admin/site-generator/SiteGeneratorSubmissionTest.php` to verify the new contract.

## Acceptance checklist (from plan)
- [x] Submit valid form → job created → redirect to wizard with success notice (PRG via helper).
- [x] Submit expired nonce → wizard re-renders with all values intact + "Session expired" banner (preserved form values).
- [x] Submit with `contai_site_category` empty → red banner naming the missing field (returned by processing function, surfaced via PRG).
- [x] Submit with 0 credits → banner using the credit-check message returned by `ContaiCreditGuard`.

## Test plan
- `vendor/bin/phpunit` → 694/694 OK locally.
- Filtered: `--filter SiteGeneratorSubmissionTest` → 39 cases, 107 assertions, pass.
- Manual (Local by Flywheel):
  - Submit the wizard with all fields filled → redirected to wizard URL with success banner; refreshing does not re-submit.
  - Submit with the wizard tab left open past the nonce TTL → wizard re-renders with all typed values intact and a "session expired" banner.
  - Empty category → red banner naming the missing field.
  - Zero credits → "Insufficient credits" banner + Top up CTA.

Closes #54.